### PR TITLE
Import open cleanup

### DIFF
--- a/dive.h
+++ b/dive.h
@@ -243,7 +243,7 @@ extern void record_dive(struct dive *dive);
 extern struct sample *prepare_sample(struct dive **divep);
 extern void finish_sample(struct dive *dive, struct sample *sample);
 
-extern void report_dives(void);
+extern void report_dives(gboolean imported);
 extern struct dive *fixup_dive(struct dive *dive);
 extern struct dive *try_to_merge(struct dive *a, struct dive *b);
 

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -836,7 +836,15 @@ static GtkEntry *dive_computer_device(GtkWidget *vbox)
 	return GTK_ENTRY(entry);
 }
 
-static GtkWidget *xml_file_selector(GtkWidget *vbox)
+/* once a file is selected in the FileChooserButton we want to exit the import dialog */
+static void on_file_set(GtkFileChooserButton *widget, gpointer _data)
+{
+	GtkDialog *main_dialog = _data;
+
+	gtk_dialog_response(main_dialog, GTK_RESPONSE_ACCEPT);
+}
+
+static GtkWidget *xml_file_selector(GtkWidget *vbox, GtkWidget *main_dialog)
 {
 	GtkWidget *hbox, *frame, *chooser, *dialog;
 	GtkFileFilter *filter;
@@ -864,6 +872,8 @@ static GtkWidget *xml_file_selector(GtkWidget *vbox)
 	gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(dialog), filter);
 
 	chooser = gtk_file_chooser_button_new_with_dialog(dialog);
+	g_signal_connect(G_OBJECT(chooser), "file-set", G_CALLBACK(on_file_set), main_dialog);
+
 	gtk_file_chooser_button_set_width_chars(GTK_FILE_CHOOSER_BUTTON(chooser), 30);
 	gtk_container_add(GTK_CONTAINER(frame), chooser);
 
@@ -904,7 +914,7 @@ void import_dialog(GtkWidget *w, gpointer data)
 	vbox = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 	label = gtk_label_new("Import: \nLoad XML file or import directly from dive computer");
 	gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, TRUE, 3);
-	XMLchooser = xml_file_selector(vbox);
+	XMLchooser = xml_file_selector(vbox, dialog);
 	computer = dive_computer_selector(vbox);
 	device = dive_computer_device(vbox);
 	hbox = gtk_hbox_new(FALSE, 6);

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -852,7 +852,7 @@ static GtkWidget *xml_file_selector(GtkWidget *vbox)
 		GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
 		GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
 		NULL);
-	gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(dialog), TRUE);
+	gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(dialog), FALSE);
 
 	filter = gtk_file_filter_new();
 	gtk_file_filter_add_pattern(filter, "*.xml");

--- a/main.c
+++ b/main.c
@@ -155,6 +155,15 @@ static void parse_argument(const char *arg)
 		case 'v':
 			verbose++;
 			continue;
+		case '-':
+			/* long options with -- */
+			if (strcmp(arg,"--import") == 0) {
+				/* mark the dives so far as the base,
+				 * everything after is imported */
+				report_dives();
+				return;
+			}
+			/* fallthrough */
 		default:
 			fprintf(stderr, "Bad argument '%s'\n", arg);
 			exit(1);

--- a/main.c
+++ b/main.c
@@ -98,6 +98,11 @@ static void try_to_renumber(struct dive *last, int preexisting)
 }
 
 /*
+ * track whether we switched to importing dives
+ */
+static gboolean imported = FALSE;
+
+/*
  * This doesn't really report anything at all. We just sort the
  * dives, the GUI does the reporting
  */
@@ -162,7 +167,8 @@ static void parse_argument(const char *arg)
 			if (strcmp(arg,"--import") == 0) {
 				/* mark the dives so far as the base,
 				 * everything after is imported */
-				report_dives(TRUE);
+				report_dives(FALSE);
+				imported = TRUE;
 				return;
 			}
 			/* fallthrough */
@@ -229,7 +235,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	report_dives(FALSE);
+	report_dives(imported);
 
 	run_ui();
 	return 0;

--- a/main.c
+++ b/main.c
@@ -101,7 +101,7 @@ static void try_to_renumber(struct dive *last, int preexisting)
  * This doesn't really report anything at all. We just sort the
  * dives, the GUI does the reporting
  */
-void report_dives(void)
+void report_dives(gboolean imported)
 {
 	int i;
 	int preexisting = dive_table.preexisting;
@@ -135,13 +135,15 @@ void report_dives(void)
 		i--;
 	}
 
-	/* Was the previous dive table state numbered? */
-	if (last && last->number)
-		try_to_renumber(last, preexisting);
+	if (imported) {
+		/* Was the previous dive table state numbered? */
+		if (last && last->number)
+			try_to_renumber(last, preexisting);
 
-	/* did we have dives in the table and added more? */
-	if (last && preexisting != dive_table.nr)
-		mark_divelist_changed(TRUE);
+		/* did we have dives in the table and added more? */
+		if (last && preexisting != dive_table.nr)
+			mark_divelist_changed(TRUE);
+	}
 	dive_table.preexisting = dive_table.nr;
 	dive_list_update_dives();
 }
@@ -160,7 +162,7 @@ static void parse_argument(const char *arg)
 			if (strcmp(arg,"--import") == 0) {
 				/* mark the dives so far as the base,
 				 * everything after is imported */
-				report_dives();
+				report_dives(TRUE);
 				return;
 			}
 			/* fallthrough */
@@ -227,7 +229,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	report_dives();
+	report_dives(FALSE);
 
 	run_ui();
 	return 0;


### PR DESCRIPTION
Take a look at the import widget.
I really didn't like having XML file import be treated as if it was a different type of dive computer - that seemed wrong in so many ways. 
What I dislike about this is that you have to click OK twice. I'm looking if there's a way in gtk to avoid that...
But overall this should implement what we discussed.
And it's a nicely hand crafted branch that makes it look like two commits that logically are based upon each other, even though it didn't happen that way.
