### PR TITLE
Simplistic first attempt to get changes saved when quitting subsurface

### DIFF
--- a/dive.h
+++ b/dive.h
@@ -195,6 +195,7 @@ static inline struct dive *get_dive(unsigned int nr)
 
 extern void parse_xml_init(void);
 extern void parse_xml_file(const char *filename, GError **error);
+extern void set_filename(const char *filename);
 
 extern void show_dive_info(struct dive *);
 extern void flush_dive_info_changes(struct dive *);

--- a/divelist.c
+++ b/divelist.c
@@ -7,6 +7,8 @@
  * void dive_list_update_dives(void)
  * void update_dive_list_units(void)
  * void set_divelist_font(const char *font)
+ * void mark_divelist_changed(int changed)
+ * int unsaved_changes()
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,6 +26,7 @@ struct DiveList {
 	GtkListStore *model;
 	GtkTreeViewColumn *date, *depth, *duration, *location;
 	GtkTreeViewColumn *temperature, *cylinder, *nitrox, *sac;
+	int changed;
 };
 
 static struct DiveList dive_list;
@@ -44,9 +47,6 @@ enum {
 	DIVE_SAC,		/* int: in ml/min */
 	DIVELIST_COLUMNS
 };
-
-/* the global dive list that we maintain */
-static struct DiveList dive_list;
 
 static void selection_cb(GtkTreeSelection *selection, GtkTreeModel *model)
 {
@@ -492,5 +492,17 @@ GtkWidget *dive_list_create(void)
 			       GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 	gtk_container_add(GTK_CONTAINER(dive_list.container_widget), dive_list.tree_view);
 
+	dive_list.changed = 0;
+
 	return dive_list.container_widget;
+}
+
+void mark_divelist_changed(int changed)
+{
+	dive_list.changed = changed;
+}
+
+int unsaved_changes()
+{
+	return dive_list.changed;
 }

--- a/divelist.h
+++ b/divelist.h
@@ -7,4 +7,6 @@ extern void dive_list_update_dives(void);
 extern void update_dive_list_units(void);
 extern void flush_divelist(struct dive *);
 
+extern void mark_divelist_changed(int);
+extern int unsaved_changes(void);
 #endif

--- a/equipment.c
+++ b/equipment.c
@@ -249,6 +249,7 @@ static void apply_cb(GtkButton *button, gpointer data)
 
 	for (i = 0; i < MAX_CYLINDERS; i++)
 		record_cylinder_changes(dive->cylinder+i, gtk_cylinder+i);
+	mark_divelist_changed(TRUE);
 	flush_divelist(dive);
 }
 

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -632,3 +632,11 @@ void update_progressbar(progressbar_t *progress, double value)
 {
 	gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(progress->bar), value);
 }
+
+
+void set_filename(const char *filename)
+{
+	if (filename)
+		existing_filename = strdup(filename);
+	return;
+}

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -148,13 +148,17 @@ static void file_save(GtkWidget *w, gpointer data)
 
 static void ask_save_changes()
 {
-	GtkWidget *dialog;
+	GtkWidget *dialog, *label, *content;
 	dialog = gtk_dialog_new_with_buttons("Save Changes?",
 		GTK_WINDOW(main_window), GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
 		GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
 		GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
 		NULL);
-
+	content = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
+	label = gtk_label_new ("You have unsaved changes\nWould you like to save those before exiting the program?");
+	gtk_container_add (GTK_CONTAINER (content), label);
+	gtk_widget_show_all (dialog);
+	gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
 	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 		file_save(NULL,NULL);
 	}
@@ -173,6 +177,11 @@ void on_destroy(GtkWidget* w, gpointer data)
 
 static void quit(GtkWidget *w, gpointer data)
 {
+	/* Make sure to flush any modified dive data */
+	update_dive(NULL);
+
+	if (unsaved_changes())
+		ask_save_changes();
 	gtk_main_quit();
 }
 

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -141,7 +141,7 @@ static void file_save(GtkWidget *w, gpointer data)
 		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
 		save_dives(filename);
 		g_free(filename);
-		mark_divelist_changed(TRUE);
+		mark_divelist_changed(FALSE);
 	}
 	gtk_widget_destroy(dialog);
 }
@@ -165,13 +165,19 @@ static void ask_save_changes()
 	gtk_widget_destroy(dialog);
 }
 
-void on_destroy(GtkWidget* w, gpointer data)
+static gboolean on_delete(GtkWidget* w, gpointer data)
 {
 	/* Make sure to flush any modified dive data */
 	update_dive(NULL);
 
 	if (unsaved_changes())
 		ask_save_changes();
+
+	return FALSE; /* go ahead, kill the program, we're good now */
+}
+
+static void on_destroy(GtkWidget* w, gpointer data)
+{
 	gtk_main_quit();
 }
 
@@ -417,6 +423,7 @@ void init_ui(int argc, char **argv)
 	error_info_bar = NULL;
 	win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
 	gtk_window_set_icon_from_file(GTK_WINDOW(win), "icon.svg", NULL);
+	g_signal_connect(G_OBJECT(win), "delete-event", G_CALLBACK (on_delete), NULL);
 	g_signal_connect(G_OBJECT(win), "destroy", G_CALLBACK(on_destroy), NULL);
 	main_window = win;
 

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -163,6 +163,9 @@ static void ask_save_changes()
 
 void on_destroy(GtkWidget* w, gpointer data)
 {
+	/* Make sure to flush any modified dive data */
+	update_dive(NULL);
+
 	if (unsaved_changes())
 		ask_save_changes();
 	gtk_main_quit();

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -31,11 +31,6 @@ struct units output_units;
 
 #define GCONF_NAME(x) "/apps/subsurface/" #x
 
-void on_destroy(GtkWidget* w, gpointer data)
-{
-	gtk_main_quit();
-}
-
 static GtkWidget *dive_profile;
 
 void repaint_dive(void)
@@ -146,8 +141,31 @@ static void file_save(GtkWidget *w, gpointer data)
 		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
 		save_dives(filename);
 		g_free(filename);
+		mark_divelist_changed(TRUE);
 	}
 	gtk_widget_destroy(dialog);
+}
+
+static void ask_save_changes()
+{
+	GtkWidget *dialog;
+	dialog = gtk_dialog_new_with_buttons("Save Changes?",
+		GTK_WINDOW(main_window), GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+		GTK_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
+		GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+		NULL);
+
+	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
+		file_save(NULL,NULL);
+	}
+	gtk_widget_destroy(dialog);
+}
+
+void on_destroy(GtkWidget* w, gpointer data)
+{
+	if (unsaved_changes())
+		ask_save_changes();
+	gtk_main_quit();
 }
 
 static void quit(GtkWidget *w, gpointer data)

--- a/info.c
+++ b/info.c
@@ -33,30 +33,59 @@ static char *get_text(GtkTextBuffer *buffer)
 	return gtk_text_buffer_get_text(buffer, &start, &end, FALSE);
 }
 
+/* old is NULL or a valid string, new is a valid string
+ * NOTW: NULL and "" need to be treated as "unchanged" */
+static int text_changed(char *old, char *new)
+{
+	return ((old && strcmp(old,new)) ||
+		(!old && strcmp("",new)));
+}
+
 void flush_dive_info_changes(struct dive *dive)
 {
+	char *old_text;
+	int changed = 0;
+
 	if (!dive)
 		return;
 
 	if (location_changed) {
-		g_free(dive->location);
+		old_text = dive->location;
 		dive->location = gtk_editable_get_chars(GTK_EDITABLE(location), 0, -1);
+		if (text_changed(old_text,dive->location))
+			changed = 1;
+		if (old_text)
+			g_free(old_text);
 	}
 
 	if (divemaster_changed) {
-		g_free(dive->divemaster);
+		old_text = dive->divemaster;
 		dive->divemaster = gtk_editable_get_chars(GTK_EDITABLE(divemaster), 0, -1);
+		if (text_changed(old_text,dive->divemaster))
+			changed = 1;
+		if (old_text)
+			g_free(old_text);
 	}
 
 	if (buddy_changed) {
-		g_free(dive->buddy);
+		old_text = dive->buddy;
 		dive->buddy = gtk_editable_get_chars(GTK_EDITABLE(buddy), 0, -1);
+		if (text_changed(old_text,dive->buddy))
+			changed = 1;
+		if (old_text)
+			g_free(old_text);
 	}
 
 	if (notes_changed) {
-		g_free(dive->notes);
+		old_text = dive->notes;
 		dive->notes = get_text(notes);
+		if (text_changed(old_text,dive->notes))
+			changed = 1;
+		if (old_text)
+			g_free(old_text);
 	}
+	if (changed)
+		mark_divelist_changed(TRUE);
 }
 
 #define SET_TEXT_ENTRY(x) \

--- a/parse-xml.c
+++ b/parse-xml.c
@@ -1380,7 +1380,9 @@ void parse_xml_file(const char *filename, GError **error)
 		}
 		return;
 	}
-
+	/* we assume that the last (or only) filename passed as argument is a 
+	 * great filename to use as default when saving the dives */ 
+	set_filename(filename);
 	reset_all();
 	dive_start();
 	traverse(xmlDocGetRootElement(doc));

--- a/print.c
+++ b/print.c
@@ -58,14 +58,28 @@ static void show_dive_text(struct dive *dive, cairo_t *cr, double w, double h, P
 	 * with the depth/duration information. Need to mask that or
 	 * create a box or something.
 	 */
-	snprintf(buffer, sizeof(buffer),
-		"<span size=\"small\">"
-		"Max depth: %d ft\n"
-		"Duration: %d:%02d"
-		"</span>",
-		to_feet(dive->maxdepth),
-		dive->duration.seconds / 60,
-		dive->duration.seconds % 60);
+	switch (output_units.length) {
+	case FEET:
+		snprintf(buffer, sizeof(buffer),
+			"<span size=\"small\">"
+			"Max depth: %d ft\n"
+			"Duration: %d:%02d min"
+			"</span>",
+			to_feet(dive->maxdepth),
+			dive->duration.seconds / 60,
+			dive->duration.seconds % 60);
+		break;
+	case METERS:
+		snprintf(buffer, sizeof(buffer),
+			"<span size=\"small\">"
+			"Max depth: %3.1f m\n"
+			"Duration: %d:%02d min"
+			"</span>",
+			dive->maxdepth.mm / 1000.0,
+			dive->duration.seconds / 60,
+			dive->duration.seconds % 60);
+		break;
+	}
 
 	pango_layout_set_alignment(layout, PANGO_ALIGN_RIGHT);
 	pango_layout_set_markup(layout, buffer, -1);


### PR DESCRIPTION
Track whether things changed in the global dive_list

So far this actually works if changing dive info (but only if dive
selected was changed after the dive info was changed).

We are not tracking changes to the cylinder information, yet.

also remove the duplicate static dive_list

Signed-off-by: Dirk Hohndel dirk@hohndel.org
