### PR TITLE
Clean up the drag and drop code and allow ripping off the Dive Profile

### DIFF
--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -524,9 +524,9 @@ static void drag_cb(GtkWidget *widget, GdkDragContext *context,
 	 * this all to figure out which window we're talking about.
 	 */
 	source = gtk_drag_get_source_widget(context);
-	if (! strcmp(nbd[0].name,gtk_widget_get_name(source)))
+	if (nbd[0].name && ! strcmp(nbd[0].name,gtk_widget_get_name(source)))
 		nbdp = nbd;
-	else if (! strcmp(nbd[1].name,gtk_widget_get_name(source)))
+	else if (nbd[1].name && ! strcmp(nbd[1].name,gtk_widget_get_name(source)))
 		nbdp = nbd + 1;
 	else
 		/* HU? */
@@ -601,7 +601,7 @@ void init_ui(int argc, char **argv)
 	gtk_notebook_set_group_name(GTK_NOTEBOOK(notebook), notebook_name);
 	g_signal_connect(notebook, "create-window", G_CALLBACK(create_new_notebook_window), NULL);
 	gtk_drag_dest_set(notebook, GTK_DEST_DEFAULT_ALL, &notebook_target, 1, GDK_ACTION_MOVE);
-	g_signal_connect(notebook, "drag-data-received", G_CALLBACK(drag_cb), notebook);
+	g_signal_connect(notebook, "drag-drop", G_CALLBACK(drag_cb), notebook);
 	g_signal_connect(notebook, "switch-page", G_CALLBACK(switch_page), NULL);
 
 	/* Create the actual divelist */


### PR DESCRIPTION
Linus had used some deprecated interfcase and didn't correctly untangle
the new window that he created (hiding it the window... very nifty).

I think I'm closer to the real solution with a data structure that keeps
track of the components of the new top level window that I need to be able
to untangle (and eventually, destroy) at the end.

The one error I also can't seem to get rid of is the
Clean up the drag and drop code and allow ripping of the Dive Profile

Gtk-CRITICAL **: IA__gtk_selection_data_set: assertion `length <= 0' failed

Signed-off-by: Dirk Hohndel dirk@hohndel.org
