### PR TITLE
Gui separation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ LIBDIVECOMPUTERINCLUDES = $(LIBDIVECOMPUTERDIR)/include/libdivecomputer
 LIBDIVECOMPUTERARCHIVE = $(LIBDIVECOMPUTERDIR)/lib/libdivecomputer.a
 
 OBJS =	main.o dive.o profile.o info.o equipment.o divelist.o \
-	parse-xml.o save-xml.o libdivecomputer.o print.o uemis.o
+	parse-xml.o save-xml.o libdivecomputer.o print.o uemis.o \
+	gtk-gui.o
 
 subsurface: $(OBJS)
 	$(CC) $(LDFLAGS) -o subsurface $(OBJS) \
@@ -24,8 +25,12 @@ dive.o: dive.c dive.h
 	$(CC) $(CFLAGS) `pkg-config --cflags glib-2.0` -c dive.c
 
 main.o: main.c dive.h display.h divelist.h
-	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0 gconf-2.0` \
+	$(CC) $(CFLAGS) `pkg-config --cflags glib-2.0 gconf-2.0` \
 		-c main.c
+
+gtk-gui.o: gtk-gui.c dive.h display.h divelist.h
+	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0 gconf-2.0` \
+		-c gtk-gui.c
 
 profile.o: profile.c dive.h display.h divelist.h
 	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0` -c profile.c

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,10 @@ main.o: main.c dive.h display.h divelist.h
 	$(CC) $(CFLAGS) `pkg-config --cflags glib-2.0 gconf-2.0` \
 		-c main.c
 
-gtk-gui.o: gtk-gui.c dive.h display.h divelist.h
-	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0 gconf-2.0` \
-		-c gtk-gui.c
-
 profile.o: profile.c dive.h display.h divelist.h
 	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0` -c profile.c
 
-info.o: info.c dive.h display.h divelist.h
+info.o: info.c dive.h display.h display-gtk.h divelist.h
 	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0` -c info.c
 
 equipment.o: equipment.c dive.h display.h divelist.h
@@ -44,13 +40,18 @@ equipment.o: equipment.c dive.h display.h divelist.h
 divelist.o: divelist.c dive.h display.h divelist.h
 	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0` -c divelist.c
 
-print.o: print.c dive.h display.h
+print.o: print.c dive.h display.h display-gtk.h
 	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0` -c print.c
 
-libdivecomputer.o: libdivecomputer.c dive.h display.h
+libdivecomputer.o: libdivecomputer.c dive.h display.h display-gtk.h libdivecomputer.h
 	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0` \
 			-I$(LIBDIVECOMPUTERINCLUDES) \
 			-c libdivecomputer.c
+
+gtk-gui.o: gtk-gui.c dive.h display.h divelist.h display-gtk.h libdivecomputer.h
+	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0 gconf-2.0` \
+			-I$(LIBDIVECOMPUTERINCLUDES) \
+			-c gtk-gui.c
 
 uemis.o: uemis.c uemis.h
 	$(CC) $(CFLAGS) `pkg-config --cflags gtk+-2.0 glib-2.0` -c uemis.c

--- a/README
+++ b/README
@@ -37,6 +37,25 @@ and subsurface will de-duplicate the ones that are exactly the same
 the dives have duplicates that were edited by Dirk in the Suunto Dive
 Manager, so they don't trigger the "exact duplicates" match.
 
+Implementation details:
+
+main.c - program frame
+dive.c - creates and maintaines the internal dive list structure
+libdivecomputer.c 
+uemis.c 
+parse-xml.c 
+save-xml.c - interface with dive computers and the XML files 
+profile.c - creates the data for the profile and draws it using cairo
+
+A first UI has been implemented in gtk and an attempt has been made to
+separate program logic from UI implementation. 
+
+gtk-gui.c - overall layout, main window of the UI
+divelist.c  - list of dives subsurface maintains
+equipment.c - equipment / tank information for each dive
+info.c      - detailed dive info 
+print.c     - printing 
+
 WARNING! I wasn't kidding when I said that I've done this by reading
 gtk2 tutorials as I've gone along.  If somebody is more comfortable with
 gtk, feel free to send me (signed-off) patches.

--- a/display-gtk.h
+++ b/display-gtk.h
@@ -6,8 +6,15 @@
 
 extern GtkWidget *main_window;
 
+/* we want a progress bar as part of the device_data_t - let's abstract this out */
+typedef struct {
+	GtkWidget *bar;
+} progressbar_t;
+
 extern void import_dialog(GtkWidget *, gpointer);
 extern void report_error(GError* error);
+extern int process_ui_events(void);
+extern void update_progressbar(progressbar_t *progress, double value);
 
 extern GtkWidget *dive_profile_widget(void);
 extern GtkWidget *dive_info_frame(void);

--- a/display-gtk.h
+++ b/display-gtk.h
@@ -1,0 +1,17 @@
+#ifndef DISPLAY_GTK_H
+#define DISPLAY_GTK_H
+
+#include <gtk/gtk.h>
+#include <gdk/gdk.h>
+
+extern GtkWidget *main_window;
+
+extern void import_dialog(GtkWidget *, gpointer);
+extern void report_error(GError* error);
+
+extern GtkWidget *dive_profile_widget(void);
+extern GtkWidget *dive_info_frame(void);
+extern GtkWidget *extended_dive_info_widget(void);
+extern GtkWidget *equipment_widget(void);
+
+#endif

--- a/display.h
+++ b/display.h
@@ -1,19 +1,7 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
-#include <gtk/gtk.h>
-#include <gdk/gdk.h>
 #include <cairo.h>
-
-extern GtkWidget *main_window;
-
-extern void import_dialog(GtkWidget *, gpointer);
-extern void report_error(GError* error);
-
-extern GtkWidget *dive_profile_widget(void);
-extern GtkWidget *dive_info_frame(void);
-extern GtkWidget *extended_dive_info_widget(void);
-extern GtkWidget *equipment_widget(void);
 
 extern void repaint_dive(void);
 extern void do_print(void);
@@ -35,5 +23,6 @@ struct graphics_context {
 };
 
 extern void plot(struct graphics_context *gc, int w, int h, struct dive *dive);
+extern void set_source_rgb(struct graphics_context *gc, double r, double g, double b);
 
 #endif

--- a/dive.c
+++ b/dive.c
@@ -1,3 +1,5 @@
+/* dive.h */
+/* maintains the internal dive list structure */
 #include <string.h>
 #include <stdio.h>
 

--- a/dive.h
+++ b/dive.h
@@ -208,8 +208,6 @@ extern void report_dives(void);
 extern struct dive *fixup_dive(struct dive *dive);
 extern struct dive *try_to_merge(struct dive *a, struct dive *b);
 
-extern void update_air_info(char *buffer);
-
 extern void renumber_dives(int nr);
 
 /* UI related protopypes */

--- a/dive.h
+++ b/dive.h
@@ -178,6 +178,7 @@ static inline struct dive *get_dive(unsigned int nr)
 	return dive_table.dives[nr];
 }
 
+
 extern void parse_xml_init(void);
 extern void parse_xml_file(const char *filename, GError **error);
 

--- a/dive.h
+++ b/dive.h
@@ -209,6 +209,20 @@ extern struct dive *try_to_merge(struct dive *a, struct dive *b);
 
 extern void update_air_info(char *buffer);
 
+extern void renumber_dives(int nr);
+
+/* UI related protopypes */
+
+extern void init_ui(int argc, char **argv);
+
+extern void run_ui(void);
+
+extern void report_error(GError* error);
+
+extern void dive_list_update_dives(void);
+
+extern int open_import_file_dialog(char *filterpattern, char *filtertext, 
+				void(* parse_function)(char *));
 #define DIVE_ERROR_PARSE 1
 
 #endif /* DIVE_H */

--- a/divelist.c
+++ b/divelist.c
@@ -1,3 +1,11 @@
+/* divelist.c */
+/* this creates the UI for the dive list - 
+ * controlled through the following interfaces:
+ * 
+ * struct DiveList dive_list_create(void)
+ * void dive_list_update_dives(void)
+ * void update_dive_list_units(struct DiveList *dive_list)
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/divelist.c
+++ b/divelist.c
@@ -7,6 +7,9 @@
 #include "dive.h"
 #include "display.h"
 
+/* let's just have a global dive list */
+struct DiveList dive_list;
+ 
 static void selection_cb(GtkTreeSelection *selection, GtkTreeModel *model)
 {
 	GtkTreeIter iter;
@@ -127,7 +130,7 @@ static void fill_dive_list(struct DiveList *dive_list)
 	update_dive_list_units(dive_list);
 }
 
-void dive_list_update_dives(struct DiveList dive_list)
+void dive_list_update_dives(void)
 {
 	gtk_list_store_clear(GTK_LIST_STORE(dive_list.model));
 	fill_dive_list(&dive_list);

--- a/divelist.h
+++ b/divelist.h
@@ -12,7 +12,7 @@ struct DiveList {
 
 extern struct DiveList dive_list;
 extern struct DiveList dive_list_create(void);
-extern void dive_list_update_dives(struct DiveList);
+
 extern void update_dive_list_units(struct DiveList *);
 
 #endif

--- a/equipment.c
+++ b/equipment.c
@@ -1,3 +1,13 @@
+/* equipment.c */
+/* creates the UI for the equipment page -
+ * controlled through the following interfaces:
+ * 
+ * void show_dive_equipment(struct dive *dive)
+ * void flush_dive_equipment_changes(struct dive *dive)
+ *
+ * called from gtk-ui:
+ * GtkWidget *equipment_widget(void)
+ */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -8,6 +8,7 @@
 #include "dive.h"
 #include "divelist.h"
 #include "display.h"
+#include "display-gtk.h"
 
 GtkWidget *main_window;
 GtkWidget *main_vbox;
@@ -435,4 +436,36 @@ int open_import_file_dialog(char *filterpattern, char *filtertext,
 	gtk_widget_destroy(dialog);
 
 	return ret;
+}
+
+static gboolean expose_event(GtkWidget *widget, GdkEventExpose *event, gpointer data)
+{
+	struct dive *dive = current_dive;
+	struct graphics_context gc = { .printer = 0 };
+	int w,h;
+
+	w = widget->allocation.width;
+	h = widget->allocation.height;
+
+	gc.cr = gdk_cairo_create(widget->window);
+	set_source_rgb(&gc, 0, 0, 0);
+	cairo_paint(gc.cr);
+
+	if (dive)
+		plot(&gc, w, h, dive);
+
+	cairo_destroy(gc.cr);
+
+	return FALSE;
+}
+
+GtkWidget *dive_profile_widget(void)
+{
+	GtkWidget *da;
+
+	da = gtk_drawing_area_new();
+	gtk_widget_set_size_request(da, 350, 250);
+	g_signal_connect(da, "expose_event", G_CALLBACK(expose_event), NULL);
+
+	return da;
 }

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -1,0 +1,438 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <gconf/gconf-client.h>
+
+#include "dive.h"
+#include "divelist.h"
+#include "display.h"
+
+GtkWidget *main_window;
+GtkWidget *main_vbox;
+GtkWidget *error_info_bar;
+GtkWidget *error_label;
+int        error_count;
+struct DiveList   dive_list;
+
+GConfClient *gconf;
+struct units output_units;
+
+#define GCONF_NAME(x) "/apps/subsurface/" #x
+
+void on_destroy(GtkWidget* w, gpointer data)
+{
+	gtk_main_quit();
+}
+
+static GtkWidget *dive_profile;
+
+void repaint_dive(void)
+{
+	update_dive(current_dive);
+	gtk_widget_queue_draw(dive_profile);
+}
+
+static char *existing_filename;
+
+static void on_info_bar_response(GtkWidget *widget, gint response,
+                                 gpointer data)
+{
+	if (response == GTK_RESPONSE_OK)
+	{
+		gtk_widget_destroy(widget);
+		error_info_bar = NULL;
+	}
+}
+
+void report_error(GError* error)
+{
+	if (error == NULL)
+	{
+		return;
+	}
+	
+	if (error_info_bar == NULL)
+	{
+		error_count = 1;
+		error_info_bar = gtk_info_bar_new_with_buttons(GTK_STOCK_OK,
+		                                               GTK_RESPONSE_OK,
+		                                               NULL);
+		g_signal_connect(error_info_bar, "response", G_CALLBACK(on_info_bar_response), NULL);
+		gtk_info_bar_set_message_type(GTK_INFO_BAR(error_info_bar),
+		                              GTK_MESSAGE_ERROR);
+		
+		error_label = gtk_label_new(error->message);
+		GtkWidget *container = gtk_info_bar_get_content_area(GTK_INFO_BAR(error_info_bar));
+		gtk_container_add(GTK_CONTAINER(container), error_label);
+		
+		gtk_box_pack_start(GTK_BOX(main_vbox), error_info_bar, FALSE, FALSE, 0);
+		gtk_widget_show_all(main_vbox);
+	}
+	else
+	{
+		error_count++;
+		char buffer[256];
+		snprintf(buffer, sizeof(buffer), "Failed to open %i files.", error_count);
+		gtk_label_set(GTK_LABEL(error_label), buffer);
+	}
+}
+
+static void file_open(GtkWidget *w, gpointer data)
+{
+	GtkWidget *dialog;
+	dialog = gtk_file_chooser_dialog_new("Open File",
+		GTK_WINDOW(main_window),
+		GTK_FILE_CHOOSER_ACTION_OPEN,
+		GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+		GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
+		NULL);
+	gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(dialog), TRUE);
+
+	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
+		GSList *filenames;
+		char *filename;
+		filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog));
+		
+		GError *error = NULL;
+		while(filenames != NULL) {
+			filename = (char *)filenames->data;
+			parse_xml_file(filename, &error);
+			if (error != NULL)
+			{
+				report_error(error);
+				g_error_free(error);
+				error = NULL;
+			}
+			
+			g_free(filename);
+			filenames = g_slist_next(filenames);
+		}
+		g_slist_free(filenames);
+		report_dives();
+		dive_list_update_dives();
+	}
+	gtk_widget_destroy(dialog);
+}
+
+static void file_save(GtkWidget *w, gpointer data)
+{
+	GtkWidget *dialog;
+	dialog = gtk_file_chooser_dialog_new("Save File",
+		GTK_WINDOW(main_window),
+		GTK_FILE_CHOOSER_ACTION_SAVE,
+		GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+		GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
+		NULL);
+	gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), TRUE);
+	if (!existing_filename) {
+		gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), "Untitled document");
+	} else
+		gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(dialog), existing_filename);
+
+	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
+		char *filename;
+		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+		save_dives(filename);
+		g_free(filename);
+	}
+	gtk_widget_destroy(dialog);
+}
+
+static void quit(GtkWidget *w, gpointer data)
+{
+	gtk_main_quit();
+}
+
+static void create_radio(GtkWidget *dialog, const char *name, ...)
+{
+	va_list args;
+	GtkRadioButton *group = NULL;
+	GtkWidget *box, *label;
+
+	box = gtk_hbox_new(TRUE, 10);
+	gtk_container_add(GTK_CONTAINER(GTK_DIALOG(dialog)->vbox), box);
+
+	label = gtk_label_new(name);
+	gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
+
+	va_start(args, name);
+	for (;;) {
+		int enabled;
+		const char *name;
+		GtkWidget *button;
+		void *callback_fn;
+
+		name = va_arg(args, char *);
+		if (!name)
+			break;
+		callback_fn = va_arg(args, void *);
+		enabled = va_arg(args, int);
+
+		button = gtk_radio_button_new_with_label_from_widget(group, name);
+		group = GTK_RADIO_BUTTON(button);
+		gtk_box_pack_start(GTK_BOX(box), button, TRUE, TRUE, 0);
+		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), enabled);
+		g_signal_connect(button, "toggled", G_CALLBACK(callback_fn), NULL);
+	}
+	va_end(args);
+}
+
+#define UNITCALLBACK(name, type, value)				\
+static void name(GtkWidget *w, gpointer data) 			\
+{								\
+	if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w)))	\
+		menu_units.type = value;			\
+}
+
+static struct units menu_units;
+
+UNITCALLBACK(set_meter, length, METERS)
+UNITCALLBACK(set_feet, length, FEET)
+UNITCALLBACK(set_bar, pressure, BAR)
+UNITCALLBACK(set_psi, pressure, PSI)
+UNITCALLBACK(set_liter, volume, LITER)
+UNITCALLBACK(set_cuft, volume, CUFT)
+UNITCALLBACK(set_celsius, temperature, CELSIUS)
+UNITCALLBACK(set_fahrenheit, temperature, FAHRENHEIT)
+
+static void unit_dialog(GtkWidget *w, gpointer data)
+{
+	int result;
+	GtkWidget *dialog;
+
+	menu_units = output_units;
+
+	dialog = gtk_dialog_new_with_buttons("Units",
+		GTK_WINDOW(main_window),
+		GTK_DIALOG_DESTROY_WITH_PARENT,
+		GTK_STOCK_OK, GTK_RESPONSE_ACCEPT,
+		GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
+		NULL);
+
+	create_radio(dialog, "Depth:",
+		"Meter", set_meter, (output_units.length == METERS),
+		"Feet",  set_feet, (output_units.length == FEET),
+		NULL);
+
+	create_radio(dialog, "Pressure:",
+		"Bar", set_bar, (output_units.pressure == BAR),
+		"PSI",  set_psi, (output_units.pressure == PSI),
+		NULL);
+
+	create_radio(dialog, "Volume:",
+		"Liter",  set_liter, (output_units.volume == LITER),
+		"CuFt", set_cuft, (output_units.volume == CUFT),
+		NULL);
+
+	create_radio(dialog, "Temperature:",
+		"Celsius", set_celsius, (output_units.temperature == CELSIUS),
+		"Fahrenheit",  set_fahrenheit, (output_units.temperature == FAHRENHEIT),
+		NULL);
+
+	gtk_widget_show_all(dialog);
+	result = gtk_dialog_run(GTK_DIALOG(dialog));
+	if (result == GTK_RESPONSE_ACCEPT) {
+		/* Make sure to flush any modified old dive data with old units */
+		update_dive(NULL);
+		output_units = menu_units;
+		update_dive_list_units(&dive_list);
+		repaint_dive();
+		gconf_client_set_bool(gconf, GCONF_NAME(feet), output_units.length == FEET, NULL);
+		gconf_client_set_bool(gconf, GCONF_NAME(psi), output_units.pressure == PSI, NULL);
+		gconf_client_set_bool(gconf, GCONF_NAME(cuft), output_units.volume == CUFT, NULL);
+		gconf_client_set_bool(gconf, GCONF_NAME(fahrenheit), output_units.temperature == FAHRENHEIT, NULL);
+	}
+	gtk_widget_destroy(dialog);
+}
+
+static void renumber_dialog(GtkWidget *w, gpointer data)
+{
+	int result;
+	GtkWidget *dialog, *frame, *button;
+
+	dialog = gtk_dialog_new_with_buttons("Renumber",
+		GTK_WINDOW(main_window),
+		GTK_DIALOG_DESTROY_WITH_PARENT,
+		GTK_STOCK_OK, GTK_RESPONSE_ACCEPT,
+		GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
+		NULL);
+
+	frame = gtk_frame_new("New starting number");
+	gtk_container_add(GTK_CONTAINER(GTK_DIALOG(dialog)->vbox), frame);
+
+	button = gtk_spin_button_new_with_range(1, 50000, 1);
+	gtk_container_add(GTK_CONTAINER(frame), button);
+
+	gtk_widget_show_all(dialog);
+	result = gtk_dialog_run(GTK_DIALOG(dialog));
+	if (result == GTK_RESPONSE_ACCEPT) {
+		int nr = gtk_spin_button_get_value(GTK_SPIN_BUTTON(button));
+		renumber_dives(nr);
+		repaint_dive();
+	}
+	gtk_widget_destroy(dialog);
+}
+
+static GtkActionEntry menu_items[] = {
+	{ "FileMenuAction", GTK_STOCK_FILE, "Log", NULL, NULL, NULL},
+	{ "OpenFile",       GTK_STOCK_OPEN, NULL,   "<control>O", NULL, G_CALLBACK(file_open) },
+	{ "SaveFile",       GTK_STOCK_SAVE, NULL,   "<control>S", NULL, G_CALLBACK(file_save) },
+	{ "Print",          GTK_STOCK_PRINT, NULL,  "<control>P", NULL, G_CALLBACK(do_print) },
+	{ "Import",         NULL, "Import", NULL, NULL, G_CALLBACK(import_dialog) },
+	{ "Units",          NULL, "Units",    NULL, NULL, G_CALLBACK(unit_dialog) },
+	{ "Renumber",       NULL, "Renumber", NULL, NULL, G_CALLBACK(renumber_dialog) },
+	{ "Quit",           GTK_STOCK_QUIT, NULL,   "<control>Q", NULL, G_CALLBACK(quit) },
+};
+static gint nmenu_items = sizeof (menu_items) / sizeof (menu_items[0]);
+
+static const gchar* ui_string = " \
+	<ui> \
+		<menubar name=\"MainMenu\"> \
+			<menu name=\"FileMenu\" action=\"FileMenuAction\"> \
+				<menuitem name=\"Open\" action=\"OpenFile\" /> \
+				<menuitem name=\"Save\" action=\"SaveFile\" /> \
+				<menuitem name=\"Print\" action=\"Print\" /> \
+				<separator name=\"Separator1\"/> \
+				<menuitem name=\"Import\" action=\"Import\" /> \
+				<separator name=\"Separator2\"/> \
+				<menuitem name=\"Units\" action=\"Units\" /> \
+				<menuitem name=\"Renumber\" action=\"Renumber\" /> \
+				<separator name=\"Separator3\"/> \
+				<menuitem name=\"Quit\" action=\"Quit\" /> \
+			</menu> \
+		</menubar> \
+	</ui> \
+";
+
+static GtkWidget *get_menubar_menu(GtkWidget *window)
+{
+	GtkActionGroup *action_group = gtk_action_group_new("Menu");
+	gtk_action_group_add_actions(action_group, menu_items, nmenu_items, 0);
+
+	GtkUIManager *ui_manager = gtk_ui_manager_new();
+	gtk_ui_manager_insert_action_group(ui_manager, action_group, 0);
+	GError* error = 0;
+	gtk_ui_manager_add_ui_from_string(GTK_UI_MANAGER(ui_manager), ui_string, -1, &error);
+
+	gtk_window_add_accel_group(GTK_WINDOW(window), gtk_ui_manager_get_accel_group(ui_manager));
+	GtkWidget* menu = gtk_ui_manager_get_widget(ui_manager, "/MainMenu");
+
+	return menu;
+}
+
+static void switch_page(GtkNotebook *notebook, gint arg1, gpointer user_data)
+{
+	repaint_dive();
+}
+
+void init_ui(int argc, char **argv)
+{
+	GtkWidget *win;
+	GtkWidget *paned;
+	GtkWidget *info_box;
+	GtkWidget *notebook;
+	GtkWidget *frame;
+	GtkWidget *dive_info;
+	GtkWidget *equipment;
+	GtkWidget *menubar;
+	GtkWidget *vbox;
+
+	gtk_init(&argc, &argv);
+
+	error_info_bar = NULL;
+	win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+	g_signal_connect(G_OBJECT(win), "destroy", G_CALLBACK(on_destroy), NULL);
+	main_window = win;
+
+	vbox = gtk_vbox_new(FALSE, 0);
+	gtk_container_add(GTK_CONTAINER(win), vbox);
+	main_vbox = vbox;
+
+	menubar = get_menubar_menu(win);
+	gtk_box_pack_start(GTK_BOX(vbox), menubar, FALSE, FALSE, 0);
+
+	/* HPane for left the dive list, and right the dive info */
+	paned = gtk_hpaned_new();
+	gtk_box_pack_end(GTK_BOX(vbox), paned, TRUE, TRUE, 0);
+
+	/* Create the actual divelist */
+	dive_list = dive_list_create();
+	gtk_paned_add1(GTK_PANED(paned), dive_list.container_widget);
+
+	/* VBox for dive info, and tabs */
+	info_box = gtk_vbox_new(FALSE, 6);
+	gtk_paned_add2(GTK_PANED(paned), info_box);
+
+	/* Frame for minimal dive info */
+	frame = dive_info_frame();
+	gtk_box_pack_start(GTK_BOX(info_box), frame, FALSE, TRUE, 6);
+
+	/* Notebook for dive info vs profile vs .. */
+	notebook = gtk_notebook_new();
+	g_signal_connect(notebook, "switch-page", G_CALLBACK(switch_page), NULL);
+	gtk_box_pack_start(GTK_BOX(info_box), notebook, TRUE, TRUE, 6);
+
+	/* Frame for dive profile */
+	dive_profile = dive_profile_widget();
+	gtk_notebook_append_page(GTK_NOTEBOOK(notebook), dive_profile, gtk_label_new("Dive Profile"));
+
+	/* Frame for extended dive info */
+	dive_info = extended_dive_info_widget();
+	gtk_notebook_append_page(GTK_NOTEBOOK(notebook), dive_info, gtk_label_new("Dive Notes"));
+
+	/* Frame for dive equipment */
+	equipment = equipment_widget();
+	gtk_notebook_append_page(GTK_NOTEBOOK(notebook), equipment, gtk_label_new("Equipment"));
+
+	gtk_widget_set_app_paintable(win, TRUE);
+	gtk_widget_show_all(win);
+
+	return;
+}
+
+void run_ui(void)
+{
+	gtk_main();
+}
+
+/* get the filenames the user selects and call the parsing function
+ * on them
+ * return 0 if the user cancelled the dialog
+ */
+int open_import_file_dialog(char *filterpattern, char *filtertext, 
+			void(* parse_function)(char *))
+{
+	int ret=0;
+
+	GtkWidget *dialog;
+	GtkFileFilter *filter = gtk_file_filter_new ();
+	gtk_file_filter_add_pattern (filter, filterpattern);
+	gtk_file_filter_set_name(filter, filtertext);
+	dialog = gtk_file_chooser_dialog_new("Open File",
+					GTK_WINDOW(main_window),
+					GTK_FILE_CHOOSER_ACTION_OPEN,
+					GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+					GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
+					NULL);
+	gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(dialog), TRUE);
+	gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog),filter);
+
+	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
+		GSList *filenames;
+		char *filename;
+		filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog));
+		while(filenames != NULL) {
+			filename = (char *)filenames->data;
+			parse_function(filename);
+			g_free(filename);
+			filenames = g_slist_next(filenames);
+		}
+		g_slist_free(filenames);
+		ret = 1;
+	}
+	gtk_widget_destroy(dialog);
+
+	return ret;
+}

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -1,3 +1,8 @@
+/* gtk-gui.c */
+/* gtk UI implementation */
+/* creates the window and overall layout
+ * divelist, dive info, equipment and printing are handled in their own source files
+ */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/info.c
+++ b/info.c
@@ -5,6 +5,7 @@
 
 #include "dive.h"
 #include "display.h"
+#include "display-gtk.h"
 #include "divelist.h"
 
 static GtkWidget *info_frame;

--- a/info.c
+++ b/info.c
@@ -14,6 +14,9 @@ static GtkTextBuffer *notes;
 static int location_changed = 1, notes_changed = 1;
 static int divemaster_changed = 1, buddy_changed = 1;
 
+#define EMPTY_AIRCONSUMPTION " \n "
+#define AIRCON_WIDTH 20
+
 static const char *weekday(int wday)
 {
 	static const char wday_array[7][4] = {
@@ -67,7 +70,8 @@ void show_dive_info(struct dive *dive)
 	if (!dive) {
 		gtk_label_set_text(GTK_LABEL(depth), "");
 		gtk_label_set_text(GTK_LABEL(duration), "");
-		gtk_label_set_text(GTK_LABEL(airconsumption), "");
+		gtk_label_set_text(GTK_LABEL(airconsumption), EMPTY_AIRCONSUMPTION);
+		gtk_label_set_width_chars(GTK_LABEL(airconsumption), AIRCON_WIDTH);
 		return;
 	}
 	/* dive number and location (or lacking that, the date) go in the window title */
@@ -183,6 +187,8 @@ GtkWidget *dive_info_frame(void)
 	duration = info_label(hbox, "duration", GTK_JUSTIFY_RIGHT);
 	temperature = info_label(hbox, "temperature", GTK_JUSTIFY_RIGHT);
 	airconsumption = info_label(hbox, "air", GTK_JUSTIFY_RIGHT);
+	gtk_misc_set_alignment(GTK_MISC(airconsumption), 1.0, 0.5);
+	gtk_label_set_width_chars(GTK_LABEL(airconsumption), AIRCON_WIDTH);
 
 	return frame;
 }

--- a/info.c
+++ b/info.c
@@ -1,3 +1,14 @@
+/* info.c */
+/* creates the UI for the info frame - 
+ * controlled through the following interfaces:
+ * 
+ * void flush_dive_info_changes(struct dive *dive)
+ * void show_dive_info(struct dive *dive)
+ *
+ * called from gtk-ui:
+ * GtkWidget *dive_info_frame(void)
+ * GtkWidget *extended_dive_info_widget(void)
+ */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -36,7 +47,7 @@ static char *get_text(GtkTextBuffer *buffer)
 	return gtk_text_buffer_get_text(buffer, &start, &end, FALSE);
 }
 
-void update_air_info(char *buffer)
+static void update_air_info(char *buffer)
 {
 	char markup[120];
 	

--- a/libdivecomputer.c
+++ b/libdivecomputer.c
@@ -5,6 +5,7 @@
 #include "dive.h"
 #include "divelist.h"
 #include "display.h"
+#include "display-gtk.h"
 
 /* libdivecomputer */
 #include <device.h>

--- a/libdivecomputer.c
+++ b/libdivecomputer.c
@@ -608,5 +608,5 @@ void import_dialog(GtkWidget *w, gpointer data)
 	gtk_widget_destroy(dialog);
 
 	report_dives();
-	dive_list_update_dives(dive_list);
+	dive_list_update_dives();
 }

--- a/libdivecomputer.h
+++ b/libdivecomputer.h
@@ -1,0 +1,38 @@
+#ifndef LIBDIVECOMPUTER_H
+#define LIBDIVECOMPUTER_H
+
+/* libdivecomputer */
+#include <device.h>
+#include <suunto.h>
+#include <reefnet.h>
+#include <uwatec.h>
+#include <oceanic.h>
+#include <mares.h>
+#include <hw.h>
+#include <cressi.h>
+#include <zeagle.h>
+#include <atomics.h>
+#include <utils.h>
+
+/* handling uemis Zurich SDA files */
+#include "uemis.h"
+
+/* don't forget to include the UI toolkit specific display-XXX.h first
+   to get the definition of progressbar_t */
+typedef struct device_data_t {
+	device_type_t type;
+	const char *name, *devname;
+	progressbar_t *progress;
+	device_devinfo_t devinfo;
+	device_clock_t clock;
+} device_data_t;
+
+struct device_list {
+	const char *name;
+	device_type_t type;
+};
+
+extern struct device_list device_list[];
+extern void do_import(device_data_t *data);
+
+#endif

--- a/main.c
+++ b/main.c
@@ -1,3 +1,4 @@
+/* main.c */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/main.c
+++ b/main.c
@@ -6,15 +6,6 @@
 #include <gconf/gconf-client.h>
 
 #include "dive.h"
-#include "divelist.h"
-#include "display.h"
-
-GtkWidget *main_window;
-GtkWidget *main_vbox;
-GtkWidget *error_info_bar;
-GtkWidget *error_label;
-int        error_count;
-struct DiveList   dive_list;
 
 GConfClient *gconf;
 struct units output_units;
@@ -83,13 +74,6 @@ static void parse_argument(const char *arg)
 	} while (*++p);
 }
 
-static void on_destroy(GtkWidget* w, gpointer data)
-{
-	gtk_main_quit();
-}
-
-static GtkWidget *dive_profile;
-
 void update_dive(struct dive *new_dive)
 {
 	static struct dive *buffered_dive;
@@ -106,226 +90,7 @@ void update_dive(struct dive *new_dive)
 	buffered_dive = new_dive;
 }
 
-void repaint_dive(void)
-{
-	update_dive(current_dive);
-	gtk_widget_queue_draw(dive_profile);
-}
-
-static char *existing_filename;
-
-static void on_info_bar_response(GtkWidget *widget, gint response,
-                                 gpointer data)
-{
-	if (response == GTK_RESPONSE_OK)
-	{
-		gtk_widget_destroy(widget);
-		error_info_bar = NULL;
-	}
-}
-
-void report_error(GError* error)
-{
-	if (error == NULL)
-	{
-		return;
-	}
-	
-	if (error_info_bar == NULL)
-	{
-		error_count = 1;
-		error_info_bar = gtk_info_bar_new_with_buttons(GTK_STOCK_OK,
-		                                               GTK_RESPONSE_OK,
-		                                               NULL);
-		g_signal_connect(error_info_bar, "response", G_CALLBACK(on_info_bar_response), NULL);
-		gtk_info_bar_set_message_type(GTK_INFO_BAR(error_info_bar),
-		                              GTK_MESSAGE_ERROR);
-		
-		error_label = gtk_label_new(error->message);
-		GtkWidget *container = gtk_info_bar_get_content_area(GTK_INFO_BAR(error_info_bar));
-		gtk_container_add(GTK_CONTAINER(container), error_label);
-		
-		gtk_box_pack_start(GTK_BOX(main_vbox), error_info_bar, FALSE, FALSE, 0);
-		gtk_widget_show_all(main_vbox);
-	}
-	else
-	{
-		error_count++;
-		char buffer[256];
-		snprintf(buffer, sizeof(buffer), "Failed to open %i files.", error_count);
-		gtk_label_set(GTK_LABEL(error_label), buffer);
-	}
-}
-
-static void file_open(GtkWidget *w, gpointer data)
-{
-	GtkWidget *dialog;
-	dialog = gtk_file_chooser_dialog_new("Open File",
-		GTK_WINDOW(main_window),
-		GTK_FILE_CHOOSER_ACTION_OPEN,
-		GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-		GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
-		NULL);
-	gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(dialog), TRUE);
-
-	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-		GSList *filenames;
-		char *filename;
-		filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog));
-		
-		GError *error = NULL;
-		while(filenames != NULL) {
-			filename = (char *)filenames->data;
-			parse_xml_file(filename, &error);
-			if (error != NULL)
-			{
-				report_error(error);
-				g_error_free(error);
-				error = NULL;
-			}
-			
-			g_free(filename);
-			filenames = g_slist_next(filenames);
-		}
-		g_slist_free(filenames);
-		report_dives();
-		dive_list_update_dives(dive_list);
-	}
-	gtk_widget_destroy(dialog);
-}
-
-static void file_save(GtkWidget *w, gpointer data)
-{
-	GtkWidget *dialog;
-	dialog = gtk_file_chooser_dialog_new("Save File",
-		GTK_WINDOW(main_window),
-		GTK_FILE_CHOOSER_ACTION_SAVE,
-		GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-		GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
-		NULL);
-	gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), TRUE);
-	if (!existing_filename) {
-		gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), "Untitled document");
-	} else
-		gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(dialog), existing_filename);
-
-	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-		char *filename;
-		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-		save_dives(filename);
-		g_free(filename);
-	}
-	gtk_widget_destroy(dialog);
-}
-
-static void quit(GtkWidget *w, gpointer data)
-{
-	gtk_main_quit();
-}
-
-static void create_radio(GtkWidget *dialog, const char *name, ...)
-{
-	va_list args;
-	GtkRadioButton *group = NULL;
-	GtkWidget *box, *label;
-
-	box = gtk_hbox_new(TRUE, 10);
-	gtk_container_add(GTK_CONTAINER(GTK_DIALOG(dialog)->vbox), box);
-
-	label = gtk_label_new(name);
-	gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
-
-	va_start(args, name);
-	for (;;) {
-		int enabled;
-		const char *name;
-		GtkWidget *button;
-		void *callback_fn;
-
-		name = va_arg(args, char *);
-		if (!name)
-			break;
-		callback_fn = va_arg(args, void *);
-		enabled = va_arg(args, int);
-
-		button = gtk_radio_button_new_with_label_from_widget(group, name);
-		group = GTK_RADIO_BUTTON(button);
-		gtk_box_pack_start(GTK_BOX(box), button, TRUE, TRUE, 0);
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), enabled);
-		g_signal_connect(button, "toggled", G_CALLBACK(callback_fn), NULL);
-	}
-	va_end(args);
-}
-
-#define UNITCALLBACK(name, type, value)				\
-static void name(GtkWidget *w, gpointer data) 			\
-{								\
-	if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w)))	\
-		menu_units.type = value;			\
-}
-
-static struct units menu_units;
-
-UNITCALLBACK(set_meter, length, METERS)
-UNITCALLBACK(set_feet, length, FEET)
-UNITCALLBACK(set_bar, pressure, BAR)
-UNITCALLBACK(set_psi, pressure, PSI)
-UNITCALLBACK(set_liter, volume, LITER)
-UNITCALLBACK(set_cuft, volume, CUFT)
-UNITCALLBACK(set_celsius, temperature, CELSIUS)
-UNITCALLBACK(set_fahrenheit, temperature, FAHRENHEIT)
-
-static void unit_dialog(GtkWidget *w, gpointer data)
-{
-	int result;
-	GtkWidget *dialog;
-
-	menu_units = output_units;
-
-	dialog = gtk_dialog_new_with_buttons("Units",
-		GTK_WINDOW(main_window),
-		GTK_DIALOG_DESTROY_WITH_PARENT,
-		GTK_STOCK_OK, GTK_RESPONSE_ACCEPT,
-		GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
-		NULL);
-
-	create_radio(dialog, "Depth:",
-		"Meter", set_meter, (output_units.length == METERS),
-		"Feet",  set_feet, (output_units.length == FEET),
-		NULL);
-
-	create_radio(dialog, "Pressure:",
-		"Bar", set_bar, (output_units.pressure == BAR),
-		"PSI",  set_psi, (output_units.pressure == PSI),
-		NULL);
-
-	create_radio(dialog, "Volume:",
-		"Liter",  set_liter, (output_units.volume == LITER),
-		"CuFt", set_cuft, (output_units.volume == CUFT),
-		NULL);
-
-	create_radio(dialog, "Temperature:",
-		"Celsius", set_celsius, (output_units.temperature == CELSIUS),
-		"Fahrenheit",  set_fahrenheit, (output_units.temperature == FAHRENHEIT),
-		NULL);
-
-	gtk_widget_show_all(dialog);
-	result = gtk_dialog_run(GTK_DIALOG(dialog));
-	if (result == GTK_RESPONSE_ACCEPT) {
-		/* Make sure to flush any modified old dive data with old units */
-		update_dive(NULL);
-		output_units = menu_units;
-		update_dive_list_units(&dive_list);
-		repaint_dive();
-		gconf_client_set_bool(gconf, GCONF_NAME(feet), output_units.length == FEET, NULL);
-		gconf_client_set_bool(gconf, GCONF_NAME(psi), output_units.pressure == PSI, NULL);
-		gconf_client_set_bool(gconf, GCONF_NAME(cuft), output_units.volume == CUFT, NULL);
-		gconf_client_set_bool(gconf, GCONF_NAME(fahrenheit), output_units.temperature == FAHRENHEIT, NULL);
-	}
-	gtk_widget_destroy(dialog);
-}
-
-static void renumber_dives(int nr)
+void renumber_dives(int nr)
 {
 	int i;
 
@@ -335,103 +100,14 @@ static void renumber_dives(int nr)
 	}
 }
 
-static void renumber_dialog(GtkWidget *w, gpointer data)
-{
-	int result;
-	GtkWidget *dialog, *frame, *button;
-
-	dialog = gtk_dialog_new_with_buttons("Renumber",
-		GTK_WINDOW(main_window),
-		GTK_DIALOG_DESTROY_WITH_PARENT,
-		GTK_STOCK_OK, GTK_RESPONSE_ACCEPT,
-		GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
-		NULL);
-
-	frame = gtk_frame_new("New starting number");
-	gtk_container_add(GTK_CONTAINER(GTK_DIALOG(dialog)->vbox), frame);
-
-	button = gtk_spin_button_new_with_range(1, 50000, 1);
-	gtk_container_add(GTK_CONTAINER(frame), button);
-
-	gtk_widget_show_all(dialog);
-	result = gtk_dialog_run(GTK_DIALOG(dialog));
-	if (result == GTK_RESPONSE_ACCEPT) {
-		int nr = gtk_spin_button_get_value(GTK_SPIN_BUTTON(button));
-		renumber_dives(nr);
-		repaint_dive();
-	}
-	gtk_widget_destroy(dialog);
-}
-
-static GtkActionEntry menu_items[] = {
-	{ "FileMenuAction", GTK_STOCK_FILE, "Log", NULL, NULL, NULL},
-	{ "OpenFile",       GTK_STOCK_OPEN, NULL,   "<control>O", NULL, G_CALLBACK(file_open) },
-	{ "SaveFile",       GTK_STOCK_SAVE, NULL,   "<control>S", NULL, G_CALLBACK(file_save) },
-	{ "Print",          GTK_STOCK_PRINT, NULL,  "<control>P", NULL, G_CALLBACK(do_print) },
-	{ "Import",         NULL, "Import", NULL, NULL, G_CALLBACK(import_dialog) },
-	{ "Units",          NULL, "Units",    NULL, NULL, G_CALLBACK(unit_dialog) },
-	{ "Renumber",       NULL, "Renumber", NULL, NULL, G_CALLBACK(renumber_dialog) },
-	{ "Quit",           GTK_STOCK_QUIT, NULL,   "<control>Q", NULL, G_CALLBACK(quit) },
-};
-static gint nmenu_items = sizeof (menu_items) / sizeof (menu_items[0]);
-
-static const gchar* ui_string = " \
-	<ui> \
-		<menubar name=\"MainMenu\"> \
-			<menu name=\"FileMenu\" action=\"FileMenuAction\"> \
-				<menuitem name=\"Open\" action=\"OpenFile\" /> \
-				<menuitem name=\"Save\" action=\"SaveFile\" /> \
-				<menuitem name=\"Print\" action=\"Print\" /> \
-				<separator name=\"Separator1\"/> \
-				<menuitem name=\"Import\" action=\"Import\" /> \
-				<separator name=\"Separator2\"/> \
-				<menuitem name=\"Units\" action=\"Units\" /> \
-				<menuitem name=\"Renumber\" action=\"Renumber\" /> \
-				<separator name=\"Separator3\"/> \
-				<menuitem name=\"Quit\" action=\"Quit\" /> \
-			</menu> \
-		</menubar> \
-	</ui> \
-";
-
-static GtkWidget *get_menubar_menu(GtkWidget *window)
-{
-	GtkActionGroup *action_group = gtk_action_group_new("Menu");
-	gtk_action_group_add_actions(action_group, menu_items, nmenu_items, 0);
-
-	GtkUIManager *ui_manager = gtk_ui_manager_new();
-	gtk_ui_manager_insert_action_group(ui_manager, action_group, 0);
-	GError* error = 0;
-	gtk_ui_manager_add_ui_from_string(GTK_UI_MANAGER(ui_manager), ui_string, -1, &error);
-
-	gtk_window_add_accel_group(GTK_WINDOW(window), gtk_ui_manager_get_accel_group(ui_manager));
-	GtkWidget* menu = gtk_ui_manager_get_widget(ui_manager, "/MainMenu");
-
-	return menu;
-}
-
-static void switch_page(GtkNotebook *notebook, gint arg1, gpointer user_data)
-{
-	repaint_dive();
-}
-
 int main(int argc, char **argv)
 {
 	int i;
-	GtkWidget *win;
-	GtkWidget *paned;
-	GtkWidget *info_box;
-	GtkWidget *notebook;
-	GtkWidget *frame;
-	GtkWidget *dive_info;
-	GtkWidget *equipment;
-	GtkWidget *menubar;
-	GtkWidget *vbox;
 
 	output_units = SI_units;
 	parse_xml_init();
 
-	gtk_init(&argc, &argv);
+	init_ui(argc, argv);
 
 	g_type_init();
 	gconf = gconf_client_get_default();
@@ -444,54 +120,6 @@ int main(int argc, char **argv)
 		output_units.volume = CUFT;
 	if (gconf_client_get_bool(gconf, GCONF_NAME(fahrenheit), NULL))
 		output_units.temperature = FAHRENHEIT;
-
-	error_info_bar = NULL;
-	win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-	g_signal_connect(G_OBJECT(win), "destroy", G_CALLBACK(on_destroy), NULL);
-	main_window = win;
-
-	vbox = gtk_vbox_new(FALSE, 0);
-	gtk_container_add(GTK_CONTAINER(win), vbox);
-	main_vbox = vbox;
-
-	menubar = get_menubar_menu(win);
-	gtk_box_pack_start(GTK_BOX(vbox), menubar, FALSE, FALSE, 0);
-
-	/* HPane for left the dive list, and right the dive info */
-	paned = gtk_hpaned_new();
-	gtk_box_pack_end(GTK_BOX(vbox), paned, TRUE, TRUE, 0);
-
-	/* Create the actual divelist */
-	dive_list = dive_list_create();
-	gtk_paned_add1(GTK_PANED(paned), dive_list.container_widget);
-
-	/* VBox for dive info, and tabs */
-	info_box = gtk_vbox_new(FALSE, 6);
-	gtk_paned_add2(GTK_PANED(paned), info_box);
-
-	/* Frame for minimal dive info */
-	frame = dive_info_frame();
-	gtk_box_pack_start(GTK_BOX(info_box), frame, FALSE, TRUE, 6);
-
-	/* Notebook for dive info vs profile vs .. */
-	notebook = gtk_notebook_new();
-	g_signal_connect(notebook, "switch-page", G_CALLBACK(switch_page), NULL);
-	gtk_box_pack_start(GTK_BOX(info_box), notebook, TRUE, TRUE, 6);
-
-	/* Frame for dive profile */
-	dive_profile = dive_profile_widget();
-	gtk_notebook_append_page(GTK_NOTEBOOK(notebook), dive_profile, gtk_label_new("Dive Profile"));
-
-	/* Frame for extended dive info */
-	dive_info = extended_dive_info_widget();
-	gtk_notebook_append_page(GTK_NOTEBOOK(notebook), dive_info, gtk_label_new("Dive Notes"));
-
-	/* Frame for dive equipment */
-	equipment = equipment_widget();
-	gtk_notebook_append_page(GTK_NOTEBOOK(notebook), equipment, gtk_label_new("Equipment"));
-
-	gtk_widget_set_app_paintable(win, TRUE);
-	gtk_widget_show_all(win);
 	
 	for (i = 1; i < argc; i++) {
 		const char *a = argv[i];
@@ -512,8 +140,8 @@ int main(int argc, char **argv)
 	}
 
 	report_dives();
-	dive_list_update_dives(dive_list);
+	dive_list_update_dives();
 
-	gtk_main();
+	run_ui();
 	return 0;
 }

--- a/print.c
+++ b/print.c
@@ -2,6 +2,7 @@
 
 #include "dive.h"
 #include "display.h"
+#include "display-gtk.h"
 
 static void draw_page(GtkPrintOperation *operation,
 			GtkPrintContext *context,

--- a/profile.c
+++ b/profile.c
@@ -1,3 +1,7 @@
+/* profile.c */
+/* creates all the necessary data for drawing the dive profile 
+ * uses cairo to draw it
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/profile.c
+++ b/profile.c
@@ -72,7 +72,7 @@ static void set_source_rgba(struct graphics_context *gc, double r, double g, dou
 	cairo_set_source_rgba(gc->cr, r, g, b, a);
 }
 
-static void set_source_rgb(struct graphics_context *gc, double r, double g, double b)
+void set_source_rgb(struct graphics_context *gc, double r, double g, double b)
 {
 	set_source_rgba(gc, r, g, b, 1);
 }
@@ -740,36 +740,4 @@ void plot(struct graphics_context *gc, int w, int h, struct dive *dive)
 	cairo_close_path(gc->cr);
 	cairo_stroke(gc->cr);
 
-}
-
-static gboolean expose_event(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{
-	struct dive *dive = current_dive;
-	struct graphics_context gc = { .printer = 0 };
-	int w,h;
-
-	w = widget->allocation.width;
-	h = widget->allocation.height;
-
-	gc.cr = gdk_cairo_create(widget->window);
-	set_source_rgb(&gc, 0, 0, 0);
-	cairo_paint(gc.cr);
-
-	if (dive)
-		plot(&gc, w, h, dive);
-
-	cairo_destroy(gc.cr);
-
-	return FALSE;
-}
-
-GtkWidget *dive_profile_widget(void)
-{
-	GtkWidget *da;
-
-	da = gtk_drawing_area_new();
-	gtk_widget_set_size_request(da, 350, 250);
-	g_signal_connect(da, "expose_event", G_CALLBACK(expose_event), NULL);
-
-	return da;
 }

--- a/uemis.c
+++ b/uemis.c
@@ -16,10 +16,7 @@
 #include <time.h>
 #include <regex.h>
 
-#include <gtk/gtk.h>
-
 #include "dive.h"
-#include "display.h"
 #include "uemis.h"
 
 /*
@@ -214,8 +211,11 @@ static void parse_divelog_binary(char *base64, struct dive **divep) {
 	return;
 }
 
+/* parse a single file
+ * TODO: we don't report any errors when the parse fails - we simply don't add them to the list
+ */
 void
-parse_uemis_file(char *divelogfilename,GError **error) {
+parse_uemis_file(char *divelogfilename) {
 	char *found=NULL;
 	struct tm tm;
 	struct dive *dive;
@@ -261,40 +261,7 @@ bail:
  */
 void
 uemis_import() {
-	GtkWidget *dialog;
-	GtkFileFilter *filter = gtk_file_filter_new ();
-	gtk_file_filter_add_pattern (filter, "*.SDA");
-	gtk_file_filter_set_name(filter, "uemis Zurich SDA files");
-	dialog = gtk_file_chooser_dialog_new("Open File",
-					GTK_WINDOW(main_window),
-					GTK_FILE_CHOOSER_ACTION_OPEN,
-					GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-					GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
-					NULL);
-	gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(dialog), TRUE);
-	gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog),filter);
-
-	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-		GSList *filenames;
-		char *filename;
-		filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog));
-
-		GError *error = NULL;
-		while(filenames != NULL) {
-			filename = (char *)filenames->data;
-			parse_uemis_file(filename, &error);
-			if (error != NULL)
-			{
-				report_error(error);
-				g_error_free(error);
-				error = NULL;
-			}
-
-			g_free(filename);
-			filenames = g_slist_next(filenames);
-		}
-		g_slist_free(filenames);
+	if (open_import_file_dialog("*.SDA","uemis Zurich SDA files",
+					&parse_uemis_file))
 		report_dives();
-	}
-	gtk_widget_destroy(dialog);
-}
+}	

--- a/uemis.h
+++ b/uemis.h
@@ -10,6 +10,4 @@
 
 void uemis_import();
 
-extern GtkWidget *main_window;
-
 #endif /* DIVE_H */


### PR DESCRIPTION
Trying to find the balance of how much I want to abstract out the UI
There is some of the logic still hidden in the five files that are considered the UI implementation:
gtk-gui.c - overall layout, main window of the UI
divelist.c  - list of dives subsurface maintains
equipment.c - equipment / tank information for each dive
info.c      - detailed dive info 
print.c     - printing 
it's mainly small things that seem almost silly to pull out - but I'll be happy to revisit that if you want.
The rest is now basically gtk independent
main.c - program frame
dive.c - creates and maintaines the internal dive list structure
libdivecomputer.c 
uemis.c 
parse-xml.c 
save-xml.c - interface with dive computers and the XML files 
profile.c - creates the data for the profile and draws it using cairo

libdivecomputer is the exception as I haven't really done the double blind separation of the progress bar.
