### PR TITLE
Fix bug in for loop that can lead to segfault

### DIFF
--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -84,7 +84,7 @@ void PreferencesDefaults::refreshSettings()
 	ui->localDefaultFile->setChecked(qPrefGeneral::default_file_behavior() == LOCAL_DEFAULT_FILE);
 
 	ui->default_cylinder->clear();
-	for (int i = 0; tank_info[i].name != NULL && i < MAX_TANK_INFO; i++) {
+	for (int i = 0; i < MAX_TANK_INFO && tank_info[i].name != NULL; i++) {
 		ui->default_cylinder->addItem(tank_info[i].name);
 		if (qPrefGeneral::default_cylinder() == tank_info[i].name)
 			ui->default_cylinder->setCurrentIndex(i);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes a bug, where in big log files, opening preferences crashed with a segfault.
Only happens if MAX_TANK_INFO is reached.

### Changes made:
Fix bug by first check for proper index
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
Fixes #1608
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
can be tested with sample dive log
https://github.com/Subsurface-divelog/large-anonymous-sample-data
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
not needed

### Mentions:
@bstoeger @dirkhh
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
