### PR TITLE
Show tank / nitrox / air consumption information in the info_frame

### DIFF
--- a/dive.h
+++ b/dive.h
@@ -207,6 +207,8 @@ extern void report_dives(void);
 extern struct dive *fixup_dive(struct dive *dive);
 extern struct dive *try_to_merge(struct dive *a, struct dive *b);
 
+extern void update_air_info(char *buffer);
+
 #define DIVE_ERROR_PARSE 1
 
 #endif /* DIVE_H */

--- a/info.c
+++ b/info.c
@@ -8,7 +8,7 @@
 #include "divelist.h"
 
 static GtkWidget *info_frame;
-static GtkWidget *depth, *duration, *temperature;
+static GtkWidget *depth, *duration, *temperature, *airconsumption;
 static GtkEntry *location, *buddy, *divemaster;
 static GtkTextBuffer *notes;
 static int location_changed = 1, notes_changed = 1;
@@ -67,6 +67,7 @@ void show_dive_info(struct dive *dive)
 	if (!dive) {
 		gtk_label_set_text(GTK_LABEL(depth), "");
 		gtk_label_set_text(GTK_LABEL(duration), "");
+		gtk_label_set_text(GTK_LABEL(airconsumption), "");
 		return;
 	}
 	/* dive number and location (or lacking that, the date) go in the window title */
@@ -181,8 +182,17 @@ GtkWidget *dive_info_frame(void)
 	depth = info_label(hbox, "depth", GTK_JUSTIFY_RIGHT);
 	duration = info_label(hbox, "duration", GTK_JUSTIFY_RIGHT);
 	temperature = info_label(hbox, "temperature", GTK_JUSTIFY_RIGHT);
+	airconsumption = info_label(hbox, "air", GTK_JUSTIFY_RIGHT);
 
 	return frame;
+}
+
+void update_air_info(char *buffer)
+{
+	char markup[120];
+	
+	snprintf(markup, sizeof(markup), "<span font=\"8\">%s</span>",buffer);
+	gtk_label_set_markup(GTK_LABEL(airconsumption), markup);
 }
 
 static GtkEntry *text_entry(GtkWidget *box, const char *label)

--- a/profile.c
+++ b/profile.c
@@ -504,7 +504,7 @@ static void plot_info(struct dive *dive, struct graphics_context *gc)
 
 	airuse = calculate_airuse(dive);
 	if (!airuse) {
-		update_air_info("");
+		update_air_info("          \n          ");
 		return;
 	}
 	switch (output_units.volume) {


### PR DESCRIPTION
Even though we go down to an 8pt font the info_frame changes size when the
air info is added. I don't like this but want to see how Linus would like
this resolved before going overboard.

Minor tweaks to the formating (we don't need two decimals when printing
the liters of air consumed).

This patch does NOT remove the plot of the air information in the profile
graph. I think we want to remove that once we like the text where it is,
but I wanted to do one thing at a time.

Signed-off-by: Dirk Hohndel dirk@hohndel.org
