### PR TITLE
Display "air" for imported dives with 21% O2

### DIFF
--- a/dive.c
+++ b/dive.c
@@ -572,3 +572,8 @@ struct dive *try_to_merge(struct dive *a, struct dive *b)
 	merge_events(res, a, b, 0);
 	return merge_samples(res, a, b, 0);
 }
+
+int is_air(int o2)
+{
+	return o2 >= 209 && o2 <= 210;
+}

--- a/dive.h
+++ b/dive.h
@@ -93,6 +93,7 @@ extern int get_pressure_units(unsigned int mb, const char **units);
 extern double get_depth_units(unsigned int mm, int *frac, const char **units);
 extern double get_volume_units(unsigned int mm, int *frac, const char **units);
 extern double get_temp_units(unsigned int mm, const char **units);
+extern int is_air(int o2);
 
 static inline double ml_to_cuft(int ml)
 {

--- a/divelist.c
+++ b/divelist.c
@@ -258,7 +258,7 @@ newmax:
 		maxo2 = o2;
 	}
 	/* All air? Show/sort as "air"/zero */
-	if (!maxhe && maxo2 == 209 && mino2 == maxo2)
+	if (!maxhe && is_air(maxo2) && mino2 == maxo2)
 		maxo2 = mino2 = 0;
 	*o2 = maxo2;
 	*he = maxhe;

--- a/parse-xml.c
+++ b/parse-xml.c
@@ -1075,7 +1075,7 @@ static void sanitize_gasmix(struct gasmix *mix)
 		if (!o2)
 			return;
 		/* 20.9% or 21% O2 is just air */
-		if (o2 >= 209 && o2 <= 210) {
+		if (is_air(o2)) {
 			mix->o2.permille = 0;
 			return;
 		}


### PR DESCRIPTION
Dives imported from my Suunto Zoop are saved with a cylinder with o2="21.0%".
These were displayed as "21" and not "air" in the divelist.

Signed-off-by: Henrik Brautaset Aronsen subsurface@henrik.synth.no
