### PR TITLE
Planner: Improve CCR Bailout and Backgas Break Options.

### DIFF
--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -712,6 +712,9 @@ planner_error_t plan(struct deco_state *ds, struct diveplan &diveplan, struct di
 	if (inappropriate_cylinder_use) {
 		error = PLAN_ERROR_INAPPROPRIATE_GAS;
 	}
+	if (prefs.dobailout && best_first_ascend_cylinder == -1) {
+		error = PLAN_ERROR_NO_SUITABLE_BAILOUT_GAS;
+	}
 	if (prefs.doo2breaks) {
 		if (best_first_ascend_cylinder != -1 && get_o2(dive->get_cylinder(best_first_ascend_cylinder)->gasmix) <= 320)
 			break_cylinder = best_first_ascend_cylinder;

--- a/core/planner.h
+++ b/core/planner.h
@@ -28,6 +28,7 @@ typedef enum {
 	PLAN_OK,
 	PLAN_ERROR_TIMEOUT,
 	PLAN_ERROR_INAPPROPRIATE_GAS,
+	PLAN_ERROR_NO_SUITABLE_BAILOUT_GAS,
 } planner_error_t;
 
 struct diveplan {

--- a/core/plannernotes.cpp
+++ b/core/plannernotes.cpp
@@ -128,6 +128,11 @@ void diveplan::add_plan_to_notes(struct dive &dive, bool show_disclaimer, planne
 				"Please change them to appropriate tanks to enable the generation of a dive plan.");
 
 			break;
+		case PLAN_ERROR_NO_SUITABLE_BAILOUT_GAS:
+			message = translate("gettextFromC", "No suitable gas for OC bailout at the planned final depth found in the gaslist. "
+				"Please add an OC gas with an MOD suitable for the planned final depth to enable the generation of a dive plan.");
+
+			break;
 		default:
 			message = translate("gettextFromC", "An error occurred during dive plan generation!");
 

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -309,17 +309,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode, divemode_t divemode)
 		ui.gflow->setDisabled(true);
 		ui.gfhigh->setDisabled(true);
 		ui.lastStop->setDisabled(false);
-		if (prefs.last_stop) {
-			ui.backgasBreaks->setDisabled(false);
-			ui.backgasBreaks->blockSignals(true);
-			ui.backgasBreaks->setChecked(prefs.doo2breaks);
-			ui.backgasBreaks->blockSignals(false);
-		} else {
-			ui.backgasBreaks->setDisabled(true);
-			ui.backgasBreaks->blockSignals(true);
-			ui.backgasBreaks->setChecked(false);
-			ui.backgasBreaks->blockSignals(false);
-		}
+		ui.backgasBreaks->setDisabled(false);
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
@@ -342,17 +332,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode, divemode_t divemode)
 		ui.gflow->setDisabled(false);
 		ui.gfhigh->setDisabled(false);
 		ui.lastStop->setDisabled(false);
-		if (prefs.last_stop) {
-			ui.backgasBreaks->setDisabled(false);
-			ui.backgasBreaks->blockSignals(true);
-			ui.backgasBreaks->setChecked(prefs.doo2breaks);
-			ui.backgasBreaks->blockSignals(false);
-		} else {
-			ui.backgasBreaks->setDisabled(true);
-			ui.backgasBreaks->blockSignals(true);
-			ui.backgasBreaks->setChecked(false);
-			ui.backgasBreaks->blockSignals(false);
-		}
+		ui.backgasBreaks->setDisabled(false);
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
@@ -369,24 +349,6 @@ void PlannerSettingsWidget::disableDecoElements(int mode, divemode_t divemode)
 		ui.sacfactor->setValue(PlannerShared::sacfactor());
 		ui.problemsolvingtime->setValue(prefs.problemsolvingtime);
 		ui.display_variations->setDisabled(false);
-	}
-}
-
-void PlannerSettingsWidget::disableBackgasBreaks(bool enabled)
-{
-	if (prefs.planner_deco_mode == RECREATIONAL)
-		return;
-
-	if (enabled) {
-		ui.backgasBreaks->setDisabled(false);
-		ui.backgasBreaks->blockSignals(true);
-		ui.backgasBreaks->setChecked(prefs.doo2breaks);
-		ui.backgasBreaks->blockSignals(false);
-	} else {
-		ui.backgasBreaks->setDisabled(true);
-		ui.backgasBreaks->blockSignals(true);
-		ui.backgasBreaks->setChecked(false);
-		ui.backgasBreaks->blockSignals(false);
 	}
 }
 
@@ -426,7 +388,6 @@ PlannerSettingsWidget::PlannerSettingsWidget(PlannerWidgets *parent)
 	connect(ui.vpmb_deco, &QAbstractButton::clicked, [] { PlannerShared::set_planner_deco_mode(VPMB); });
 
 	connect(ui.lastStop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setLastStop6m);
-	connect(ui.lastStop, &QAbstractButton::toggled, this, &PlannerSettingsWidget::disableBackgasBreaks);
 	connect(ui.verbatim_plan, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setVerbatim);
 	connect(ui.display_duration, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDisplayDuration);
 	connect(ui.display_runtime, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDisplayRuntime);

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -57,7 +57,6 @@ public
 slots:
 	void settingsChanged();
 	void setBackgasBreaks(bool dobreaks);
-	void disableBackgasBreaks(bool enabled);
 	void diveModeChanged(int mode);
 
 private:

--- a/desktop-widgets/diveplanner.h
+++ b/desktop-widgets/diveplanner.h
@@ -21,8 +21,9 @@ public:
 	explicit DivePlannerWidget(const dive &planned_dive, int &dcNr, PlannerWidgets *parent);
 	~DivePlannerWidget();
 	void setReplanButton(bool replan);
-	void setColumnVisibility(int mode);
+	void diveModeChanged(int mode);
 	void setDiveMode(int mode);
+	void disableDecoElements(int mode, divemode_t divemode);
 public
 slots:
 	void setupStartTime(QDateTime startTime);
@@ -51,13 +52,13 @@ class PlannerSettingsWidget : public QWidget {
 public:
 	explicit PlannerSettingsWidget(PlannerWidgets *parent);
 	~PlannerSettingsWidget();
+	void disableDecoElements(int mode, divemode_t divemode);
 public
 slots:
 	void settingsChanged();
 	void setBackgasBreaks(bool dobreaks);
-	void disableDecoElements(int mode, divemode_t divemode);
 	void disableBackgasBreaks(bool enabled);
-	void setBailoutVisibility(int mode);
+	void diveModeChanged(int mode);
 
 private:
 	Ui::plannerSettingsWidget ui;
@@ -98,7 +99,8 @@ public:
 public
 slots:
 	void printDecoPlan();
-	void setDiveMode(int mode);
+	void diveModeChanged(int mode);
+	void disableDecoElements(int mode, divemode_t divemode);
 private:
 	std::unique_ptr<dive> planned_dive;
 	int dcNr;

--- a/desktop-widgets/diveplanner.ui
+++ b/desktop-widgets/diveplanner.ui
@@ -148,6 +148,20 @@
          </property>
         </widget>
        </item>
+       <item row="2" column="2">
+        <widget class="QLabel" name="label_bailout">
+         <property name="text">
+          <string>Rebreather:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QCheckBox" name="bailout">
+         <property name="text">
+          <string>Deco on OC bailout</string>
+         </property>
+        </widget>
+       </item>
        <item row="2" column="3">
         <widget class="QLabel" name="label_3">
          <property name="text">

--- a/desktop-widgets/plannerSettings.ui
+++ b/desktop-widgets/plannerSettings.ui
@@ -255,7 +255,7 @@
           <property name="spacing">
            <number>2</number>
           </property>
-          <item row="3" column="2">
+          <item row="2" column="2">
            <widget class="QSpinBox" name="reserve_gas">
             <property name="suffix">
              <string>bar</string>
@@ -274,7 +274,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="4" column="1">
            <spacer name="verticalSpacer_6">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -287,7 +287,7 @@
             </property>
            </spacer>
           </item>
-          <item row="21" column="1" colspan="2">
+          <item row="20" column="1" colspan="2">
            <widget class="QCheckBox" name="switch_at_req_stop">
             <property name="toolTip">
              <string>Postpone gas change if a stop is not required</string>
@@ -297,14 +297,14 @@
             </property>
            </widget>
           </item>
-          <item row="17" column="1" colspan="2">
+          <item row="16" column="1" colspan="2">
            <widget class="QCheckBox" name="lastStop">
             <property name="text">
              <string>Last stop at 6m</string>
             </property>
            </widget>
           </item>
-          <item row="15" column="2">
+          <item row="14" column="2">
            <widget class="QSpinBox" name="vpmb_conservatism">
             <property name="prefix">
              <string>+</string>
@@ -314,7 +314,7 @@
             </property>
            </widget>
           </item>
-          <item row="11" column="2">
+          <item row="10" column="2">
            <widget class="QSpinBox" name="gfhigh">
             <property name="suffix">
              <string>%</string>
@@ -327,7 +327,7 @@
             </property>
            </widget>
           </item>
-          <item row="22" column="2">
+          <item row="21" column="2">
            <widget class="QSpinBox" name="min_switch_duration">
             <property name="suffix">
              <string>min</string>
@@ -346,14 +346,14 @@
             </property>
            </widget>
           </item>
-          <item row="19" column="1" colspan="2">
+          <item row="18" column="1" colspan="2">
            <widget class="QCheckBox" name="backgasBreaks">
             <property name="text">
              <string>Plan backgas breaks</string>
             </property>
            </widget>
           </item>
-          <item row="24" column="1">
+          <item row="23" column="1">
            <spacer name="verticalSpacer_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -366,21 +366,21 @@
             </property>
            </spacer>
           </item>
-          <item row="22" column="1">
+          <item row="21" column="1">
            <widget class="QLabel" name="label_min_switch_duration">
             <property name="text">
              <string>Min. switch duration O₂% below 100%</string>
             </property>
            </widget>
           </item>
-          <item row="16" column="1" colspan="2">
+          <item row="15" column="1" colspan="2">
            <widget class="QCheckBox" name="drop_stone_mode">
             <property name="text">
              <string>Drop to first depth</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="2">
+          <item row="9" column="2">
            <widget class="QSpinBox" name="gflow">
             <property name="suffix">
              <string>%</string>
@@ -393,7 +393,7 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="1">
+          <item row="9" column="1">
            <widget class="QLabel" name="label_gflow">
             <property name="text">
              <string>GFLow</string>
@@ -403,7 +403,7 @@
             </property>
            </widget>
           </item>
-          <item row="11" column="1">
+          <item row="10" column="1">
            <widget class="QLabel" name="label_gfhigh">
             <property name="text">
              <string>GFHigh</string>
@@ -413,7 +413,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="1" column="1">
            <widget class="QRadioButton" name="recreational_deco">
             <property name="toolTip">
              <string>Maximize bottom time allowed by gas and no decompression limits</string>
@@ -423,7 +423,7 @@
             </property>
            </widget>
           </item>
-          <item row="15" column="1">
+          <item row="14" column="1">
            <widget class="QLabel" name="label_vpmb_conservatism">
             <property name="text">
              <string>Conservatism level</string>
@@ -433,7 +433,7 @@
             </property>
            </widget>
           </item>
-          <item row="14" column="1">
+          <item row="13" column="1">
            <widget class="QRadioButton" name="vpmb_deco">
             <property name="text">
              <string>VPM-B deco</string>
@@ -453,7 +453,7 @@
             </property>
            </widget>
           </item>
-          <item row="12" column="1">
+          <item row="11" column="1">
            <spacer name="verticalSpacer_7">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -466,7 +466,7 @@
             </property>
            </spacer>
           </item>
-          <item row="15" column="1">
+          <item row="14" column="1">
            <spacer name="verticalSpacer_5">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -479,7 +479,7 @@
             </property>
            </spacer>
           </item>
-          <item row="6" column="1">
+          <item row="5" column="1">
            <widget class="QRadioButton" name="buehlmann_deco">
             <property name="text">
              <string>Bühlmann deco</string>
@@ -489,7 +489,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="2" column="1">
            <widget class="QLabel" name="label_reserve_gas">
             <property name="text">
              <string>Reserve gas</string>
@@ -499,21 +499,14 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="bailout">
-            <property name="text">
-             <string>Rebreather: Bailout / Deco on OC</string>
-            </property>
-           </widget>
-          </item>
-          <item row="23" column="1">
+          <item row="22" column="1">
            <widget class="QLabel" name="label_surface_segment">
             <property name="text">
              <string>Surface segment</string>
             </property>
            </widget>
           </item>
-          <item row="23" column="2">
+          <item row="22" column="2">
            <widget class="QSpinBox" name="surface_segment">
             <property name="suffix">
              <string>min</string>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Multiple small improvements to the planner.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- move the 'Deco on Bailout' option to the top of the planner to better fit with a typical CCR planning workflow;
- allow backgas breaks even with a 3m deco stop - the resulting plan is fit for purpose, and this is less confusing to the user;
- error out of the plan calculation for a CCR dive with 'OC bailout on deco' if no suitable OC bailout gas is defined.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

<img width="820" height="105" alt="image" src="https://github.com/user-attachments/assets/f513a21e-cbd7-4643-aebd-7ff625773288" />


<img width="834" height="486" alt="image" src="https://github.com/user-attachments/assets/bfe4a81a-c012-4acd-903a-679565a02e4b" />

<img width="1300" height="540" alt="image" src="https://github.com/user-attachments/assets/6ec402ee-df46-43cc-9d94-fd64fe0e9107" />


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
