### PR TITLE
Activate and silence more warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 CC=gcc
 CFLAGS=-Wall -Wextra -Wno-pointer-sign -Wno-unused-parameter -g
 
+RM=rm
+
 OBJS=main.o dive.o profile.o info.o divelist.o parse-xml.o save-xml.o
 
 divelog: $(OBJS)
@@ -28,3 +30,8 @@ info.o: info.c dive.h display.h divelist.h
 
 divelist.o: divelist.c dive.h display.h divelist.h
 	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0` -c divelist.c
+
+clean:
+	$(RM) -f $(OBJS) divelog
+
+.PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-Wall -Wextra -Wno-pointer-sign -Wno-unused-parameter -g
+CFLAGS=-O2 -Wall -Wextra -Wno-pointer-sign -Wno-unused-parameter -Wno-unused-result -g
 
 RM=rm
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-Wall -Wno-pointer-sign -g
+CFLAGS=-Wall -Wextra -Wno-pointer-sign -Wno-unused-parameter -g
 
 OBJS=main.o dive.o profile.o info.o divelist.o parse-xml.o save-xml.o
 

--- a/dive.h
+++ b/dive.h
@@ -50,7 +50,7 @@ typedef struct {
 } depth_t;
 
 typedef struct {
-	int mbar;
+	unsigned int mbar;
 } pressure_t;
 
 typedef struct {
@@ -159,7 +159,7 @@ extern struct units input_units, output_units;
 extern int verbose;
 
 struct dive_table {
-	int nr, allocated;
+	unsigned int nr, allocated;
 	struct dive **dives;
 };
 

--- a/divelist.c
+++ b/divelist.c
@@ -62,6 +62,7 @@ static gboolean set_one_dive(GtkTreeModel *model,
 		/* Rounding? */
 		break;
 	case FEET:
+	default:
 		integer = to_feet(dive->maxdepth);
 		frac = -1;
 	}
@@ -97,6 +98,7 @@ void update_dive_list_units(struct DiveList *dive_list)
 		unit = "m";
 		break;
 	case FEET:
+	default:
 		unit = "ft";
 		break;
 	}

--- a/divelist.c
+++ b/divelist.c
@@ -10,7 +10,9 @@
 static void selection_cb(GtkTreeSelection *selection, GtkTreeModel *model)
 {
 	GtkTreeIter iter;
-	GValue value = {0, };
+	GValue value;
+
+	memset(&value, 0, sizeof(value));
 
 	if (!gtk_tree_selection_get_selected(selection, NULL, &iter))
 		return;
@@ -26,11 +28,13 @@ static gboolean set_one_dive(GtkTreeModel *model,
 			     gpointer data)
 {
 	int len;
-	GValue value = {0, };
+	GValue value;
 	struct dive *dive;
 	char buffer[256], *datestr, *depth, *duration;
 	struct tm *tm;
 	int integer, frac;
+
+	memset(&value, 0, sizeof(value));
 
 	/* Get the dive number */
 	gtk_tree_model_get_value(model, iter, 6, &value);
@@ -103,7 +107,7 @@ void update_dive_list_units(struct DiveList *dive_list)
 
 static void fill_dive_list(struct DiveList *dive_list)
 {
-	int i;
+	unsigned int i;
 	GtkTreeIter iter;
 	GtkListStore *store;
 

--- a/main.c
+++ b/main.c
@@ -34,7 +34,7 @@ static int sortfn(const void *_a, const void *_b)
  */
 static void report_dives(void)
 {
-	int i;
+	unsigned int i;
 
 	qsort(dive_table.dives, dive_table.nr, sizeof(struct dive *), sortfn);
 

--- a/parse-xml.c
+++ b/parse-xml.c
@@ -802,8 +802,10 @@ static void uddf_datetime(char *buffer, void *_when)
 	char c;
 	int y,m,d,hh,mm,ss;
 	time_t *when = _when;
-	struct tm tm = { 0 };
+	struct tm tm;
 	int i;
+
+	memset(&tm, 0, sizeof(tm));
 
 	i = sscanf(buffer, "%d-%d-%d%c%d:%d:%d", &y, &m, &d, &c, &hh, &mm, &ss);
 	if (i == 7)
@@ -1279,12 +1281,12 @@ static struct nesting {
 	{ "P", sample_start, sample_end },
 
 	/* Import type recognition */
-	{ "SUUNTO", suunto_importer },
-	{ "Divinglog", DivingLog_importer },
-	{ "pre_dive", uemis_importer },
-	{ "uddf", uddf_importer },
+	{ "SUUNTO", suunto_importer, NULL },
+	{ "Divinglog", DivingLog_importer, NULL },
+	{ "pre_dive", uemis_importer, NULL },
+	{ "uddf", uddf_importer, NULL },
 
-	{ NULL, }
+	{ NULL, NULL, NULL }
 };
 
 static void traverse(xmlNode *root)

--- a/parse-xml.c
+++ b/parse-xml.c
@@ -252,6 +252,7 @@ static void pressure(char *buffer, void *_press)
 				mbar = mbar * 1000;
 			break;
 		case PSI:
+		default:
 			mbar = val.fp * 68.95;
 			break;
 		}

--- a/profile.c
+++ b/profile.c
@@ -78,12 +78,12 @@ static void plot_text(struct graphics_context *gc, const text_render_options_t *
 
 	cairo_set_font_size(cr, tro->size);
 	cairo_text_extents(cr, buffer, &extents);
-	dx = 0;
 	switch (tro->halign) {
 	case CENTER:
 		dx = -(extents.width/2 + extents.x_bearing);
 		break;
 	case LEFT:
+	default:
 		dx = 0;
 		break;
 	}
@@ -95,6 +95,7 @@ static void plot_text(struct graphics_context *gc, const text_render_options_t *
 		dy = -extents.height * 0.8;
 		break;
 	case MIDDLE:
+	default:
 		dy = 0;
 		break;
 	}
@@ -126,6 +127,7 @@ static void render_depth_sample(struct graphics_context *gc, struct sample *samp
 		fmt = "%.1f";
 		break;
 	case FEET:
+	default:
 		d = to_feet(depth);
 		fmt = "%.0f";
 		break;
@@ -249,7 +251,7 @@ static void plot_depth_profile(struct dive *dive, struct graphics_context *gc)
 	gc->scaley = maxdepth;
 	switch (output_units.length) {
 	case METERS: marker = 10000; break;
-	case FEET: marker = 9144; break;	/* 30 ft */
+	case FEET: default: marker = 9144; break;	/* 30 ft */
 	}
 
 	cairo_set_source_rgba(cr, 1, 1, 1, 0.5);
@@ -269,7 +271,7 @@ static void plot_depth_profile(struct dive *dive, struct graphics_context *gc)
 
 	sample = dive->sample;
 	cairo_set_source_rgba(cr, 1, 0.2, 0.2, 0.80);
-	begins = sample->time.seconds;
+	sec = begins = sample->time.seconds;
 	move_to(gc, sample->time.seconds, sample->depth.mm);
 	for (i = 1; i < dive->samples; i++) {
 		sample++;
@@ -399,6 +401,7 @@ static void plot_info(struct dive *dive, struct graphics_context *gc)
 		unit = "l";
 		break;
 	case CUFT:
+	default:
 		unit = "cuft";
 		airuse /= liters_per_cuft;
 		break;
@@ -431,6 +434,7 @@ static void plot_cylinder_pressure_text(struct dive *dive, struct graphics_conte
 			unit = "bar";
 			break;
 		case PSI:
+		default:
 			start = to_PSI(startp);
 			end = to_PSI(endp);
 			unit = "psi";

--- a/save-xml.c
+++ b/save-xml.c
@@ -219,7 +219,7 @@ static void save_dive(FILE *f, struct dive *dive)
 
 void save_dives(const char *filename)
 {
-	int i;
+	unsigned int i;
 	FILE *f = fopen(filename, "w");
 
 	if (!f)


### PR DESCRIPTION
This adds -Wextra and -O2, and silence the warnings produced by those (except for the fprintf unused result)
It also adds a clean target for facilities
