### PR TITLE
[RFC] Mobile: don't format trip heading for all dives (Warning: contains #1870)

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -758,16 +758,22 @@ extern void set_git_prefs(const char *prefs);
 extern char *get_dive_date_c_string(timestamp_t when);
 extern void update_setpoint_events(const struct dive *dive, struct divecomputer *dc);
 
-#ifdef __cplusplus
-}
-#endif
-
 extern weight_t string_to_weight(const char *str);
 extern depth_t string_to_depth(const char *str);
 extern pressure_t string_to_pressure(const char *str);
 extern volume_t string_to_volume(const char *str, pressure_t workp);
 extern fraction_t string_to_fraction(const char *str);
 extern void average_max_depth(struct diveplan *dive, int *avg_depth, int *max_depth);
+
+#ifdef __cplusplus
+}
+
+/* Make pointers to dive and dive_trip "Qt metatypes" so that they can
+ * be passed through QVariants. */
+Q_DECLARE_METATYPE(struct dive *);
+Q_DECLARE_METATYPE(struct dive_trip *);
+
+#endif
 
 #include "pref.h"
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -288,7 +288,6 @@ typedef struct dive_trip
 	char *location;
 	char *notes;
 	struct dive_table dives;
-	int showndives;
 	/* Used by the io-routines to mark trips that have already been written. */
 	bool saved;
 	bool autogen;

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -54,6 +54,8 @@ extern void set_dive_nr_for_current_dive();
 extern timestamp_t get_surface_interval(timestamp_t when);
 extern void delete_dive_from_table(struct dive_table *table, int idx);
 extern struct dive *find_next_visible_dive(timestamp_t when);
+extern bool trip_is_single_day(const struct dive_trip *trip);
+extern int trip_shown_dives(const struct dive_trip *trip);
 
 int get_min_datafile_version();
 void reset_min_datafile_version();

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -950,22 +950,6 @@ extern "C" char *get_current_date()
 	return copy_qstring(current_date);
 }
 
-bool is_same_day(timestamp_t trip_when, timestamp_t dive_when)
-{
-	static timestamp_t twhen = (timestamp_t) 0;
-	static struct tm tmt;
-	struct tm tmd;
-
-	utc_mkdate(dive_when, &tmd);
-
-	if (twhen != trip_when) {
-		twhen = trip_when;
-		utc_mkdate(twhen, &tmt);
-	}
-
-	return (tmd.tm_mday == tmt.tm_mday) && (tmd.tm_mon == tmt.tm_mon) && (tmd.tm_year == tmt.tm_year);
-}
-
 QString get_trip_date_string(timestamp_t when, int nr, bool getday)
 {
 	struct tm tm;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -77,7 +77,6 @@ QString get_dive_duration_string(timestamp_t when, QString hoursText, QString mi
 QString get_dive_surfint_string(timestamp_t when, QString daysText, QString hoursText, QString minutesText, QString separator = " ", int maxdays = 4);
 QString get_dive_date_string(timestamp_t when);
 QString get_short_dive_date_string(timestamp_t when);
-bool is_same_day (timestamp_t trip_when, timestamp_t dive_when);
 QString get_trip_date_string(timestamp_t when, int nr, bool getday);
 QString uiLanguage(QLocale *callerLoc);
 QLocale getLocale();

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -324,11 +324,6 @@ QList<CylinderObjectHelper*> DiveObjectHelper::cylinderObjects() const
 	return m_cyls;
 }
 
-QString DiveObjectHelper::trip() const
-{
-	return m_dive->divetrip ? m_dive->divetrip->location : EMPTY_DIVE_STRING;
-}
-
 // combine the pointer address with the trip title so that
 // we detect multiple, destinct trips with the same title
 // the trip title is designed to be
@@ -448,5 +443,6 @@ QString DiveObjectHelper::fullText() const
 
 QString DiveObjectHelper::fullTextNoNotes() const
 {
-	return trip() + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags();
+	QString tripLocation = m_dive->divetrip ? m_dive->divetrip->location : EMPTY_DIVE_STRING;
+	return tripLocation + ":-:" + location() + ":-:" + buddy() + ":-:" + divemaster() + ":-:" + suit() + ":-:" + tags();
 }

--- a/core/subsurface-qt/DiveObjectHelper.cpp
+++ b/core/subsurface-qt/DiveObjectHelper.cpp
@@ -324,40 +324,9 @@ QList<CylinderObjectHelper*> DiveObjectHelper::cylinderObjects() const
 	return m_cyls;
 }
 
-// combine the pointer address with the trip title so that
-// we detect multiple, destinct trips with the same title
-// the trip title is designed to be
-// location (# dives)
-// or, if there is no location name
-// date range (# dives)
-// where the date range is given as "month year" or "month-month year" or "month year - month year"
-QString DiveObjectHelper::tripMeta() const
+QString DiveObjectHelper::tripId() const
 {
-	QString ret = EMPTY_DIVE_STRING;
-	struct dive_trip *dt = m_dive->divetrip;
-	if (dt) {
-		QString numDives = tr("(%n dive(s))", "", dt->showndives);
-		QString title(dt->location);
-		QDateTime firstTime = QDateTime::fromMSecsSinceEpoch(1000*trip_date(dt), Qt::UTC);
-		QString firstMonth = firstTime.toString("MMM");
-		QString tripDate = QStringLiteral("%1@%2").arg(firstMonth,firstTime.toString("yy"));
-
-		if (title.isEmpty()) {
-			// so use the date range
-			QString firstYear = firstTime.toString("yyyy");
-			QDateTime lastTime = QDateTime::fromMSecsSinceEpoch(1000*dt->dives.dives[0]->when, Qt::UTC);
-			QString lastMonth = lastTime.toString("MMM");
-			QString lastYear = lastTime.toString("yyyy");
-			if (lastMonth == firstMonth && lastYear == firstYear)
-				title = firstMonth + " " + firstYear;
-			else if (lastMonth != firstMonth && lastYear == firstYear)
-				title = firstMonth + "-" + lastMonth + " " + firstYear;
-			else
-				title = firstMonth + " " + firstYear + " - " + lastMonth + " " + lastYear;
-		}
-		ret = QString::number((quint64)m_dive->divetrip, 16) + QLatin1Literal("++") +  tripDate + QLatin1Literal("::") + QStringLiteral("%1 %2").arg(title, numDives);
-	}
-	return ret;
+	return m_dive->divetrip ? QString::number((quint64)m_dive->divetrip, 16) : QString();
 }
 
 int DiveObjectHelper::tripNrDives() const

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -39,7 +39,7 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList cylinderList READ cylinderList CONSTANT)
 	Q_PROPERTY(QStringList cylinders READ cylinders CONSTANT)
 	Q_PROPERTY(QList<CylinderObjectHelper*> cylinderObjects READ cylinderObjects CONSTANT)
-	Q_PROPERTY(QString tripMeta READ tripMeta CONSTANT)
+	Q_PROPERTY(QString tripId READ tripId CONSTANT)
 	Q_PROPERTY(int tripNrDives READ tripNrDives CONSTANT)
 	Q_PROPERTY(int maxcns READ maxcns CONSTANT)
 	Q_PROPERTY(int otu READ otu CONSTANT)
@@ -85,7 +85,7 @@ public:
 	QStringList cylinders() const;
 	QString cylinder(int idx) const;
 	QList<CylinderObjectHelper*> cylinderObjects() const;
-	QString tripMeta() const;
+	QString tripId() const;
 	int tripNrDives() const;
 	int maxcns() const;
 	int otu() const;

--- a/core/subsurface-qt/DiveObjectHelper.h
+++ b/core/subsurface-qt/DiveObjectHelper.h
@@ -39,7 +39,6 @@ class DiveObjectHelper : public QObject {
 	Q_PROPERTY(QStringList cylinderList READ cylinderList CONSTANT)
 	Q_PROPERTY(QStringList cylinders READ cylinders CONSTANT)
 	Q_PROPERTY(QList<CylinderObjectHelper*> cylinderObjects READ cylinderObjects CONSTANT)
-	Q_PROPERTY(QString trip READ trip CONSTANT)
 	Q_PROPERTY(QString tripMeta READ tripMeta CONSTANT)
 	Q_PROPERTY(int tripNrDives READ tripNrDives CONSTANT)
 	Q_PROPERTY(int maxcns READ maxcns CONSTANT)
@@ -86,7 +85,6 @@ public:
 	QStringList cylinders() const;
 	QString cylinder(int idx) const;
 	QList<CylinderObjectHelper*> cylinderObjects() const;
-	QString trip() const;
 	QString tripMeta() const;
 	int tripNrDives() const;
 	int maxcns() const;

--- a/mobile-widgets/qml/DiveList.qml
+++ b/mobile-widgets/qml/DiveList.qml
@@ -58,7 +58,7 @@ Kirigami.ScrollablePage {
 			states: [
 				State {
 					name: "isHidden";
-					when: dive.tripMeta !== activeTrip && ! diveOutsideTrip
+					when: dive.tripId !== activeTrip && ! diveOutsideTrip
 					PropertyChanges {
 						target: innerListItem
 						height: 0
@@ -67,7 +67,7 @@ Kirigami.ScrollablePage {
 				},
 				State {
 					name: "isVisible";
-					when: dive.tripMeta === activeTrip || diveOutsideTrip
+					when: dive.tripId === activeTrip || diveOutsideTrip
 					PropertyChanges {
 						target: innerListItem
 						height: diveListEntry.height + Kirigami.Units.smallSpacing
@@ -130,7 +130,7 @@ Kirigami.ScrollablePage {
 			Item {
 				Rectangle {
 					id: leftBarDive
-					width: dive.tripMeta == "" ? 0 : Kirigami.Units.smallSpacing
+					width: dive.tripId == "" ? 0 : Kirigami.Units.smallSpacing
 					height: diveListEntry.height * 0.8
 					color: subsurfaceTheme.lightPrimaryColor
 					anchors {
@@ -348,7 +348,10 @@ Kirigami.ScrollablePage {
 						leftMargin: Kirigami.Units.smallSpacing
 					}
 					Controls.Label {
-						text: {	section.replace(/.*\+\+/, "").replace(/::.*/, "").replace("@", "\n'") }
+						text: {
+							var trip = diveListView.model.tripIdToObject(section);
+							diveListView.model.tripShortDate(trip);
+						}
 						color: subsurfaceTheme.primaryTextColor
 						font.pointSize: subsurfaceTheme.smallPointSize
 						lineHeightMode: Text.FixedHeight
@@ -372,17 +375,8 @@ Kirigami.ScrollablePage {
 				Controls.Label {
 					id: sectionText
 					text: {
-						// if the tripMeta (which we get as "section") ends in ::-- we know
-						// that there's no trip -- otherwise strip the meta information before
-						// the :: and show the trip location
-						var shownText
-						var endsWithDoubleDash = /::--$/;
-						if (endsWithDoubleDash.test(section) || section === "--") {
-							shownText = ""
-						} else {
-							shownText = section.replace(/.*::/, "")
-						}
-						shownText
+						var trip = diveListView.model.tripIdToObject(section);
+						diveListView.model.tripTitle(trip);
 					}
 					wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 					visible: text !== ""
@@ -526,7 +520,7 @@ Kirigami.ScrollablePage {
 		maximumFlickVelocity: parent.height * 5
 		bottomMargin: Kirigami.Units.iconSizes.medium + Kirigami.Units.gridUnit
 		cacheBuffer: 40 // this will increase memory use, but should help with scrolling
-		section.property: "dive.tripMeta"
+		section.property: "dive.tripId"
 		section.criteria: ViewSection.FullString
 		section.delegate: tripHeading
 		section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -15,6 +15,9 @@ public:
 	void setSourceModel(QAbstractItemModel *sourceModel);
 	Q_INVOKABLE void addAllDives();
 	Q_INVOKABLE void clear();
+	Q_INVOKABLE QVariant tripIdToObject(const QString &s);
+	Q_INVOKABLE QString tripTitle(const QVariant &trip);
+	Q_INVOKABLE QString tripShortDate(const QVariant &trip);
 public slots:
 	int getDiveId(int idx);
 	int getIdxForId(int id);

--- a/qt-models/divelistmodel.h
+++ b/qt-models/divelistmodel.h
@@ -24,11 +24,9 @@ public slots:
 	void setFilter(QString f);
 	void resetFilter();
 	int shown();
-	void updateDivesShownInTrips();
 protected:
 	bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const;
 private:
-	std::vector<unsigned char> filteredRows; // using unsigned char because using 'bool' turns this into a bitfield
 	QString filterString;
 	void updateFilterState();
 };

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -51,7 +51,7 @@ QVariant DiveTripModel::tripData(const dive_trip *trip, int column, int role)
 	bool oneDayTrip=true;
 
 	if (role == TRIP_ROLE)
-		return QVariant::fromValue<void *>((void *)trip); // Not nice: casting away a const
+		return QVariant::fromValue(const_cast<dive_trip *>(trip)); // Not nice: casting away a const
 
 	if (role == Qt::DisplayRole) {
 		switch (column) {
@@ -248,7 +248,7 @@ QVariant DiveTripModel::diveData(const struct dive *d, int column, int role)
 	case STAR_ROLE:
 		return d->rating;
 	case DIVE_ROLE:
-		return QVariant::fromValue<void *>((void *)d);  // Not nice: casting away a const
+		return QVariant::fromValue(const_cast<dive *>(d));  // Not nice: casting away a const
 	case DIVE_IDX:
 		return get_divenr(d);
 	case SELECTED_ROLE:

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -48,7 +48,6 @@ static QVariant dive_table_alignment(int column)
 
 QVariant DiveTripModel::tripData(const dive_trip *trip, int column, int role)
 {
-	bool oneDayTrip=true;
 
 	if (role == TRIP_ROLE)
 		return QVariant::fromValue(const_cast<dive_trip *>(trip)); // Not nice: casting away a const
@@ -57,13 +56,8 @@ QVariant DiveTripModel::tripData(const dive_trip *trip, int column, int role)
 		switch (column) {
 		case DiveTripModel::NR:
 			QString shownText;
-			int countShown = 0;
-			for (int i = 0; i < trip->dives.nr; ++i) {
-				struct dive *d = trip->dives.dives[i];
-				if (!d->hidden_by_filter)
-					countShown++;
-				oneDayTrip &= is_same_day(trip_date(trip),  d->when);
-			}
+			bool oneDayTrip = trip_is_single_day(trip);
+			int countShown = trip_shown_dives(trip);
 			if (countShown < trip->dives.nr)
 				shownText = tr("(%1 shown)").arg(countShown);
 			if (!empty_string(trip->location))

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -619,16 +619,14 @@ bool MultiFilterSortModel::showDive(const struct dive *d) const
 bool MultiFilterSortModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
 {
 	QModelIndex index0 = sourceModel()->index(source_row, 0, source_parent);
-	QVariant diveVariant = sourceModel()->data(index0, DiveTripModel::DIVE_ROLE);
-	struct dive *d = (struct dive *)diveVariant.value<void *>();
+	struct dive *d = sourceModel()->data(index0, DiveTripModel::DIVE_ROLE).value<struct dive *>();
 
 	// For dives, simply check the hidden_by_filter flag
 	if (d)
 		return !d->hidden_by_filter;
 
 	// Since this is not a dive, it must be a trip
-	QVariant tripVariant = sourceModel()->data(index0, DiveTripModel::TRIP_ROLE);
-	dive_trip *trip = (dive_trip *)tripVariant.value<void *>();
+	dive_trip *trip = sourceModel()->data(index0, DiveTripModel::TRIP_ROLE).value<dive_trip *>();
 
 	if (!trip)
 		return false; // Oops. Neither dive nor trip, something is seriously wrong.


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
I checked the source code of "QuickListView" and I found no obvious way of passing anything other than a string as "section". Perhaps I'm simply blind. So this is the best I could come up with to remove that crazy format the trip-header for every dive instead of every trip. Note that this is not so much a performance thing but a code-cleanliness / flexibility thing. I'm not very happy about it, but it is a step forward I think. Especially if someone can tell us how this is really planned to be used.

I know that it worked before, but this is better for my mental health. 😛

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace tripMeta by tripId and only pass the pointer, not the fully formatted strings.
2) Use distinct functions for formatting the trip header and short-date.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Contains #1870 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
No.
### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No.
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
