### PR TITLE
desktop: fix div-by-zero when selecting multiple invalid dives

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -75,7 +75,7 @@ void TabDiveStatistics::updateData()
 	stats_t stats_selection;
 	calculate_stats_selected(&stats_selection);
 	clear();
-	if (amount_selected > 1) {
+	if (amount_selected > 1 && stats_selection.selection_size >= 1) {
 		ui->depthLimits->setMaximum(get_depth_string(stats_selection.max_depth, true));
 		ui->depthLimits->setMinimum(get_depth_string(stats_selection.min_depth, true));
 		ui->depthLimits->setAverage(get_depth_string(stats_selection.combined_max_depth.mm / stats_selection.selection_size, true));


### PR DESCRIPTION
Signed-off-by: Tim Segers <tsegers@pm.me>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When selecting a dive trip with no valid dives and more than one invalid dive, the calculation on [line 81](https://github.com/subsurface/subsurface/blob/18c0fa37d1769a7cd1c666b0afd7a9e90f11a517/desktop-widgets/tab-widgets/TabDiveStatistics.cpp#L81) of `TabDiveStatistics.cpp`, specifically in `TabDiveStatistics::updateData()`, will crash the application with a floating point exception.

This patch adds a check to make sure that at least one valid dive is selected.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #3332