### PR TITLE
Use compilation flags

### DIFF
--- a/subsurface.pro
+++ b/subsurface.pro
@@ -340,3 +340,9 @@ include(subsurface-install.pri)
 # to build debuggable binaries on Windows, you need something like this
 #QMAKE_CFLAGS_RELEASE=$$QMAKE_CFLAGS_DEBUG -O0 -g
 #QMAKE_CXXFLAGS_RELEASE=$$QMAKE_CXXFLAGS_DEBUG -O0 -g
+
+QMAKE_CXXFLAGS += $$(CXXFLAGS)
+QMAKE_CFLAGS += $$(CFLAGS)
+QMAKE_LFLAGS += $$(LDFLAGS)
+QMAKE_CPPFLAGS += $$(CPPFLAGS)
+


### PR DESCRIPTION
This changes the .pro file to use the envvars CFLAGS, LDFLAGS
CXXFLAGS and CPPFLAGS.

This lets people easily add the wanted compile flags and most
importantly lets dpkg use hardening options without the need to
carry a patch downstream.
