### PR TITLE
Added a preference for time format

### DIFF
--- a/display-gtk.h
+++ b/display-gtk.h
@@ -45,6 +45,7 @@ extern const char *subsurface_icon_name(void);
 extern void subsurface_ui_setup(GtkSettings *settings, GtkWidget *menubar,
 		GtkWidget *vbox, GtkUIManager *ui_manager);
 
+extern const char *time_format;
 extern const char *divelist_font;
 
 extern visible_cols_t visible_cols;

--- a/divelist.c
+++ b/divelist.c
@@ -132,12 +132,7 @@ static void date_data_func(GtkTreeViewColumn *col,
 	when = val;
 
 	tm = gmtime(&when);
-	snprintf(buffer, sizeof(buffer),
-		"%s, %s %d, %d %02d:%02d",
-		weekday(tm->tm_wday),
-		monthname(tm->tm_mon),
-		tm->tm_mday, tm->tm_year + 1900,
-		tm->tm_hour, tm->tm_min);
+	strftime(buffer, sizeof(buffer), time_format, tm);
 	g_object_set(renderer, "text", buffer, NULL);
 }
 

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -23,6 +23,8 @@ GtkWidget *error_label;
 GtkWidget *vpane, *hpane;
 int        error_count;
 
+#define DEFAULT_TIME_FORMAT "%a, %b %e, %Y %H:%M"
+const char *time_format;
 const char *divelist_font;
 
 struct units output_units;
@@ -319,7 +321,7 @@ static void event_toggle(GtkWidget *w, gpointer _data)
 static void preferences_dialog(GtkWidget *w, gpointer data)
 {
 	int result;
-	GtkWidget *dialog, *font, *frame, *box, *vbox, *button;
+	GtkWidget *dialog, *font, *frame, *box, *vbox, *button, *time_format_entry;
 
 	menu_units = output_units;
 
@@ -388,6 +390,12 @@ static void preferences_dialog(GtkWidget *w, gpointer data)
 	gtk_box_pack_start(GTK_BOX(box), button, FALSE, FALSE, 6);
 	g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(otu_toggle), NULL);
 
+	frame = gtk_frame_new("Time format (http://linux.die.net/man/3/strftime)");
+	time_format_entry = gtk_entry_new();
+	gtk_entry_set_text(GTK_ENTRY(time_format_entry), time_format);
+	gtk_box_pack_start(GTK_BOX(vbox), frame, FALSE, FALSE, 5);
+	gtk_container_add(GTK_CONTAINER(frame), time_format_entry);
+
 	font = gtk_font_button_new_with_font(divelist_font);
 	gtk_box_pack_start(GTK_BOX(vbox), font, FALSE, FALSE, 5);
 
@@ -399,6 +407,8 @@ static void preferences_dialog(GtkWidget *w, gpointer data)
 
 		divelist_font = strdup(gtk_font_button_get_font_name(GTK_FONT_BUTTON(font)));
 		set_divelist_font(divelist_font);
+
+		time_format = strdup(gtk_entry_get_text(GTK_ENTRY(time_format_entry)));
 
 		output_units = menu_units;
 		update_dive_list_units();
@@ -415,6 +425,7 @@ static void preferences_dialog(GtkWidget *w, gpointer data)
 		subsurface_set_conf("SAC", PREF_BOOL, BOOL_TO_PTR(visible_cols.sac));
 		subsurface_set_conf("OTU", PREF_BOOL, BOOL_TO_PTR(visible_cols.otu));
 		subsurface_set_conf("divelist_font", PREF_STRING, divelist_font);
+		subsurface_set_conf("time_format", PREF_STRING, time_format);
 		subsurface_close_conf();
 	}
 	gtk_widget_destroy(dialog);
@@ -680,6 +691,10 @@ void init_ui(int *argcp, char ***argvp)
 	visible_cols.sac = PTR_TO_BOOL(subsurface_get_conf("SAC", PREF_BOOL));
 
 	divelist_font = subsurface_get_conf("divelist_font", PREF_STRING);
+
+	time_format = subsurface_get_conf("time_format", PREF_STRING);
+	if (!time_format)
+		time_format = DEFAULT_TIME_FORMAT;
 
 	error_info_bar = NULL;
 	win = gtk_window_new(GTK_WINDOW_TOPLEVEL);

--- a/info.c
+++ b/info.c
@@ -65,12 +65,12 @@ static char *get_combo_box_entry_text(GtkComboBoxEntry *combo_box, char **textp)
 static int divename(char *buf, size_t size, struct dive *dive)
 {
 	struct tm *tm = gmtime(&dive->when);
-	return snprintf(buf, size, "Dive #%d - %s %02d/%02d/%04d at %d:%02d",
-		dive->number,
-		weekday(tm->tm_wday),
-		tm->tm_mon+1, tm->tm_mday,
-		tm->tm_year+1900,
-		tm->tm_hour, tm->tm_min);
+	int len;
+
+	len = snprintf(buf, size, "Dive #%d - ", dive->number);
+	len += strftime(buf + len, size - len, time_format, tm);
+
+	return len;
 }
 
 void show_dive_info(struct dive *dive)

--- a/print.c
+++ b/print.c
@@ -31,7 +31,7 @@ static void show_dive_text(struct dive *dive, cairo_t *cr, double w, double h, P
 	int len, decimals, width, height, maxwidth, maxheight;
 	PangoLayout *layout;
 	struct tm *tm;
-	char buffer[80], divenr[20], *people;
+	char buffer[80], *people;
 
 	maxwidth = w * PANGO_SCALE;
 	maxheight = h * PANGO_SCALE * 0.9;
@@ -40,18 +40,14 @@ static void show_dive_text(struct dive *dive, cairo_t *cr, double w, double h, P
 	pango_layout_set_width(layout, maxwidth);
 	pango_layout_set_height(layout, maxheight);
 
-	*divenr = 0;
+	*buffer = '\0';
 	if (dive->number)
-		snprintf(divenr, sizeof(divenr), "Dive #%d - ", dive->number);
+		len = snprintf(buffer, sizeof(buffer), "Dive #%d - ", dive->number);
+	else
+		len = 0;
 
 	tm = gmtime(&dive->when);
-	len = snprintf(buffer, sizeof(buffer),
-		"%s%s, %s %d, %d   %d:%02d",
-		divenr,
-		weekday(tm->tm_wday),
-		monthname(tm->tm_mon),
-		tm->tm_mday, tm->tm_year + 1900,
-		tm->tm_hour, tm->tm_min);
+	len += strftime(buffer + len, sizeof(buffer) - len, time_format, tm);
 
 	set_font(layout, font, FONT_LARGE, PANGO_ALIGN_LEFT);
 	pango_layout_set_text(layout, buffer, len);

--- a/statistics.c
+++ b/statistics.c
@@ -130,12 +130,7 @@ void show_dive_stats(struct dive *dive)
 	process_all_dives(dive, &prev_dive);
 
 	tm = gmtime(&dive->when);
-	snprintf(buf, sizeof(buf),
-		"%s, %s %d, %d %2d:%02d",
-		weekday(tm->tm_wday),
-		monthname(tm->tm_mon),
-		tm->tm_mday, tm->tm_year + 1900,
-		tm->tm_hour, tm->tm_min);
+	strftime(buf, sizeof(buf), time_format, tm);
 
 	set_label(info_stat_w.date, buf);
 	set_label(info_stat_w.dive_time, "%d min", (dive->duration.seconds + 30) / 60);


### PR DESCRIPTION
Added a preference so that the users can changed the time format to
a strftime format string of their own choosing. The preference has its
own frame named "Time format (http://linux.die.net/man/3/strftime)"
between the frame "Columns" and the font button.

I implemented usage of the global time format in the places where I
found a date that was outputted to the user. These places were the
divelist, the statistics, the dive info and the output when printing.

Signed-off-by: Johannes Larsen johs.a.larsen@gmail.com
