### PR TITLE
2 GPS related commits (cleanup and  fix)

### DIFF
--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -39,7 +39,7 @@ GpsLocation::GpsLocation(void (*showMsgCB)(const char *), QObject *parent) :
 	loadFromStorage();
 
 	// register changes in time threshold
-	connect(qPrefLocationService::instance(), SIGNAL(qPrefLocationService::time_thresholdChanged()), this, SLOT(setGpsTimeThreshold(int seconds)));
+	connect(qPrefLocationService::instance(), SIGNAL(time_thresholdChanged(int)), this, SLOT(setGpsTimeThreshold(int)));
 }
 
 GpsLocation *GpsLocation::instance()

--- a/core/gpslocation.cpp
+++ b/core/gpslocation.cpp
@@ -11,14 +11,6 @@
 #include <QUrlQuery>
 #include <QApplication>
 #include <QTimer>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-
-#define GPS_FIX_ADD_URL "http://api.subsurface-divelog.org/api/dive/add/"
-#define GPS_FIX_DELETE_URL "http://api.subsurface-divelog.org/api/dive/delete/"
-#define GPS_FIX_DOWNLOAD_URL "http://api.subsurface-divelog.org/api/dive/get/"
-#define GET_WEBSERVICE_UID_URL "https://cloud.subsurface-divelog.org/webuserid/"
 
 GpsLocation *GpsLocation::m_Instance = NULL;
 

--- a/core/gpslocation.h
+++ b/core/gpslocation.h
@@ -32,7 +32,6 @@ public:
 	int getGpsNum() const;
 	bool hasLocationsSource();
 	QString currentPosition();
-	void setGpsTimeThreshold(int seconds);
 
 	QMap<qint64, gpsTracker> currentGPSInfo() const;
 
@@ -66,6 +65,7 @@ public slots:
 	void updateTimeout();
 	void positionSourceError(QGeoPositionInfoSource::Error error);
 	void postError(QNetworkReply::NetworkError error);
+	void setGpsTimeThreshold(int seconds);
 #ifdef SUBSURFACE_MOBILE
 	void clearGpsData();
 #endif


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Fix multiple run-time errors in connect call introduced in 504e912. 1) Set the proper signature of the signal. 2) make the used slot a real slot (so move it to the proper section in the header) and 3) set the proper signature for the slot.

Highly unlikely that normal users notice the run-time errors and possibly unwanted behavior, as this all deals with the subtile GPS service update threshold.

And while we are at it, as a second commit some more stripping of unused code after removal of the GPS webservice.

### Changes made:
See commits
