### PR TITLE
Events

### DIFF
--- a/display.h
+++ b/display.h
@@ -24,5 +24,6 @@ struct graphics_context {
 
 extern void plot(struct graphics_context *gc, cairo_rectangle_int_t *drawing_area, struct dive *dive);
 extern void set_source_rgb(struct graphics_context *gc, double r, double g, double b);
+extern void attach_tooltip(int x, int y, int w, int h, const char *text);
 
 #endif

--- a/display.h
+++ b/display.h
@@ -22,7 +22,7 @@ struct graphics_context {
 	double topy, bottomy;
 };
 
-extern void plot(struct graphics_context *gc, int w, int h, struct dive *dive);
+extern void plot(struct graphics_context *gc, cairo_rectangle_int_t *drawing_area, struct dive *dive);
 extern void set_source_rgb(struct graphics_context *gc, double r, double g, double b);
 
 #endif

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -674,18 +674,21 @@ static gboolean expose_event(GtkWidget *widget, GdkEventExpose *event, gpointer 
 {
 	struct dive *dive = current_dive;
 	struct graphics_context gc = { .printer = 0 };
-	int w,h;
+	static cairo_rectangle_int_t drawing_area;
 
-	w = widget->allocation.width;
-	h = widget->allocation.height;
+	/* the drawing area gives TOTAL width * height - x,y is used as the topx/topy offset
+	 * so effective drawing area is width-2x * height-2y */
+	drawing_area.width = widget->allocation.width;
+	drawing_area.height = widget->allocation.height;
+	drawing_area.x = drawing_area.width / 20.0;
+	drawing_area.y = drawing_area.height / 20.0;
 
 	gc.cr = gdk_cairo_create(widget->window);
 	set_source_rgb(&gc, 0, 0, 0);
 	cairo_paint(gc.cr);
 
 	if (dive)
-		plot(&gc, w, h, dive);
-
+		plot(&gc, &drawing_area, dive);
 	cairo_destroy(gc.cr);
 
 	return FALSE;

--- a/print.c
+++ b/print.c
@@ -127,12 +127,13 @@ static void show_dive_text(struct dive *dive, cairo_t *cr, double w, double h, P
 
 static void show_dive_profile(struct dive *dive, cairo_t *cr, double w, double h)
 {
+	cairo_rectangle_int_t drawing_area = { w/20.0, h/20.0, w, h};
 	struct graphics_context gc = {
 		.printer = 1,
 		.cr = cr
 	};
 	cairo_save(cr);
-	plot(&gc, w, h, dive);
+	plot(&gc, &drawing_area, dive);
 	cairo_restore(cr);
 }
 

--- a/profile.c
+++ b/profile.c
@@ -160,6 +160,7 @@ static void plot_text(struct graphics_context *gc, const text_render_options_t *
 static void plot_one_event(struct graphics_context *gc, struct plot_info *pi, struct event *event, const text_render_options_t *tro)
 {
 	int i, depth = 0;
+	int x,y;
 
 	for (i = 0; i < pi->nr; i++) {
 		struct plot_data *data = pi->entry + i;
@@ -167,7 +168,17 @@ static void plot_one_event(struct graphics_context *gc, struct plot_info *pi, st
 			break;
 		depth = data->val;
 	}
-	plot_text(gc, tro, event->time.seconds, depth, "%s", event->name);
+	/* draw a little tirangular marker and attach tooltip */
+	x = SCALEX(gc, event->time.seconds);
+	y = SCALEY(gc, depth);
+	set_source_rgba(gc, 1.0, 0.1, 0.1, 0.5);
+	cairo_move_to(gc->cr, x-6, y-3);
+	cairo_line_to(gc->cr, x  , y-3);
+	cairo_line_to(gc->cr, x-3, y+3);
+	cairo_line_to(gc->cr, x-6, y-3);
+	cairo_stroke_preserve(gc->cr);
+	cairo_fill(gc->cr);
+	attach_tooltip(x-6, y-3, 6, 6, event->name);
 }
 
 static void plot_events(struct graphics_context *gc, struct plot_info *pi, struct dive *dive)

--- a/profile.c
+++ b/profile.c
@@ -722,14 +722,11 @@ static struct plot_info *create_plot_info(struct dive *dive)
 	return analyze_plot_info(pi);
 }
 
-void plot(struct graphics_context *gc, int w, int h, struct dive *dive)
+void plot(struct graphics_context *gc, cairo_rectangle_int_t *drawing_area, struct dive *dive)
 {
-	double topx, topy;
 	struct plot_info *pi = create_plot_info(dive);
 
-	topx = w / 20.0;
-	topy = h / 20.0;
-	cairo_translate(gc->cr, topx, topy);
+	cairo_translate(gc->cr, drawing_area->x, drawing_area->y);
 	cairo_set_line_width(gc->cr, 2);
 	cairo_set_line_cap(gc->cr, CAIRO_LINE_CAP_ROUND);
 	cairo_set_line_join(gc->cr, CAIRO_LINE_JOIN_ROUND);
@@ -741,8 +738,8 @@ void plot(struct graphics_context *gc, int w, int h, struct dive *dive)
 	 *
 	 * Snif. What a pity.
 	 */
-	gc->maxx = (w - 2*topx);
-	gc->maxy = (h - 2*topy);
+	gc->maxx = (drawing_area->width - 2*drawing_area->x);
+	gc->maxy = (drawing_area->height - 2*drawing_area->y);
 
 	/* Temperature profile */
 	plot_temperature_profile(gc, pi);

--- a/uemis.c
+++ b/uemis.c
@@ -151,7 +151,7 @@ void uemis_event(struct dive *dive, struct sample *sample, uemis_sample_t *u_sam
 	if (flags[4] & 0x08)
 		add_event(dive, sample->time.seconds, 0, 0, 0, "RGT Alert");
 	if (flags[4] & 0x40)
-		add_event(dive, sample->time.seconds, 0, 0, 0, "Tank Change Suggest");
+		add_event(dive, sample->time.seconds, 0, 0, 0, "Tank Change Suggested");
 	if (flags[4] & 0x80)
 		add_event(dive, sample->time.seconds, 0, 0, 0, "Depth Limit Exceeded");
 	if (flags[5] & 0x01)


### PR DESCRIPTION
As promised, here's the code to replace the "text written into the profile plot" with cute (I hope) little markers and attached tooltips.
Those triangles can still get REALLY crowded, but since I don't scale them in size as the plot scales, it's easy to make the plot window bigger to be able to get to the individual event.
I was surprised that I couldn't find any routines to attach tooltips to a cairo canvas, but implementing them by hand wasn't /too/ hard.
