### PR TITLE
Event filter

### DIFF
--- a/dive.c
+++ b/dive.c
@@ -26,6 +26,7 @@ void add_event(struct dive *dive, int time, int type, int flags, int value, cons
 	while (*p)
 		p = &(*p)->next;
 	*p = ev;
+	remember_event(name);
 }
 
 double get_depth_units(unsigned int mm, int *frac, const char **units)

--- a/dive.h
+++ b/dive.h
@@ -262,6 +262,7 @@ extern void report_error(GError* error);
 extern void add_cylinder_description(cylinder_type_t *);
 extern void add_people(const char *string);
 extern void add_location(const char *string);
+extern void remember_event(const char *eventname);
 
 extern void dive_list_update_dives(void);
 extern void flush_divelist(struct dive *dive);

--- a/dive.h
+++ b/dive.h
@@ -263,6 +263,7 @@ extern void add_cylinder_description(cylinder_type_t *);
 extern void add_people(const char *string);
 extern void add_location(const char *string);
 extern void remember_event(const char *eventname);
+extern void evn_foreach(void (*callback)(const char *, int *, void *), void *data);
 
 extern void dive_list_update_dives(void);
 extern void flush_divelist(struct dive *dive);

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -305,6 +305,13 @@ OPTIONCALLBACK(nitrox_toggle, visible_cols.nitrox)
 OPTIONCALLBACK(temperature_toggle, visible_cols.temperature)
 OPTIONCALLBACK(cylinder_toggle, visible_cols.cylinder)
 
+static void event_toggle(GtkWidget *w, gpointer _data)
+{
+	gboolean *plot_ev = _data;
+
+	*plot_ev = GTK_TOGGLE_BUTTON(w)->active;
+}
+
 static void preferences_dialog(GtkWidget *w, gpointer data)
 {
 	int result;
@@ -407,6 +414,45 @@ static void preferences_dialog(GtkWidget *w, gpointer data)
 	gtk_widget_destroy(dialog);
 }
 
+static void create_toggle(const char* label, int *on, void *_data)
+{
+	GtkWidget *button, *box = _data;
+
+	button = gtk_check_button_new_with_label(label);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), *on);
+	gtk_box_pack_start(GTK_BOX(box), button, FALSE, FALSE, 6);
+	g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(event_toggle), on);
+}
+
+static void selectevents_dialog(GtkWidget *w, gpointer data)
+{
+	int result;
+	GtkWidget *dialog, *frame, *vbox, *hbox;
+
+	dialog = gtk_dialog_new_with_buttons("SelectEvents",
+		GTK_WINDOW(main_window),
+		GTK_DIALOG_DESTROY_WITH_PARENT,
+		GTK_STOCK_OK, GTK_RESPONSE_ACCEPT,
+		GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
+		NULL);
+
+	frame = gtk_frame_new("Enable / Disable Events");
+	vbox = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
+	gtk_box_pack_start(GTK_BOX(vbox), frame, FALSE, FALSE, 5);
+
+	hbox = gtk_hbox_new(FALSE, 6);
+	gtk_container_add(GTK_CONTAINER(frame), hbox);
+
+	evn_foreach(&create_toggle, hbox);
+
+	gtk_widget_show_all(dialog);
+	result = gtk_dialog_run(GTK_DIALOG(dialog));
+	if (result == GTK_RESPONSE_ACCEPT) {
+		repaint_dive();
+	}
+	gtk_widget_destroy(dialog);
+}
+
 static void renumber_dialog(GtkWidget *w, gpointer data)
 {
 	int result;
@@ -475,6 +521,7 @@ static void about_dialog(GtkWidget *w, gpointer data)
 static GtkActionEntry menu_items[] = {
 	{ "FileMenuAction", GTK_STOCK_FILE, "File", NULL, NULL, NULL},
 	{ "LogMenuAction",  GTK_STOCK_FILE, "Log", NULL, NULL, NULL},
+	{ "FilterMenuAction",  GTK_STOCK_FILE, "Filter", NULL, NULL, NULL},
 	{ "HelpMenuAction", GTK_STOCK_HELP, "Help", NULL, NULL, NULL},
 	{ "OpenFile",       GTK_STOCK_OPEN, NULL,   "<control>O", NULL, G_CALLBACK(file_open) },
 	{ "SaveFile",       GTK_STOCK_SAVE, NULL,   "<control>S", NULL, G_CALLBACK(file_save) },
@@ -482,8 +529,9 @@ static GtkActionEntry menu_items[] = {
 	{ "Import",         NULL, "Import", NULL, NULL, G_CALLBACK(import_dialog) },
 	{ "Preferences",    NULL, "Preferences", NULL, NULL, G_CALLBACK(preferences_dialog) },
 	{ "Renumber",       NULL, "Renumber", NULL, NULL, G_CALLBACK(renumber_dialog) },
+	{ "SelectEvents",   NULL, "SelectEvents", NULL, NULL, G_CALLBACK(selectevents_dialog) },
 	{ "Quit",           GTK_STOCK_QUIT, NULL,   "<control>Q", NULL, G_CALLBACK(quit) },
-	{ "About",           GTK_STOCK_ABOUT, NULL,  NULL, NULL, G_CALLBACK(about_dialog) },
+	{ "About",          GTK_STOCK_ABOUT, NULL,  NULL, NULL, G_CALLBACK(about_dialog) },
 };
 static gint nmenu_items = sizeof (menu_items) / sizeof (menu_items[0]);
 
@@ -503,6 +551,9 @@ static const gchar* ui_string = " \
 			</menu> \
 			<menu name=\"LogMenu\" action=\"LogMenuAction\"> \
 				<menuitem name=\"Renumber\" action=\"Renumber\" /> \
+			</menu> \
+			<menu name=\"FilterMenu\" action=\"FilterMenuAction\"> \
+				<menuitem name=\"SelectEvents\" action=\"SelectEvents\" /> \
 			</menu> \
 			<menu name=\"Help\" action=\"HelpMenuAction\"> \
 				<menuitem name=\"About\" action=\"About\" /> \

--- a/profile.c
+++ b/profile.c
@@ -166,6 +166,37 @@ static void plot_text(struct graphics_context *gc, const text_render_options_t *
 	cairo_show_text(cr, buffer);
 }
 
+struct ev_select {
+	char *ev_name;
+	gboolean plot_ev;
+};
+static struct ev_select *ev_namelist;
+static int evn_allocated;
+static int evn_used;
+
+void remember_event(const char *eventname)
+{
+	int i=0, len;
+
+	if (!eventname || (len = strlen(eventname)) == 0)
+		return;
+	while (i < evn_used) {
+		if (!strncmp(eventname,ev_namelist[i].ev_name,len))
+			return;
+		i++;
+	}
+	if (evn_used == evn_allocated) {
+		evn_allocated += 10;
+		ev_namelist = realloc(ev_namelist, evn_allocated * sizeof(struct ev_select));
+		if (! ev_namelist)
+			/* we are screwed, but let's just bail out */
+			return;
+	}
+	ev_namelist[evn_used].ev_name = strdup(eventname);
+	ev_namelist[evn_used].plot_ev = TRUE;
+	evn_used++;
+}
+
 static void plot_one_event(struct graphics_context *gc, struct plot_info *pi, struct event *event, const text_render_options_t *tro)
 {
 	int i, depth = 0;

--- a/profile.c
+++ b/profile.c
@@ -174,6 +174,15 @@ static struct ev_select *ev_namelist;
 static int evn_allocated;
 static int evn_used;
 
+void evn_foreach(void (*callback)(const char *, int *, void *), void *data)
+{
+	int i;
+
+	for (i = 0; i < evn_used; i++) {
+		callback(ev_namelist[i].ev_name, &ev_namelist[i].plot_ev, data);
+	}
+}
+
 void remember_event(const char *eventname)
 {
 	int i=0, len;

--- a/profile.c
+++ b/profile.c
@@ -202,6 +202,17 @@ static void plot_one_event(struct graphics_context *gc, struct plot_info *pi, st
 	int i, depth = 0;
 	int x,y;
 
+	/* is plotting this event disabled? */
+	if (event->name) {
+		for (i = 0; i < evn_used; i++) {
+			if (! strcmp(event->name, ev_namelist[i].ev_name)) {
+				if (ev_namelist[i].plot_ev)
+					break;
+				else
+					return;
+			}
+		}
+	}
 	for (i = 0; i < pi->nr; i++) {
 		struct plot_data *data = pi->entry + i;
 		if (event->time.seconds < data->sec)


### PR DESCRIPTION
Many dive computers create a ton of events - whether it's PO2 warnings to RGT warnings or what not.
While they may be interesting in general, at times you just want the profile without some or all of those little event triangles cluttering the plot.
This adds a new menu that allows you to select which events to show (with all on by default)
