### PR TITLE
README spelling, capitalization

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 Half-arsed divelog software in C.
 
-I'm tired of java programs that don't work etc.
+I'm tired of Java programs that don't work etc.
 
 License: GPLv2
 
@@ -161,13 +161,13 @@ See: http://gerrit.googlecode.com/svn/documentation/2.0/user-signedoffby.html
 Also, please write good git commit messages.  A good commit message
 looks like this:
 
-	header line: explaining the commit in one line
+	Header line: explaining the commit in one line
 
 	Body of commit message is a few lines of text, explaining things
 	in more detail, possibly giving some background about the issue
 	being fixed, etc etc.
 
-	The body of the commit message can be several paragrahps, and
+	The body of the commit message can be several paragraphs, and
 	please do proper word-wrap and keep columns shorter than about
 	74 characters or so. That way "git log" will show things
 	nicely even when it's indented.


### PR DESCRIPTION
Spelling: paragrahps -> paragraphs.

Update the README's example commit message to start with a capital
letter. Capitalize "Java".

Signed-off-by: Joachim Schipper joachim@joachimschipper.nl [it's trivial, do what you want.]

(Via [Hacker News](http://news.ycombinator.com/item?id=3282674).)
