### PR TITLE
Freediving tweaks

### DIFF
--- a/display.h
+++ b/display.h
@@ -26,4 +26,6 @@ extern void plot(struct graphics_context *gc, cairo_rectangle_int_t *drawing_are
 extern void init_profile_background(struct graphics_context *gc);
 extern void attach_tooltip(int x, int y, int w, int h, const char *text);
 
+extern char zoomed_plot;
+
 #endif

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -24,7 +24,6 @@ GtkWidget *vpane, *hpane;
 GtkWidget *notebook;
 
 int        error_count;
-extern char zoomed_plot;
 
 const char *divelist_font;
 

--- a/gtk-gui.c
+++ b/gtk-gui.c
@@ -22,6 +22,7 @@ GtkWidget *error_info_bar;
 GtkWidget *error_label;
 GtkWidget *vpane, *hpane;
 int        error_count;
+extern char zoomed_plot;
 
 const char *divelist_font;
 
@@ -610,6 +611,13 @@ static void view_three(GtkWidget *w, gpointer data)
 	gtk_paned_set_position(GTK_PANED(vpane), 200);
 }
 
+static void toggle_zoom(GtkWidget *w, gpointer data)
+{
+	zoomed_plot = (zoomed_plot)?0 : 1;
+	/*Update dive*/
+	repaint_dive();
+}
+
 static GtkActionEntry menu_items[] = {
 	{ "FileMenuAction", GTK_STOCK_FILE, "File", NULL, NULL, NULL},
 	{ "LogMenuAction",  GTK_STOCK_FILE, "Log", NULL, NULL, NULL},
@@ -628,7 +636,8 @@ static GtkActionEntry menu_items[] = {
 	{ "ViewList",       NULL, "List",  CTRLCHAR "1", NULL, G_CALLBACK(view_list) },
 	{ "ViewProfile",    NULL, "Profile", CTRLCHAR "2", NULL, G_CALLBACK(view_profile) },
 	{ "ViewInfo",       NULL, "Info", CTRLCHAR "3", NULL, G_CALLBACK(view_info) },
-	{ "ViewThree",       NULL, "Three", CTRLCHAR "4", NULL, G_CALLBACK(view_three) },
+	{ "ViewThree",      NULL, "Three", CTRLCHAR "4", NULL, G_CALLBACK(view_three) },
+	{ "ToggleZoom",     NULL, "Toggle Zoom", CTRLCHAR "0", NULL, G_CALLBACK(toggle_zoom) },
 };
 static gint nmenu_items = sizeof (menu_items) / sizeof (menu_items[0]);
 
@@ -648,6 +657,7 @@ static const gchar* ui_string = " \
 				<menuitem name=\"Import\" action=\"Import\" /> \
 				<separator name=\"Separator\"/> \
 				<menuitem name=\"Renumber\" action=\"Renumber\" /> \
+				<menuitem name=\"Toggle Zoom\" action=\"ToggleZoom\" /> \
 				<menu name=\"View\" action=\"ViewMenuAction\"> \
 					<menuitem name=\"List\" action=\"ViewList\" /> \
 					<menuitem name=\"Profile\" action=\"ViewProfile\" /> \

--- a/profile.c
+++ b/profile.c
@@ -468,7 +468,7 @@ static void plot_depth_profile(struct graphics_context *gc, struct plot_info *pi
 	maxtime = get_maxtime(pi);
 	maxdepth = get_maxdepth(pi);
 
-	/* Time markers: at most every 5 min, but no more than 12 markers.
+	/* Time markers: at most every 10 seconds, but no more than 12 markers.
 	 * We start out with 10 seconds and increment up to 30 minutes,
 	 * depending on the dive time.
 	 * This allows for 6h dives - enough (I hope) for even the craziest

--- a/profile.c
+++ b/profile.c
@@ -189,14 +189,13 @@ static void dump_pi (struct plot_info *pi)
 static int get_maxtime(struct plot_info *pi)
 {
 	int seconds = pi->maxtime;
-  if (seconds < 600)
-  {
-    /* Possible apnea dive, we scale accordingly */
-    return ROUND_UP(seconds+seconds/4, 60);
-  } else {
-    /* min 30 minutes, rounded up to 5 minutes, with at least 2.5 minutes to spare */
-    return MAX(30*60, ROUND_UP(seconds+150, 60*5));
-  }
+	if (seconds < 600) {
+		/* Possible apnea dive, we scale accordingly */
+		return ROUND_UP(seconds+seconds/4, 60);
+	} else {
+		/* min 30 minutes, rounded up to 5 minutes, with at least 2.5 minutes to spare */
+		return MAX(30*60, ROUND_UP(seconds+150, 60*5));
+	}
 }
 
 static int get_maxdepth(struct plot_info *pi)
@@ -456,15 +455,14 @@ static void plot_depth_profile(struct graphics_context *gc, struct plot_info *pi
 	/* Get plot scaling limits */
 	maxtime = get_maxtime(pi);
 	maxdepth = get_maxdepth(pi);
-  /* We check whether this has been an apnea dive and overwrite
-   * the increments in order to get reasonable time markers */
-  if (maxtime < 600)
-  {
-    increments[0] = 10;
-    increments[1] = 20;
-    increments[2] = 30;
-    increments[3] = 60;
-  }
+	/* We check whether this has been an apnea dive and overwrite
+	* the increments in order to get reasonable time markers */
+	if (maxtime < 600) {
+		increments[0] = 10;
+		increments[1] = 20;
+		increments[2] = 30;
+		increments[3] = 60;
+	}
 	/* Time markers: at most every 5 min, but no more than 12 markers
 	 * and for convenience we do 5, 10, 15 or 30 min intervals.
 	 * This allows for 6h dives - enough (I hope) for even the craziest
@@ -491,16 +489,15 @@ static void plot_depth_profile(struct graphics_context *gc, struct plot_info *pi
 
 	/* now the text on the time markers */
 	text_render_options_t tro = {10, TIME_TEXT, CENTER, TOP};
-  if (maxtime < 600)
-  {
-    /* Be a bit more verbose with shorter (apnea) dives */
-	  for (i = incr; i < maxtime; i += incr)
-		  plot_text(gc, &tro, i, 1, "%d:%d", i/60, i%60);
-  } else {
-    /* Only render the time on every second marker for normal dives */
-  	for (i = incr; i < maxtime; i += 2 * incr)
-		  plot_text(gc, &tro, i, 1, "%d", i/60);
-  }
+	if (maxtime < 600) {
+		/* Be a bit more verbose with shorter (apnea) dives */
+		for (i = incr; i < maxtime; i += incr)
+		plot_text(gc, &tro, i, 1, "%d:%d", i/60, i%60);
+	} else {
+		/* Only render the time on every second marker for normal dives */
+		for (i = incr; i < maxtime; i += 2 * incr)
+		plot_text(gc, &tro, i, 1, "%d", i/60);
+	}
 	/* Depth markers: every 30 ft or 10 m*/
 	gc->leftx = 0; gc->rightx = 1.0;
 	gc->topy = 0; gc->bottomy = maxdepth;

--- a/profile.c
+++ b/profile.c
@@ -498,7 +498,7 @@ static void plot_depth_profile(struct graphics_context *gc, struct plot_info *pi
 	if (maxtime < 600) {
 		/* Be a bit more verbose with shorter dives */
 		for (i = incr; i < maxtime; i += incr)
-			plot_text(gc, &tro, i, 1, "%d:%d", i/60, i%60);
+			plot_text(gc, &tro, i, 1, "%02d:%02d", i/60, i%60);
 	} else {
 		/* Only render the time on every second marker for normal dives */
 		for (i = incr; i < maxtime; i += 2 * incr)

--- a/profile.c
+++ b/profile.c
@@ -461,9 +461,9 @@ static void plot_depth_profile(struct graphics_context *gc, struct plot_info *pi
   if (maxtime < 600)
   {
     increments[0] = 10;
-    increments[1] = 30;
-    increments[2] = 60;
-    increments[3] = 5*60;
+    increments[1] = 20;
+    increments[2] = 30;
+    increments[3] = 60;
   }
 	/* Time markers: at most every 5 min, but no more than 12 markers
 	 * and for convenience we do 5, 10, 15 or 30 min intervals.


### PR DESCRIPTION
For dives with a dive time shorter than 10 minutes:
- the plotting will now scale to 1.25*(dive time)
- the text will be displayed on every marker to make the plot more informative.

In general:
- a "Zoom" button has been added to the "Log" Menu along with a shortcut (Ctrl + "0")
- the number of increments has been increased to 8 with { 10, 20, 30, 60 } being the new entries

Here is how a dive to 32m, lasting 1:09 min looks like without the patch:

![Imgur](http://i.imgur.com/5nH3S.png)

with the patch:

![Imgur](http://i.imgur.com/npTFX.png)
