### PR TITLE
Some minor uemis improvements

### DIFF
--- a/dive.h
+++ b/dive.h
@@ -263,7 +263,7 @@ extern void dive_list_update_dives(void);
 extern void flush_divelist(struct dive *dive);
 
 extern int open_import_file_dialog(char *filterpattern, char *filtertext, 
-				void(* parse_function)(char *));
+				void(* parse_function)(const char *, GError **));
 #define DIVE_ERROR_PARSE 1
 
 const char *weekday(int wday);

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -637,7 +637,7 @@ void run_ui(void)
  * return 0 if the user cancelled the dialog
  */
 int open_import_file_dialog(char *filterpattern, char *filtertext, 
-			void(* parse_function)(char *))
+			void(* parse_function)(const char *, GError **))
 {
 	int ret=0;
 
@@ -659,8 +659,14 @@ int open_import_file_dialog(char *filterpattern, char *filtertext,
 		char *filename;
 		filenames = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog));
 		while(filenames != NULL) {
+			GError *error = NULL;
 			filename = (char *)filenames->data;
-			parse_function(filename);
+			parse_function(filename, &error);
+			if (error != NULL)
+			{
+				report_error(error);
+				g_error_free(error);
+			}
 			g_free(filename);
 			filenames = g_slist_next(filenames);
 		}

--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
 #include <gconf/gconf-client.h>
 
 #include "dive.h"
+#include "uemis.h"
 #include "divelist.h"
 
 GConfClient *gconf;
@@ -139,8 +140,11 @@ int main(int argc, char **argv)
 			continue;
 		}
 		GError *error = NULL;
-		parse_xml_file(a, &error);
-		
+		if (strstr(a,".SDA"))
+			parse_uemis_file(a, &error);
+		else
+			parse_xml_file(a, &error);
+
 		if (error != NULL)
 		{
 			report_error(error);

--- a/main.c
+++ b/main.c
@@ -124,7 +124,7 @@ void renumber_dives(int nr)
 
 int main(int argc, char **argv)
 {
-	int i;
+	int i, len;
 
 	output_units = SI_units;
 
@@ -140,7 +140,8 @@ int main(int argc, char **argv)
 			continue;
 		}
 		GError *error = NULL;
-		if (strstr(a,".SDA"))
+		len = strlen(a);
+		if (len > 4 && strstr(a+len-4,".SDA"))
 			parse_uemis_file(a, &error);
 		else
 			parse_xml_file(a, &error);

--- a/uemis.h
+++ b/uemis.h
@@ -9,5 +9,6 @@
 #define DEVICE_TYPE_UEMIS (-1)
 
 void uemis_import();
+void parse_uemis_file(const char *divelogfilename, GError **error);
 
 #endif /* DIVE_H */


### PR DESCRIPTION
Allow passing SDA files on the command line, just like xml files.

Basic error handling in the uemis parser (don't just fail quietly).

Initial support for uemis events (I picked the Marker as first one, many
more to follow).

Small bugfixes.

Signed-off-by: Dirk Hohndel dirk@hohndel.org
