### PR TITLE
Don't limit make to -j4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,6 +57,12 @@ jobs:
         qtpositioning5-dev qtscript5-dev qttools5-dev qttools5-dev-tools \
         qtquickcontrols2-5-dev xvfb libbluetooth-dev libmtp-dev libraw-dev
 
+    - name: set environment variables
+      id: set-variables
+      run: |
+        NUM_CORES=$(nproc)
+        echo "number-cores=$NUM_CORES" >> $GITHUB_OUTPUT
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -68,6 +74,8 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Build
+      env:
+        MAKEFLAGS: "j${{ steps.set-variables.outputs.number-cores }}"
       run: |
         cd ..
         git config --global --add safe.directory $GITHUB_WORKSPACE

--- a/packaging/android/qmake-build.sh
+++ b/packaging/android/qmake-build.sh
@@ -34,6 +34,7 @@ QUICK=""
 ARCHITECTURES=""
 BUILD_ABIS=""
 versionOnly=""
+PLATFORM=$(uname)
 
 while [ "$#" -gt 0 ] ; do
 	case "$1" in
@@ -120,6 +121,17 @@ else
 	exit 1
 fi
 
+# Use all cores, unless user set their own MAKEFLAGS
+if [[ -z "${MAKEFLAGS+x}" ]]; then
+	if [[ ${PLATFORM} == "Linux" ]]; then
+		MAKEFLAGS="-j$(nproc)"
+	elif [[ ${PLATFORM} == "Darwin" ]]; then
+		MAKEFLAGS="-j$(sysctl -n hw.logicalcpu)"
+	else
+		MAKEFLAGS="-j4"
+	fi
+fi
+
 QMAKE=$QT5_ANDROID/android/bin/qmake
 echo $QMAKE
 $QMAKE -query
@@ -182,7 +194,7 @@ if [ "$QUICK" = "" ] ; then
 	    mkdir -p googlemaps-build
 	    pushd googlemaps-build
 	    $QMAKE ANDROID_ABIS="$BUILD_ABIS" ../googlemaps/googlemaps.pro
-	    make -j4
+	    make
             make install
 	    popd
 	fi

--- a/scripts/build-libdivecomputer.sh
+++ b/scripts/build-libdivecomputer.sh
@@ -20,6 +20,16 @@ fi
 
 ../configure --disable-examples --prefix=$INSTALL_ROOT
 
+# Use all cores, unless user set their own MAKEFLAGS
+if [[ -z "${MAKEFLAGS+x}" ]]; then
+	if [[ ${PLATFORM} == "Linux" ]]; then
+		MAKEFLAGS="-j$(nproc)"
+	elif [[ ${PLATFORM} == "Darwin" ]]; then
+		MAKEFLAGS="-j$(sysctl -n hw.logicalcpu)"
+	else
+		MAKEFLAGS="-j4"
+	fi
+fi
 
 make -j4
 make install


### PR DESCRIPTION

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [X] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Current build system hard-codes "make -j4" which may be problematic if you have fewer than 4 cores, and is inefficient if you have a lot more. I suggest users should `export MAKEFLAGS="-j$(nproc)"` or similar to have make build on as many cores as they want.

### Changes made:
1) Removed all " -j4" strings from Makefile.

### Documentation change:
It may be worth adding `export MAKEFLAGS="-j$(nproc)"` to the documentation and I can do that if others feel it should be done.
