### PR TITLE
fix a couple of warnings and an error in windows.c

### DIFF
--- a/windows.c
+++ b/windows.c
@@ -38,7 +38,7 @@ void subsurface_set_conf(char *name, pref_type_t type, const void *value)
 	switch (type) {
 	case PREF_BOOL:
 		/* we simply store the value as DWORD */
-		RegSetValueEx(hkey, TEXT(name), 0, REG_DWORD, (DWORD)value, 4);
+		RegSetValueEx(hkey, TEXT(name), 0, REG_DWORD, (BYTE *)value, 4);
 		break;
 	case PREF_STRING:
 		RegSetValueEx(hkey, TEXT(name), 0, REG_SZ, value, strlen(value));
@@ -48,7 +48,7 @@ void subsurface_set_conf(char *name, pref_type_t type, const void *value)
 const void *subsurface_get_conf(char *name, pref_type_t type)
 {
 	char *string;
-	int len;
+	LONG len, success;
 
 	switch (type) {
 	case PREF_BOOL:
@@ -72,6 +72,6 @@ const void *subsurface_get_conf(char *name, pref_type_t type)
 void subsurface_close_conf(void)
 {
 	if (RegFlushKey(hkey) != ERROR_SUCCESS)
-		printf("RegFlushKey failed %ld\n");
+		printf("RegFlushKey failed\n");
 	RegCloseKey(hkey);
 }


### PR DESCRIPTION
fixes in windows.c:
- some (old) warnings related to "RegSetValueEx" and
  "RegQueryValueEx"
- declare "LONG success" in "subsurface_get_conf()"

Signed-off-by: Lubomir I. Ivanov neolit123@gmail.com
