### PR TITLE
Gtk3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OBJS=main.o dive.o profile.o info.o divelist.o parse-xml.o save-xml.o
 divelog: $(OBJS)
 	$(CC) $(LDLAGS) -o divelog $(OBJS) \
 		`xml2-config --libs` \
-		`pkg-config --libs gtk+-2.0`
+		`pkg-config --libs gtk+-3.0`
 
 parse-xml.o: parse-xml.c dive.h
 	$(CC) $(CFLAGS) -c `xml2-config --cflags` parse-xml.c
@@ -18,13 +18,13 @@ dive.o: dive.c dive.h
 	$(CC) $(CFLAGS) -c dive.c
 
 main.o: main.c dive.h display.h
-	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0` -c main.c
+	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-3.0` -c main.c
 
 profile.o: profile.c dive.h display.h
-	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0` -c profile.c
+	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-3.0` -c profile.c
 
 info.o: info.c dive.h display.h
-	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0` -c info.c
+	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-3.0` -c info.c
 
 divelist.o: divelist.c dive.h display.h
-	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0` -c divelist.c
+	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-3.0` -c divelist.c

--- a/README
+++ b/README
@@ -4,7 +4,7 @@ I'm tired of java programs that don't work etc.
 
 License: GPLv2
 
-You need libxml2-devel and gtk2-devel to build this.
+You need libxml2-devel and gtk3-devel to build this.
 
 Usage:
 

--- a/info.c
+++ b/info.c
@@ -151,10 +151,16 @@ static GtkTextBuffer *text_entry(GtkWidget *box, const char *label, gboolean exp
 
 	gtk_box_pack_start(GTK_BOX(box), frame, expand, expand, 0);
 
+	GtkWidget* scrolled_window = gtk_scrolled_window_new (0, 0);
+	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scrolled_window), GTK_SHADOW_IN);
+	gtk_widget_show(scrolled_window);
+
 	view = gtk_text_view_new ();
+	gtk_container_add(GTK_CONTAINER(scrolled_window), view);
+	
 	buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
 
-	gtk_container_add(GTK_CONTAINER(frame), view);
+	gtk_container_add(GTK_CONTAINER(frame), scrolled_window);
 	return buffer;
 }
 

--- a/main.c
+++ b/main.c
@@ -128,25 +128,38 @@ static void file_save(GtkWidget *w, gpointer data)
 	gtk_widget_destroy(dialog);
 }
 
-static GtkItemFactoryEntry menu_items[] = {
-	{ "/_File",		NULL,		NULL,		0, "<Branch>" },
-	{ "/File/_Open",	"<control>O",	file_open,	0, "<StockItem>", GTK_STOCK_OPEN },
-	{ "/File/_Save",	"<control>S",	file_save,	0, "<StockItem>", GTK_STOCK_SAVE },
+static GtkActionEntry menu_items[] = {
+	{ "FileMenuAction", GTK_STOCK_FILE,	0,		      0, 0, 0},
+	{ "OpenFile",       GTK_STOCK_OPEN, 0, "<control>O", 0, file_open},
+	{ "SaveFile",       GTK_STOCK_SAVE, 0, "<control>S", 0, file_save},
 };
 static gint nmenu_items = sizeof (menu_items) / sizeof (menu_items[0]);
 
-/* This is just directly from the gtk menubar tutorial. */
+static const gchar* ui_string = " \
+	<ui> \
+		<menubar name=\"MainMenu\"> \
+			<menu name=\"FileMenu\" action=\"FileMenuAction\"> \
+				<menuitem name=\"Open\" action=\"OpenFile\" /> \
+				<menuitem name=\"Save\" action=\"SaveFile\" /> \
+			</menu> \
+		</menubar> \
+	</ui> \
+";
+
 static GtkWidget *get_menubar_menu(GtkWidget *window)
 {
-	GtkItemFactory *item_factory;
-	GtkAccelGroup *accel_group;
+	GtkActionGroup *action_group = gtk_action_group_new("Menu");
+	gtk_action_group_add_actions(action_group, menu_items, nmenu_items, 0);
 
-	accel_group = gtk_accel_group_new();
-	item_factory = gtk_item_factory_new(GTK_TYPE_MENU_BAR, "<main>", accel_group);
+	GtkUIManager *ui_manager = gtk_ui_manager_new();
+	gtk_ui_manager_insert_action_group(ui_manager, action_group, 0);
+	GError* error = 0;
+	gtk_ui_manager_add_ui_from_string(GTK_UI_MANAGER(ui_manager), ui_string, -1, &error);
 
-	gtk_item_factory_create_items(item_factory, nmenu_items, menu_items, NULL);
-	gtk_window_add_accel_group(GTK_WINDOW(window), accel_group);
-	return gtk_item_factory_get_widget(item_factory, "<main>");
+	gtk_window_add_accel_group(GTK_WINDOW(window), gtk_ui_manager_get_accel_group(ui_manager));
+	GtkWidget* menu = gtk_ui_manager_get_widget(ui_manager, "/MainMenu");
+
+	return menu;
 }
 
 int main(int argc, char **argv)

--- a/profile.c
+++ b/profile.c
@@ -174,23 +174,19 @@ static void plot(cairo_t *cr, int w, int h, struct dive *dive)
 
 }
 
-static gboolean expose_event(GtkWidget *widget, GdkEventExpose *event, gpointer data)
+static gboolean draw(GtkWidget *widget, cairo_t *cr, gpointer data)
 {
 	struct dive *dive = current_dive;
-	cairo_t *cr;
 	int w,h;
 
-	w = widget->allocation.width;
-	h = widget->allocation.height;
+	w = gtk_widget_get_allocated_width(widget);
+	h = gtk_widget_get_allocated_height(widget);
 
-	cr = gdk_cairo_create(widget->window);
 	cairo_set_source_rgb(cr, 0, 0, 0);
 	cairo_paint(cr);
 
 	if (dive)
 		plot(cr, w, h, dive);
-
-	cairo_destroy(cr);
 
 	return FALSE;
 }
@@ -204,7 +200,7 @@ GtkWidget *dive_profile_frame(void)
 	gtk_widget_show(frame);
 	da = gtk_drawing_area_new();
 	gtk_widget_set_size_request(da, 450, 350);
-	g_signal_connect(da, "expose_event", G_CALLBACK(expose_event), NULL);
+	g_signal_connect(da, "draw", G_CALLBACK(draw), NULL);
 	gtk_container_add(GTK_CONTAINER(frame), da);
 
 	return frame;


### PR DESCRIPTION
Use GTK3 instead of GTK2. Even if you don't like GTK3, two of the 3 patches (first and the last, especially the last) will be useful on GTK2.
