### PR TITLE
[TRIVIAL] cleanup: remove obsolete logic in getFormattedCylinder()

### DIFF
--- a/core/subsurface-qt/diveobjecthelper.cpp
+++ b/core/subsurface-qt/diveobjecthelper.cpp
@@ -35,8 +35,6 @@ static QString getFormattedCylinder(const struct dive *dive, int idx)
 {
 	const cylinder_t *cyl = get_cylinder(dive, idx);
 	const char *desc = cyl->type.description;
-	if (!desc && idx > 0)
-		return QString();
 	QString fmt = desc ? QString(desc) : gettextFromC::tr("unknown");
 	fmt += ", " + get_volume_string(cyl->type.size, true);
 	fmt += ", " + get_pressure_string(cyl->type.workingpressure, true);


### PR DESCRIPTION
getFormattedCylinder() is a helper function to format a list
of cylinders. It had that weird logic that it would skip
cylinders without description unless it is the first, which
would instead be written as "unkown".

The reason was the old statically sized cylinder array,
where it wasn't clear if a cylinder was actually in use.

This became obsolete when switching to a variable size
cylinder array. Firstly, all cylinders in the array were added
by the user. Secondly, we now also support dives without
cylinders, i.e. the first cylinder is not any different from
the rest.

Thus, remove the logic and format any cylinder without
description as being of type "unknown".

Signed-off-by: Berthold Stoeger <bstoeger@mail.tuwien.ac.at>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a trivial cleanup that removes now obsolete logic.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Format cylinders without description as "unknown", not only the first cylinder.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@dirkhh