### PR TITLE
Add an '--import' command line option

### DIFF
--- a/main.c
+++ b/main.c
@@ -155,6 +155,15 @@ static void parse_argument(const char *arg)
 		case 'v':
 			verbose++;
 			continue;
+		case '-':
+			/* long options with -- */
+			if (strcmp(arg,"--import") == 0) {
+				/* mark the dives so far as the base,
+				 * everything after is imported */
+				report_dives();
+				return;
+			}
+			/* fallthrough */
 		default:
 			fprintf(stderr, "Bad argument '%s'\n", arg);
 			exit(1);


### PR DESCRIPTION
This option indicates that all files that come AFTER it on the command
line are being added to our divelist. The dives in these files should
receive numbers (assuming they are un-numbered and are all newer then the
dives in the files before the --import option, and assuming those dives
are numbered).

This also marks the dive_list changed after the new dives are added.

Using this option gives us a reasonable user experience in the case where
a user has one file with all their dives and wants to add newer dives
after this (after extracting them from a dive computer - as in the case of
a uemis owner where there is no direct import from the dive computer,
yet). Something like

subsurface MyDives.xml --import NewDives.SDA

It also doesn't break Linus' vision where the user has many files on the
command line which don't imply a changed dive_list.

Signed-off-by: Dirk Hohndel dirk@hohndel.org
