### PR TITLE
replace QRegExp with QRegularExpression

### DIFF
--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -16,6 +16,7 @@
 #include "core/pref.h"
 #include "core/sample.h"
 #include "core/selection.h"
+#include "core/taxonomy.h"
 #include "exportfuncs.h"
 
 // Default implementation of the export callback: do nothing / never cancel
@@ -119,14 +120,10 @@ void export_TeX(const char *filename, bool selected_only, bool plain, ExportCall
 		struct tm tm;
 		utc_mkdate(dive->when, &tm);
 
+		const char *country = NULL;
 		dive_site *site = dive->dive_site;
-		QRegExp ct("countrytag: (\\w+)");
-		QString country;
-		if (site && ct.indexIn(site->notes) >= 0)
-			country = ct.cap(1);
-		else
-			country = "";
-
+		if (site)
+			country = taxonomy_get_country(&site->taxonomy);
 		pressure_t delta_p = {.mbar = 0};
 
 		QString star = "*";
@@ -158,7 +155,7 @@ void export_TeX(const char *filename, bool selected_only, bool plain, ExportCall
 		site ? put_format(&buf, "\\def\\%sgpslat{%f}\n", ssrf, site->location.lat.udeg / 1000000.0) : put_format(&buf, "\\def\\%sgpslat{}\n", ssrf);
 		site ? put_format(&buf, "\\def\\%sgpslon{%f}\n", ssrf, site->location.lon.udeg / 1000000.0) : put_format(&buf, "\\def\\gpslon{}\n");
 		put_format(&buf, "\\def\\%scomputer{%s}\n", ssrf, dive->dc.model);
-		put_format(&buf, "\\def\\%scountry{%s}\n", ssrf, qPrintable(country));
+		put_format(&buf, "\\def\\%scountry{%s}\n", ssrf, country ?: "");
 		put_format(&buf, "\\def\\%stime{%u:%02u}\n", ssrf, FRACTION(dive->duration.seconds, 60));
 
 		put_format(&buf, "\n%% Dive Profile Details:\n");

--- a/core/divesitehelpers.cpp
+++ b/core/divesitehelpers.cpp
@@ -19,6 +19,7 @@
 #include <QUrlQuery>
 #include <QEventLoop>
 #include <QTimer>
+#include <QRegularExpression>
 #include <memory>
 
 /** Performs a REST get request to a service returning a JSON object. */
@@ -87,19 +88,19 @@ taxonomy_data reverseGeoLookup(degrees_t latitude, degrees_t longitude)
 	taxonomy_data taxonomy = { 0, 0 };
 
 	// check the oceans API to figure out the body of water
-	url = geonamesOceanURL.arg(getUiLanguage().section(QRegExp("[-_ ]"), 0, 0)).arg(latitude.udeg / 1000000.0).arg(longitude.udeg / 1000000.0);
+	url = geonamesOceanURL.arg(getUiLanguage().section(QRegularExpression("[-_ ]"), 0, 0)).arg(latitude.udeg / 1000000.0).arg(longitude.udeg / 1000000.0);
 	obj = doAsyncRESTGetRequest(url, 5000); // 5 secs. timeout
 	QVariantMap oceanName = obj.value("ocean").toVariant().toMap();
 	if (oceanName["name"].isValid())
 		taxonomy_set_category(&taxonomy, TC_OCEAN, qPrintable(oceanName["name"].toString()), taxonomy_origin::GEOCODED);
 
 	// check the findNearbyPlaces API from geonames - that should give us country, state, city
-	url = geonamesNearbyPlaceNameURL.arg(getUiLanguage().section(QRegExp("[-_ ]"), 0, 0)).arg(latitude.udeg / 1000000.0).arg(longitude.udeg / 1000000.0);
+	url = geonamesNearbyPlaceNameURL.arg(getUiLanguage().section(QRegularExpression("[-_ ]"), 0, 0)).arg(latitude.udeg / 1000000.0).arg(longitude.udeg / 1000000.0);
 	obj = doAsyncRESTGetRequest(url, 5000); // 5 secs. timeout
 	QVariantList geoNames = obj.value("geonames").toVariant().toList();
 	if (geoNames.count() == 0) {
 		// check the findNearby API from geonames if the previous search came up empty - that should give us country, state, location
-		url = geonamesNearbyURL.arg(getUiLanguage().section(QRegExp("[-_ ]"), 0, 0)).arg(latitude.udeg / 1000000.0).arg(longitude.udeg / 1000000.0);
+		url = geonamesNearbyURL.arg(getUiLanguage().section(QRegularExpression("[-_ ]"), 0, 0)).arg(latitude.udeg / 1000000.0).arg(longitude.udeg / 1000000.0);
 		obj = doAsyncRESTGetRequest(url, 5000); // 5 secs. timeout
 		geoNames = obj.value("geonames").toVariant().toList();
 	}

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -7,7 +7,7 @@
 #include <QShortcut>
 #include <QDrag>
 #include <QMimeData>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QUndoStack>
 #include <QPainter>
 #include "core/filterpreset.h"
@@ -121,7 +121,7 @@ int ColumnNameProvider::rowCount(const QModelIndex&) const
 int ColumnNameProvider::mymatch(QString value) const
 {
 	QString searchString = value.toLower();
-	QRegExp re(" \\(.*\\)");
+	QRegularExpression re(" \\(.*\\)");
 
 	searchString.replace("\"", "").replace(re, "").replace(" ", "").replace(".", "").replace("\n","");
 	for (int i = 0; i < columnNames.count(); i++) {
@@ -894,12 +894,15 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 			} else {
 				xml_params params;
 
-				QRegExp apdRe("^.*[/\\][0-9a-zA-Z]*_([0-9]{6})_([0-9]{6})\\.apd");
 				if (txtLog) {
 					parseTxtHeader(fileNames[i], params);
-				} else if (apdRe.exactMatch(fileNames[i])) {
-					xml_params_add(&params, "date", qPrintable("20" + apdRe.cap(1)));
-					xml_params_add(&params, "time", qPrintable("1" + apdRe.cap(2)));
+				} else {
+					QRegularExpression apdRe("^.*[/\\][0-9a-zA-Z]*_([0-9]{6})_([0-9]{6})\\.apd\\z");
+					QRegularExpressionMatch match = apdRe.match(fileNames[i]);
+					if (match.hasMatch()) {
+						xml_params_add(&params, "date", qPrintable("20" + match.captured(1)));
+						xml_params_add(&params, "time", qPrintable("1" + match.captured(2)));
+					}
 				}
 				setup_csv_params(r, params);
 				parse_csv_file(qPrintable(fileNames[i]), &params,
@@ -944,12 +947,16 @@ void DiveLogImportDialog::on_buttonBox_accepted()
 			} else {
 				xml_params params;
 
-				QRegExp apdRe("^.*[/\\][0-9a-zA-Z]*_([0-9]{6})_([0-9]{6})\\.apd");
 				if (txtLog) {
 					parseTxtHeader(fileNames[i], params);
-				} else if (apdRe.exactMatch(fileNames[i])) {
-					xml_params_add(&params, "date", qPrintable("20" + apdRe.cap(1)));
-					xml_params_add(&params, "time", qPrintable("1" + apdRe.cap(2)));
+				} else {
+					QRegularExpression apdRe("\\A^.*[/\\][0-9a-zA-Z]*_([0-9]{6})_([0-9]{6})\\.apd\\z");
+					QRegularExpressionMatch match = apdRe.match(fileNames[i]);
+					if (match.hasMatch()) {
+						xml_params_add(&params, "date", qPrintable("20" + match.captured(1)));
+						xml_params_add(&params, "time", qPrintable("1" + match.captured(2)));
+					}
+
 				}
 				setup_csv_params(r, params);
 				parse_csv_file(qPrintable(fileNames[i]), &params,

--- a/desktop-widgets/preferences/preferences_language.cpp
+++ b/desktop-widgets/preferences/preferences_language.cpp
@@ -95,14 +95,14 @@ void PreferencesLanguage::syncSettings()
 	refreshSettings();
 
 	QString qDateTimeWeb = tr("These will be used as is. This might not be what you intended.\nSee http://doc.qt.io/qt-5/qdatetime.html#toString");
-	QRegExp tfillegalchars("[^hHmszaApPt\\s:;\\.,]");
-	if (tfillegalchars.indexIn(ui->timeFormatEntry->currentText()) >= 0)
+	QRegularExpression tfillegalchars("[^hHmszaApPt\\s:;\\.,]");
+	if (tfillegalchars.match(ui->timeFormatEntry->currentText()).hasMatch())
 		QMessageBox::warning(this, tr("Literal characters"),
 			tr("Non-special character(s) in time format.\n") + qDateTimeWeb);
 
-	QRegExp dfillegalchars("[^dMy/\\s:;\\.,\\-]");
-	if (dfillegalchars.indexIn(ui->dateFormatEntry->currentText()) >= 0 ||
-	    dfillegalchars.indexIn(ui->shortDateFormatEntry->text()) >= 0)
+	QRegularExpression dfillegalchars("[^dMy/\\s:;\\.,\\-]");
+	if (dfillegalchars.match(ui->dateFormatEntry->currentText()).hasMatch() ||
+	    dfillegalchars.match(ui->shortDateFormatEntry->text()).hasMatch())
 		QMessageBox::warning(this, tr("Literal characters"),
 			tr("Non-special character(s) in date format.\n") + qDateTimeWeb);
 }

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -177,7 +177,7 @@ ShiftImageTimesDialog::ShiftImageTimesDialog(QWidget *parent, QStringList fileNa
 	matchAllImages(false)
 {
 	ui.setupUi(this);
-	ui.timeEdit->setValidator(new QRegExpValidator(QRegExp("\\d{0,6}:[0-5]\\d")));
+	ui.timeEdit->setValidator(new QRegularExpressionValidator(QRegularExpression("\\d{0,6}:[0-5]\\d")));
 	connect(ui.syncCamera, SIGNAL(clicked()), this, SLOT(syncCameraClicked()));
 	connect(ui.timeEdit, &QLineEdit::textEdited, this, &ShiftImageTimesDialog::timeEdited);
 	connect(ui.backwards, &QCheckBox::toggled, this, &ShiftImageTimesDialog::backwardsChanged);
@@ -249,10 +249,11 @@ void ShiftImageTimesDialog::timeEdited(const QString &timeText)
 	if (ui.timeEdit->hasAcceptableInput()) {
 		ui.timeEdit->setStyleSheet("");
 		// parse based on the same reg exp used to validate...
-		QRegExp re("(\\d{0,6}):(\\d\\d)");
-		if (re.indexIn(timeText) != -1) {
-			time_t hours = re.cap(1).toInt();
-			time_t minutes = re.cap(2).toInt();
+		QRegularExpression re("(\\d{0,6}):(\\d\\d)");
+		QRegularExpressionMatch match = re.match(timeText);
+		if (match.hasMatch()) {
+			time_t hours = match.captured(1).toInt();
+			time_t minutes = match.captured(2).toInt();
 			m_amount = (ui.backwards->isChecked() ? -1 : 1) * (3600 * hours + 60 * minutes);
 			updateInvalid();
 		}
@@ -579,7 +580,7 @@ QString TextHyperlinkEventFilter::fromCursorTilWhitespace(QTextCursor *cursor, b
 		  "mn.abcd." for the url (wrong). So we have to go to 'i', to
 		  capture "mn.abcd.edu " (with trailing space), and then clean it up.
 		*/
-		QStringList list = grownText.split(QRegExp("\\s"), SKIP_EMPTY);
+		QStringList list = grownText.split(QRegularExpression("\\s"), SKIP_EMPTY);
 		if (!list.isEmpty()) {
 			result = list[0];
 		}

--- a/qt-models/messagehandlermodel.cpp
+++ b/qt-models/messagehandlermodel.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "messagehandlermodel.h"
 #include "core/qthelper.h"
+#include "QRegularExpression"
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 extern void writeToAppLogFile(QString logText);
@@ -40,7 +41,7 @@ void MessageHandlerModel::addLog(QtMsgType type, const QString& message)
 			return;
 	}
 	// filter extremely noisy and unhelpful messages
-	if (message.contains("Updating RSSI for") || (message.contains(QRegExp(".*kirigami.*onFoo properties in Connections"))))
+	if (message.contains("Updating RSSI for") || (message.contains(QRegularExpression(".*kirigami.*onFoo properties in Connections"))))
 		return;
 
 	beginInsertRows(QModelIndex(), rowCount(), rowCount());


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->
Qt 6 no longer supports the ancient `QRegExp` (that was basically the Qt 4 class that was supposed to be replaced by Qt 5's new `QRegularExpression`). This pull request replaces the dozen or so instances where we for some reason used `QRegExp`.
Using that class is slightly less verbose (which might be why we used it), but other than that there is no real advantage to it.

Of course, mechanical rip-and-replace efforts like this are fraught with risk. I'd really appreciate some solid review here.

@atdotde the first commit should be correct - but I have some serious questions about the use of the `site->notes` field here, vs using the taxonomy...

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
rip and replace
`exactMatch()` doesn't exist anymore - so work around that with anchored patterns -- oh, one of those `exactMatch()` calls (that's the last commit) was completely bogus, given the pattern itself.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
well... this is required for any attempt to port to Qt 6.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger I'd love a critical eye
@tcanabrava if you have a moment :)
@atdotde 