### PR TITLE
[WIP] Shearwater Peregrine support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+core: add support for Shearwater Peregrine (requires firmware V79 or newer)
 core: fix renumbering of imported dives [#2731]
 mobile: fix editing tank information
 mobile: disable download button if no connection is selected

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -38,6 +38,7 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		    btName.startsWith("Petrel") ||
 		    btName.startsWith("Perdix") ||
 		    btName.startsWith("Teric") ||
+		    btName.startsWith("Peregrine") ||
 		    btName.startsWith("NERD")) {
 		vendor = "Shearwater";
 		// both the Petrel and Petrel 2 identify as "Petrel" as BT/BLE device
@@ -47,6 +48,7 @@ static dc_descriptor_t *getDeviceType(QString btName)
 		if (btName.startsWith("Perdix")) product = "Perdix";
 		if (btName.startsWith("Predator")) product = "Predator";
 		if (btName.startsWith("Teric")) product = "Teric";
+		if (btName.startsWith("Peregrine")) product = "Peregrine";
 		if (btName.startsWith("NERD")) product = "Nerd"; // next line might override this
 		if (btName.startsWith("NERD 2")) product = "Nerd 2";
 	} else if (btName.startsWith("EON Steel")) {

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -404,6 +404,14 @@ void BTDiscovery::discoverAddress(QString address)
 	}
 }
 
+void BTDiscovery::stopAgent()
+{
+	if (!discoveryAgent)
+		return;
+	qDebug() << "---> stopping the discovery agent";
+	discoveryAgent->stop();
+}
+
 bool isBluetoothAddress(const QString &address)
 {
 	return extractBluetoothAddress(address) != QString();
@@ -442,8 +450,10 @@ void saveBtDeviceInfo(const QString &devaddr, QBluetoothDeviceInfo deviceInfo)
 
 QBluetoothDeviceInfo getBtDeviceInfo(const QString &devaddr)
 {
-	if (btDeviceInfo.contains(devaddr))
+	if (btDeviceInfo.contains(devaddr)) {
+		BTDiscovery::instance()->stopAgent();
 		return btDeviceInfo[devaddr];
+	}
 	if(!btDeviceInfo.keys().contains(devaddr)) {
 		qDebug() << "still looking scan is still running, we should just wait for a few moments";
 		// wait for a maximum of 30 more seconds
@@ -451,8 +461,10 @@ QBluetoothDeviceInfo getBtDeviceInfo(const QString &devaddr)
 		QElapsedTimer timer;
 		timer.start();
 		do {
-			if (btDeviceInfo.keys().contains(devaddr))
+			if (btDeviceInfo.keys().contains(devaddr)) {
+				BTDiscovery::instance()->stopAgent();
 				return btDeviceInfo[devaddr];
+			}
 			QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
 			QThread::msleep(100);
 		} while (timer.elapsed() < 30000);

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -398,15 +398,6 @@ void BTDiscovery::discoverAddress(QString address)
 	QString btAddress;
 	btAddress = extractBluetoothAddress(address);
 
-#if defined(Q_OS_MACOS)
-	// macOS appears to need a fresh scan if we want to switch devices
-	static QString lastAddress;
-	if (lastAddress != address) {
-		btDeviceInfo.clear();
-		discoveryAgent->stop();
-		lastAddress = address;
-	}
-#endif
 	if (!btDeviceInfo.keys().contains(address) && !discoveryAgent->isActive()) {
 		qDebug() << "restarting discovery agent";
 		discoveryAgent->start();

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -47,6 +47,7 @@ public:
 	void btDeviceDiscoveredMain(const btPairedDevice &device);
 	bool btAvailable() const;
 	void showNonDiveComputers(bool show);
+	void stopAgent();
 
 #if defined(Q_OS_ANDROID)
 	void getBluetoothDevices();

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -141,7 +141,7 @@ static const struct uud_match serial_service_uuids[] = {
 	{ "98ae7120-e62e-11e3-badd-0002a5d5c51b", "Suunto (EON Steel/Core, G5)" },
 	{ "cb3c4555-d670-4670-bc20-b61dbc851e9a", "Pelagic (i770R, i200C, Pro Plus X, Geo 4.0)" },
 	{ "fdcdeaaa-295d-470e-bf15-04217b7aa0a0", "ScubaPro G2"},
-	{ "fe25c237-0ece-443c-b0aa-e02033e7029d", "Shearwater (Perdix/Teric)" },
+	{ "fe25c237-0ece-443c-b0aa-e02033e7029d", "Shearwater (Perdix/Teric/Peregrine)" },
 	{ NULL, }
 };
 

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -235,9 +235,12 @@ void BtDeviceSelectionDialog::currentItemChanged(QListWidgetItem *item, QListWid
 	bool enableSaveButton = true;
 
 #if !defined(Q_OS_WIN)
-	// On other platforms than Windows we can obtain the pairing status so if the devices are not paired we disable the button
-	// except on MacOS for those devices that only give us a Uuid and not and address (as we have no pairing status for those, either)
-	if (!remoteDeviceInfo.address().isNull()) {
+	// On platforms other than Windows we can obtain the pairing status so if the devices are non-BLE devices
+	// and not paired we disable the button
+	// on MacOS some devices (including all BLE devices) only give us a Uuid and not and address; for those
+	// we have no pairing status, either
+	if (!remoteDeviceInfo.address().isNull() &&
+	    remoteDeviceInfo.coreConfigurations() != QBluetoothDeviceInfo::LowEnergyCoreConfiguration) {
 		QBluetoothLocalDevice::Pairing pairingStatus = localDevice->pairingStatus(remoteDeviceInfo.address());
 
 		if (pairingStatus == QBluetoothLocalDevice::Unpaired) {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] New feature
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->
This changes a couple of things:
- on macOS, don't force that additional round of detection; it doesn't seem necessary
- stop scanning of BT/BLE device once we have the device we are looking for
- delay scanning of characteristic details until after all services have been detected
- add the Peregrine to the recognized dive computers

Important: this will only work with firmware v79 of the Peregrine or newer

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
#2911 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
done

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger - please stop laughing about my lambdas and sanity check what I'm doing there
@torvalds - please look at the subtle changes to the BLE code and make sure this still works with the dive computers you have