### PR TITLE
More divelist goodness.

### DIFF
--- a/divelist.c
+++ b/divelist.c
@@ -97,17 +97,21 @@ GtkWidget *create_dive_list(void)
 	col = gtk_tree_view_column_new();
 	gtk_tree_view_column_set_title(col, "ft");
 	gtk_tree_view_column_set_sort_column_id(col, 3);
-	gtk_tree_view_column_pack_start(col, renderer, TRUE);
+	gtk_tree_view_column_pack_start(col, renderer, FALSE);
 	gtk_tree_view_column_add_attribute(col, renderer, "text", 2);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(tree_view), col);
+	gtk_object_set(GTK_OBJECT(renderer), "alignment", PANGO_ALIGN_RIGHT, NULL);
+	gtk_cell_renderer_set_alignment(GTK_CELL_RENDERER(renderer), 1.0, 0.5);
 	
 	renderer = gtk_cell_renderer_text_new();
 	col = gtk_tree_view_column_new();
 	gtk_tree_view_column_set_title(col, "min");
 	gtk_tree_view_column_set_sort_column_id(col, 5);
-	gtk_tree_view_column_pack_start(col, renderer, TRUE);
+	gtk_tree_view_column_pack_start(col, renderer, FALSE);
 	gtk_tree_view_column_add_attribute(col, renderer, "text", 4);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(tree_view), col);
+	gtk_object_set(GTK_OBJECT(renderer), "alignment", PANGO_ALIGN_RIGHT, NULL);
+	gtk_cell_renderer_set_alignment(GTK_CELL_RENDERER(renderer), 1.0, 0.5);
 
 	g_object_set(G_OBJECT(tree_view), "headers-visible", TRUE,
 					  "search-column", 0,


### PR DESCRIPTION
Right aligned the numbers (as requested in #13). I had to look it up on http://developer.gnome.org/gtk/2.24/GtkCellRendererText.html but I found it.

I also wanted to "zebra" color the divelist by setting the rules-hint to TRUE. but I noticed it was already set explicitly to FALSE (even if this is the default).

If this is just an accidental copy paste from some tutorial you can experiment (set it to TRUE) and see what you like most.
