### PR TITLE
changed appdata <licence> tag to the new <metadata_license> tag

### DIFF
--- a/appdata/subsurface.appdata.xml
+++ b/appdata/subsurface.appdata.xml
@@ -2,7 +2,7 @@
 <!-- Copyright 2014 Pedro Neves <nevesdiver@gmail.com> -->
 <application>
  <id type="desktop">subsurface.desktop</id>
- <licence>CC-BY-SA</licence>
+ <metadata_license>CC-BY-SA</metadata_license>
  <name>Subsurface</name>
  <summary>Manage and display dive computer data</summary>
  <description>


### PR DESCRIPTION
changed the <licence> tag to the new <metadata_license> tag to reflect a change in the Appdata Spec that deprecated the <licence> tag, and replaced it with the <metadata_license> tag to remove ambiguity between the project license and the metadata license

See:
http://people.freedesktop.org/~hughsient/appdata/#metadata_license
