### PR TITLE
Update the known locations / buddies / divemasters as user enters them

### DIFF
--- a/info.c
+++ b/info.c
@@ -53,6 +53,7 @@ void flush_dive_info_changes(struct dive *dive)
 		char *new_text = gtk_combo_box_get_active_text(GTK_COMBO_BOX(location));
 		old_text = dive->location;
 		dive->location = new_text;
+		add_location(new_text);
 		if (text_changed(old_text,dive->location))
 			changed = 1;
 		if (old_text)
@@ -63,6 +64,7 @@ void flush_dive_info_changes(struct dive *dive)
 		char *new_text = gtk_combo_box_get_active_text(GTK_COMBO_BOX(divemaster));
 		old_text = dive->divemaster;
 		dive->divemaster = new_text;
+		add_people(new_text);
 		if (text_changed(old_text,dive->divemaster))
 			changed = 1;
 		if (old_text)
@@ -73,6 +75,7 @@ void flush_dive_info_changes(struct dive *dive)
 		char *new_text = gtk_combo_box_get_active_text(GTK_COMBO_BOX(buddy));
 		old_text = dive->buddy;
 		dive->buddy = new_text;
+		add_people(new_text);
 		if (text_changed(old_text,dive->buddy))
 			changed = 1;
 		if (old_text)


### PR DESCRIPTION
The code that allowed a user to start typing the name of a location, buddy
or divemaster and that would then offer completions has one flaw - it
doesn't add any new names that you enter to its store of names until you
save and restart the app. This patch fixes that.

When reading the code I also noted that the location_changed,
divemaster_changed, buddy_changed variables have become meaningless. They
are set to 1 and tested, but never changed. I wasn't sure if I should
remove the variables (as the code seems to work without them having any
impact), or if we should go back to actually tracking these changes to
prevent unnecessarily marking the divelist as changed.

Signed-off-by: Dirk Hohndel dirk@hohndel.org
