### PR TITLE
Make the dive merging code more tolerant

### DIFF
--- a/dive.c
+++ b/dive.c
@@ -410,7 +410,7 @@ struct dive *try_to_merge(struct dive *a, struct dive *b)
 	int i;
 	struct dive *res;
 
-	if (a->when != b->when)
+	if ((a->when >= b->when + 60) || (a->when <= b->when - 60))
 		return NULL;
 
 	res = alloc_dive();


### PR DESCRIPTION
Depending on the tool used to import a dive from the uemis Zurich we end
up with different time stamps for the dive - just by a few seconds, but
the existing code insisted on an exact match.

We now allow for up to 60 seconds in difference and still consider two
dives as the same.

Signed-off-by: Dirk Hohndel dirk@hohndel.org
