### PR TITLE
Mark divelist changed when renumbering or adding dives

### DIFF
--- a/main.c
+++ b/main.c
@@ -139,6 +139,9 @@ void report_dives(void)
 	if (last && last->number)
 		try_to_renumber(last, preexisting);
 
+	/* did we have dives in the table and added more? */
+	if (last && preexisting != dive_table.nr)
+		mark_divelist_changed(TRUE);
 	dive_table.preexisting = dive_table.nr;
 	dive_list_update_dives();
 }
@@ -184,6 +187,7 @@ void renumber_dives(int nr)
 		struct dive *dive = dive_table.dives[i];
 		dive->number = nr + i;
 	}
+	mark_divelist_changed(TRUE);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The behavior is not yet consistent when calling with multiple file names
on the command line (as we don't add number to the later ones in this
case), but at least it catches the case if you manually renumber the dives
or if you import new dives that get added at the end - which are the two
most typical cases.

Signed-off-by: Dirk Hohndel dirk@hohndel.org
