### PR TITLE
Export dive sites as KML

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3242,8 +3242,8 @@ A dive log or part of it can be saved in several formats:
 
 * _Subsurface XML_ format. This is the native format used by _Subsurface_.
 
-* _Subsurface dive sites XML_. Export the dive sites in XML format. This allows the
-  sharing of dive sites with other divers or software.
+* _Dive sites_. Export the dive sites in Subsurface XML format. This allows the
+  sharing of dive sites with other divers or software. By selecting the "as KML" option, you can also export the dive sites to a file that can be imported to Google Earth and similar programs.
 
 * Universal Dive Data Format (_UDDF_). Refer to _https://uddf.org/_ for more information.
   UDDF is a generic format that enables communication among many dive computers

--- a/core/dive.h
+++ b/core/dive.h
@@ -186,7 +186,7 @@ extern int save_dives_logic(const char *filename, bool select_only, bool anonymi
 extern int save_dive(FILE *f, const struct dive &dive, bool anonymize);
 extern std::pair<int, std::string> export_dives_xslt(const char *filename, bool selected, const int units, const char *export_xslt, bool anonymize);
 
-extern int save_dive_sites_logic(const char *filename, const struct dive_site *sites[], int nr_sites, bool anonymize);
+extern int save_dive_sites_logic(const char *filename, const struct dive_site *sites[], int nr_sites, bool anonymize, bool kml);
 
 struct membuffer;
 extern void save_one_dive_to_mb(struct membuffer *b, const struct dive &dive, bool anonymize);

--- a/core/membuffer.cpp
+++ b/core/membuffer.cpp
@@ -207,6 +207,14 @@ void put_location(struct membuffer *b, const location_t *loc, const char *pre, c
 	}
 }
 
+void put_location_kml(struct membuffer *b, const location_t *loc, const char *pre, const char *post)
+{
+	if (has_location(loc)) {
+		put_degrees(b, loc->lon, pre, ",");
+		put_degrees(b, loc->lat, "", post);
+	}
+}
+
 void put_quoted(struct membuffer *b, const char *text, int is_attribute, int is_html)
 {
 	const char *p = text;

--- a/core/membuffer.h
+++ b/core/membuffer.h
@@ -85,5 +85,6 @@ extern void put_pressure(struct membuffer *, pressure_t, const char *, const cha
 extern void put_salinity(struct membuffer *, int, const char *, const char *);
 extern void put_degrees(struct membuffer *b, degrees_t value, const char *, const char *);
 extern void put_location(struct membuffer *b, const location_t *, const char *, const char *);
+extern void put_location_kml(struct membuffer *b, const location_t *, const char *, const char *);
 
 #endif

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -875,13 +875,41 @@ static void save_dive_sites_buffer(struct membuffer *b, const struct dive_site *
 	put_format(b, "</divesites>\n");
 }
 
-int save_dive_sites_logic(const char *filename, const struct dive_site *sites[], int nr_sites, bool anonymize)
+static void save_dive_sites_buffer_kml(struct membuffer *b, const struct dive_site *sites[], int nr_sites, bool anonymize)
+{
+	int i;
+	put_format(b, "<?xml version=\"1.0\"  encoding=\"UTF-8\"?>\n");
+	put_format(b, "<kml xmlns=\"http://www.opengis.net/kml/2.2\">\n<Document>\n");
+	put_format(b, "  <Style id=\"subsurfaceIcon\">\n");
+	put_format(b, "    <IconStyle>\n      <Icon>\n");
+	put_format(b, "        <href>data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAFVklEQVRYR62Xe1BUdRTHv3d32V2WdywBIjjGjKY8G1rwAZSTaTomqDVO01imlRWj04xTTkymAsKkpukfmo+aXj4TgZZQMU1NReUlGC2KIi95FJKwCMs+uJ3fxSVK2L3XPDN3Zufu+f3O555zfuf8DseTdHd3obS8BBwnA3gMKy4uLvT/8P9JeWuz2WC2WKCL0cHd3ROc0djJF5cUIzoqWso+/1u3ylCF6MhocMdPHOVjnoqBTEZfT9JjtqHPwhzBQ06vVAqZ8DyKr/8vdXnFFXBnzp7iO7gg6C80oK61Ez29fbBYbKDIQE6G5QQmk8mhUsrh7qqEl7sKPh4qaL3U8PdxRaCPGqO1bvDzVsKNdByBWm1AQ3sPiqrbca6yBcE+9GGrthfyJ4qbRwq9aFczWBXlicJFDqWCHhcZPQr095MvKa/umcz0cRaY+voG82xqhBbcG5l6/sr1dtGG7IosYkqFC0xm6/1XI2Svg50nh/uBWywA/CkZgC0I8tPg+ZgxCPH3wNYjleg0miTtMzn8cQJYn8eXP4QH2JFl8c7PnAVXlQK7fjJg/8/XpQGE2QGuiffAi/GhMPZYkBAZCKWcQ3xEgGB0T0E19hZWSwTwH/BAWfUfohYG+JGrU6aiw9iHCSHeg2u6eswoq7mDzw6Ww3iPkkykDIag1NDmdAk7jvs+mYGAxzQP6FY33kXlzQ6cKmuAoa7D6V52hbgw5oGMXF4MwLgQX+z+4NlhNzdR8brVakTK5l9gs/WLBwgPIID0XL7E0Op00cLpTyIlOfwBPSsZrG3phsVqxbubTjndZ6iCLkwAyOGLf3cOkPlOAhLuJ9zQTWxUaHbqq5B7pga9ffaaII4jdgDgCF9c5RiA9YkfP50LLzcl7nab4e2uHLRQ39aN19KPUcUT73r7Yt3EQJYDOfzl31ocIo+i7P9+9UxB54u8KqxYECH8ZmV2a/ZVZJ++RuVVeiV8eiJ54HXygDMAZkyjVlDl84DZytNpGIBhYrb2Y+X2IpQZmsT5fYiWLox5ID2bv3TVsQeG7szCUbhlvlD9ein7XakDsjqQsvksapuk9RRd+H2Ai5XNkuh3fDgT44O9sGzjSSycPh6zYsegrs2IN7NOoNckvhDpwkdRCNKy+YuVtyUBrHw1DvMTn8BzKw5Te7VgxqRQrFsSh/XflSD/V/H9IFYAWMcAxMfPV+uFjKVT6AKixksf5QjgWh8N9Bvm4csCA/bklIn+mNiIIMqBtYf5CyIBWPy/Wj0bvp5qpGwsRENr16Cxr9fMQW2zEWm7z0gF+IE/XyHOAwkxoUhdFIO3s46hse0f48zinIRxSFkQjaRVOTBTWORyOTQaNXRhQQjwdRNuSd/oS8HT0bVLXORo8sA6AihvdEodHKTFtvenYVdeBY6eezDOKqUCBVtexr6TN4Rb0hSq8+NHe+NOlwnnr97G6ZJ6VNb8u+nFRQazHCAA6mKORK1W4UBGEto7e/FWhn7EmpO6NBHJ8WPRcucejl+qR2HRTdxoGrk7TooSAA7x55wAsKvP0c8X4tilBmzdd2FEVn9fd7qeeaLU0IJ+EZVxUlQIAaw96ByAleDUOWj7qwdrdkjreI48KwAsJoCzpfVOc2D3x0k0H3BYmpbrVFesQjxdaLll6w/xhUW3nK75Nm0egrQemLl8L6w03z0KmTctFNyO/Xp+w96qEYdSu6FXXoiCp5sKO7MvPwrbkNHcl7VkwsBwunxTPh0TOgnSO+rDwdB1PjlxLNLfmw3OPp4fKDiNipu91OH6QaOhZJFxPOzTu4Ku63I22TIZMtKzn5RGCBujwaK5zwjj+d8nJRk5l/zfUgAAAABJRU5ErkJggg==</href>\n");
+	put_format(b, "      </Icon>\n    </IconStyle>\n");
+	put_format(b, "  </Style>\n>");
+
+	/* save the dive sites */
+	for (i = 0; i < nr_sites; i++) {
+		const struct dive_site *ds = sites[i];
+
+		put_format(b, "  <Placemark>\n");
+		show_utf8_blanked(b, ds->name.c_str(), "    <name>", "</name>\n", 1, anonymize);
+		put_format(b, "    <styleUrl>#subsurfaceIcon</styleUrl>\n");
+		show_utf8_blanked(b, ds->description.c_str(), "    <description>", "</description>\n", 1, anonymize);
+		put_location_kml(b, &ds->location, "    <Point>\n      <coordinates>", "</coordinates>\n    </Point>\n");
+		put_format(b, "  </Placemark>\n");
+	}
+	put_format(b, "</Document>\n</kml>\n");
+}
+
+int save_dive_sites_logic(const char *filename, const struct dive_site *sites[], int nr_sites, bool anonymize, bool kml)
 {
 	membuffer buf;
 	FILE *f;
 	int error = 0;
 
-	save_dive_sites_buffer(&buf, sites, nr_sites, anonymize);
+	if (kml)
+		save_dive_sites_buffer_kml(&buf, sites, nr_sites, anonymize);
+	else
+		save_dive_sites_buffer(&buf, sites, nr_sites, anonymize);
 
 	if (same_string(filename, "-")) {
 		f = stdout;

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -201,14 +201,20 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 				save_dives_logic(bt.data(), ui->exportSelected->isChecked(), ui->anonymize->isChecked());
 			}
 		} else if (ui->exportSubsurfaceSitesXML->isChecked()) {
-			filename = QFileDialog::getSaveFileName(this, tr("Export Subsurface dive sites XML"), lastDir,
-								tr("Subsurface files") + " (*.xml)");
+			bool kml = ui->kml->isChecked();
+			if (kml)
+				filename = QFileDialog::getSaveFileName(this, tr("Export dive sites as KML"), lastDir,
+									tr("Subsurface files") + " (*.kml)");
+			else
+				filename = QFileDialog::getSaveFileName(this, tr("Export Subsurface dive sites XML"), lastDir,
+									tr("Subsurface files") + " (*.xml)");
+
 			if (!filename.isEmpty()) {
 				if (!filename.contains('.'))
-					filename.append(".xml");
+					filename.append(kml ? ".kml" : ".xml");
 				QByteArray bt = QFile::encodeName(filename);
 				auto sites = getDiveSitesToExport(ui->exportSelected->isChecked());
-				save_dive_sites_logic(bt.data(), sites.data(), (int)sites.size(), ui->anonymize->isChecked());
+				save_dive_sites_logic(bt.data(), sites.data(), (int)sites.size(), ui->anonymize->isChecked(), kml);
 			}
 		} else if (ui->exportImageDepths->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save image depths"), lastDir);

--- a/desktop-widgets/divelogexportdialog.ui
+++ b/desktop-widgets/divelogexportdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>507</width>
-    <height>556</height>
+    <height>572</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -191,6 +191,22 @@
               <string>Dive info in profile</string>
              </property>
             </widget>
+            <widget class="QCheckBox" name="kml">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="geometry">
+              <rect>
+               <x>10</x>
+               <y>110</y>
+               <width>92</width>
+               <height>24</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>as KML</string>
+             </property>
+            </widget>
            </widget>
           </item>
          </layout>
@@ -224,7 +240,7 @@
           <item>
            <widget class="QRadioButton" name="exportSubsurfaceSitesXML">
             <property name="text">
-             <string>Subsurface dive sites XML</string>
+             <string>Dive sites</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">exportGroup</string>
@@ -776,9 +792,25 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>exportSubsurfaceSitesXML</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>kml</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>145</x>
+     <y>114</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>342</x>
+     <y>267</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="exportGroup"/>
   <buttongroup name="buttonGroup"/>
+  <buttongroup name="exportGroup"/>
  </buttongroups>
 </ui>

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2198,7 +2198,7 @@ void QMLManager::exportToFile(export_types type, QString dir, bool anonymize)
 		case EX_DIVE_SITES_XML:
 			{
 				auto sites = getDiveSitesToExport(false);
-				save_dive_sites_logic(qPrintable(fileName + ".xml"), sites.data(), (int)sites.size(), anonymize);
+				save_dive_sites_logic(qPrintable(fileName + ".xml"), sites.data(), (int)sites.size(), anonymize, false);
 				break;
 			}
 		default:
@@ -2246,7 +2246,7 @@ void QMLManager::shareViaEmail(export_types type, bool anonymize)
 		fileName.replace("subsurface.log", "subsurface_divesites.xml");
 		{ // need a block so the compiler doesn't complain about creating the sites variable here
 			auto sites = getDiveSitesToExport(false);
-			if (save_dive_sites_logic(qPrintable(fileName), sites.data(), (int)sites.size(), anonymize) == 0) {
+			if (save_dive_sites_logic(qPrintable(fileName), sites.data(), (int)sites.size(), anonymize, false) == 0) {
 				// ok, we have a file, let's send it
 				body = "Subsurface dive site data";
 			} else {


### PR DESCRIPTION
Offer to export the dive sites as a KML file that can be opened in Google Earth and similar.

This is user request from the google group.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
