### PR TITLE
More Mac improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,13 @@ UNAME := $(shell $(CC) -dumpmachine 2>&1 | grep -E -o "linux|darwin|win")
 #
 ifeq ($(CC), i686-w64-mingw32-gcc)
 # ok, we are cross building for Windows
-	LIBDIVECOMPUTERINCLUDES = `$(PKGCONFIG) --cflags libdivecomputer`
-	LIBDIVECOMPUTERARCHIVE = `$(PKGCONFIG) --libs libdivecomputer`
+	LIBDIVECOMPUTERINCLUDES = $(shell $(PKGCONFIG) --cflags libdivecomputer)
+	LIBDIVECOMPUTERARCHIVE = $(shell $(PKGCONFIG) --libs libdivecomputer)
 	RESFILE = packaging/windows/subsurface.res
 	LDFLAGS += -Wl,-subsystem,windows
 else ifeq ($(UNAME), darwin)
-	LIBDIVECOMPUTERINCLUDES = `$(PKGCONFIG) --cflags libdivecomputer`
-	LIBDIVECOMPUTERARCHIVE = `$(PKGCONFIG) --libs libdivecomputer`
+	LIBDIVECOMPUTERINCLUDES = $(shell $(PKGCONFIG) --cflags libdivecomputer)
+	LIBDIVECOMPUTERARCHIVE = $(shell $(PKGCONFIG) --libs libdivecomputer)
 else
 libdc-local := $(wildcard /usr/local/lib/libdivecomputer.a)
 libdc-local64 := $(wildcard /usr/local/lib64/libdivecomputer.a)
@@ -97,8 +97,8 @@ else ifeq ($(UNAME), darwin)
 	OSSUPPORT_CFLAGS = $(GTK2CFLAGS)
 	MACOSXINSTALL = /Applications/Subsurface.app
 	MACOSXFILES = packaging/macosx
-	EXTRALIBS = `$(PKGCONFIG) --libs gtk-mac-integration` -framework CoreFoundation
-	CFLAGS += `$(PKGCONFIG) --cflags gtk-mac-integration`
+	EXTRALIBS = $(shell $(PKGCONFIG) --libs gtk-mac-integration) -framework CoreFoundation
+	CFLAGS += $(shell $(PKGCONFIG) --cflags gtk-mac-integration)
 else
 	OSSUPPORT = windows
 	OSSUPPORT_CFLAGS = $(GTK2CFLAGS)
@@ -142,7 +142,6 @@ install-macosx: $(NAME)
 	$(INSTALL) -d -m 755 $(MACOSXINSTALL)/Contents/Resources
 	$(INSTALL) -d -m 755 $(MACOSXINSTALL)/Contents/MacOS
 	$(INSTALL) $(NAME) $(MACOSXINSTALL)/Contents/MacOS/
-	$(INSTALL) $(MACOSXFILES)/subsurface.sh $(MACOSXINSTALL)/Contents/MacOS/
 	$(INSTALL) $(MACOSXFILES)/PkgInfo $(MACOSXINSTALL)/Contents/
 	$(INSTALL) $(MACOSXFILES)/Info.plist $(MACOSXINSTALL)/Contents/
 	$(INSTALL) $(ICONFILE) $(MACOSXINSTALL)/Contents/Resources/

--- a/display-gtk.h
+++ b/display-gtk.h
@@ -29,7 +29,7 @@ typedef enum {
 
 #if defined __APPLE__
 #define CTRLCHAR "<Meta>"
-#define PREFERENCE_ACCEL "<Meta>,"
+#define PREFERENCE_ACCEL "<Meta>comma"
 #else
 #define CTRLCHAR "<Control>"
 #define PREFERENCE_ACCEL NULL

--- a/macos.c
+++ b/macos.c
@@ -92,18 +92,28 @@ void subsurface_ui_setup(GtkSettings *settings, GtkWidget *menubar,
 	osx_app = g_object_new(GTK_TYPE_OSX_APPLICATION, NULL);
 	gtk_widget_hide (menubar);
 	gtk_osxapplication_set_menu_bar(osx_app, GTK_MENU_SHELL(menubar));
+
+	sep = gtk_ui_manager_get_widget(ui_manager, "/MainMenu/FileMenu/Separator3");
+	gtk_widget_destroy(sep);
+	sep = gtk_ui_manager_get_widget(ui_manager, "/MainMenu/FileMenu/Separator2");
+	gtk_widget_destroy(sep);
+
 	menu_item = gtk_ui_manager_get_widget(ui_manager, "/MainMenu/FileMenu/Quit");
 	gtk_widget_hide (menu_item);
 	menu_item = gtk_ui_manager_get_widget(ui_manager, "/MainMenu/Help/About");
 	gtk_osxapplication_insert_app_menu_item(osx_app, menu_item, 0);
+
 	sep = gtk_separator_menu_item_new();
 	g_object_ref(sep);
 	gtk_osxapplication_insert_app_menu_item (osx_app, sep, 1);
+
 	menu_item = gtk_ui_manager_get_widget(ui_manager, "/MainMenu/FileMenu/Preferences");
 	gtk_osxapplication_insert_app_menu_item(osx_app, menu_item, 2);
+
 	sep = gtk_separator_menu_item_new();
 	g_object_ref(sep);
 	gtk_osxapplication_insert_app_menu_item (osx_app, sep, 3);
+
 	gtk_osxapplication_set_use_quartz_accelerators(osx_app, TRUE);
 	gtk_osxapplication_ready(osx_app);
 }

--- a/packaging/macosx/Info.plist
+++ b/packaging/macosx/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleExecutable</key>
-	<string>subsurface.sh</string>
+	<string>subsurface</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.hohndel.subsurface</string>
 </dict>

--- a/packaging/macosx/subsurface.sh
+++ b/packaging/macosx/subsurface.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-cd `dirname $0`/../Resources
-../MacOS/subsurface &
-exit 0


### PR DESCRIPTION
The startup shell script workaround isn't needed anymore. The preferences
hotkey didn't work. Remove left-over menu separators.
