### PR TITLE
Mobile: Add CCR Support for the Dive Planner.

### DIFF
--- a/Documentation/user-manual_de.txt
+++ b/Documentation/user-manual_de.txt
@@ -2267,7 +2267,7 @@ Zeigen Sie Änderungen an der verwendeten Gasflasche an, indem Sie die Gaswechse
 
 Die für den Plan verwendeten Flaschen müssen in der Tabelle „Verfügbare Gase“ eingetragen werden. Wählen Sie in der Spalte „Typ“ die passende Flaschengröße aus, indem Sie auf eine Zelle in dieser Spalte doppelklicken. Standardmäßig sind zahlreiche Größen verfügbar. Sie können eine neue Flaschengröße erstellen, indem Sie diese in das Textfeld eingeben. Flaschengröße, Startdruck und Standard-Umschalttiefen werden automatisch initialisiert. Geben Sie die Gaszusammensetzung (z. B. Helium- und Sauerstoffgehalt) und – bei der Planung eines CCR-Tauchgangs – die beabsichtigte Verwendung als Verdünnungsgas oder OC-Bailout-Gas an. Bei der Planung von CCR-Tauchgängen wird ein Segment als geschlossenes Kreislaufsegment berechnet, wenn das verwendete Gas ein Verdünnungsgas ist, und als offenes Kreislaufsegment, wenn es sich um ein OC-Gas handelt. Wenn der Benutzer in den Einstellungen des „Tech-Setups“ die Option „Verwendung von offenem Kreislaufgas als Bailout zulassen“ aktiviert, wird eine zusätzliche Spalte angezeigt, in der der Benutzer den „Tauchmodus“ für jedes mit einem „OC-Gas“ getauchte Segment auswählen kann.
 
-image::images/Planner_OC_gas_for_CCR.png["Abbildung: Tauchplaner: OC Gas als Bailout",align="center"]
+image::images/Planner_OC_gas_for_CCR.png["Abbildung: Tauchplaner: OC-Gas als Bailout",align="center"]
 
 Für CCR-Tauchgänge wird in der Tabelle „Punkte des Tauchplaners“ eine zusätzliche Spalte angezeigt, in der der Benutzer den Sollwert für jedes Segment mit geschlossenem Kreislauf festlegen kann.
 

--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -347,7 +347,7 @@ struct gaschanges {
 	int gasidx;
 };
 
-// Return new setpoint if cylinderi is a setpoint change an 0 if not
+// Return new setpoint if cylinderid is a setpoint change and 0 if not
 
 static int setpoint_change(struct dive *dive, int cylinderid)
 {

--- a/core/plannernotes.cpp
+++ b/core/plannernotes.cpp
@@ -346,7 +346,7 @@ void diveplan::add_plan_to_notes(struct dive &dive, bool show_disclaimer, planne
 							newgasmix.name().c_str(), temp.c_str());
 					} else {
 						buf += format_string_std("<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>",
-							newgasmix.name().c_str(), dp->divemode == UNDEF_COMP_TYPE || dp->divemode == nextdp->divemode ? "" : translate("gettextFromC", divemode_text_ui[nextdp->divemode]));
+							newgasmix.name().c_str(), dive.dcs[0].divemode == OC || dp->divemode == UNDEF_COMP_TYPE || dp->divemode == nextdp->divemode ? "" : translate("gettextFromC", divemode_text_ui[nextdp->divemode]));
 						if (isascent && (get_he(lastprintgasmix) > 0)) { // For a trimix gas change on ascent, save ICD info if previous cylinder had helium
 							if (isobaric_counterdiffusion(lastprintgasmix, newgasmix, &icdvalues)) // Do icd calulations
 								icdwarning = true;
@@ -367,7 +367,7 @@ void diveplan::add_plan_to_notes(struct dive &dive, bool show_disclaimer, planne
 						buf += format_string_std("<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>", gasmix.name().c_str(), temp.c_str());
 					} else {
 						buf += format_string_std("<td style='padding-left: 10px; color: red; float: left;'><b>%s %s</b></td>", gasmix.name().c_str(),
-							   lastdivemode == UNDEF_COMP_TYPE || lastdivemode == dp->divemode ? "" : translate("gettextFromC", divemode_text_ui[dp->divemode]));
+							   dive.dcs[0].divemode == OC || dp->divemode == UNDEF_COMP_TYPE || lastdivemode == dp->divemode ? "" : translate("gettextFromC", divemode_text_ui[dp->divemode]));
 						if (get_he(lastprintgasmix) > 0) {  // For a trimix gas change, save ICD info if previous cylinder had helium
 							if (isobaric_counterdiffusion(lastprintgasmix, gasmix, &icdvalues))  // Do icd calculations
 								icdwarning = true;

--- a/core/plannernotes.cpp
+++ b/core/plannernotes.cpp
@@ -130,7 +130,7 @@ void diveplan::add_plan_to_notes(struct dive &dive, bool show_disclaimer, planne
 			break;
 		case PLAN_ERROR_NO_SUITABLE_BAILOUT_GAS:
 			message = translate("gettextFromC", "No suitable gas for OC bailout at the planned final depth found in the gaslist. "
-				"Please add an OC gas with an MOD suitable for the planned final depth to enable the generation of a dive plan.");
+				"Please add an OC-gas with an MOD suitable for the planned final depth to enable the generation of a dive plan.");
 
 			break;
 		default:

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -126,12 +126,9 @@ DivePlannerWidget::~DivePlannerWidget()
 void DivePlannerWidget::disableDecoElements(int mode, divemode_t divemode)
 {
 	if (mode == RECREATIONAL) {
-		ui.label_bailout->setVisible(false);
 		ui.bailout->setVisible(false);
 	} else if (mode == VPMB || mode == BUEHLMANN) {
-		bool isRebreatherDive = IS_REBREATHER_MODE(divemode);
-		ui.label_bailout->setVisible(isRebreatherDive);
-		ui.bailout->setVisible(isRebreatherDive);
+		ui.bailout->setVisible(IS_REBREATHER_MODE(divemode));
 	}
 }
 

--- a/desktop-widgets/diveplanner.ui
+++ b/desktop-widgets/diveplanner.ui
@@ -148,13 +148,6 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="2">
-        <widget class="QLabel" name="label_bailout">
-         <property name="text">
-          <string>Rebreather:</string>
-         </property>
-        </widget>
-       </item>
        <item row="3" column="2">
         <widget class="QCheckBox" name="bailout">
          <property name="text">

--- a/desktop-widgets/plannerSettings.ui
+++ b/desktop-widgets/plannerSettings.ui
@@ -213,6 +213,13 @@
                </property>
               </widget>
              </item>
+             <item row="1" column="0" colspan="2">
+              <widget class="QCheckBox" name="drop_stone_mode">
+               <property name="text">
+                <string>Drop to first depth</string>
+               </property>
+              </widget>
+             </item>
             </layout>
             <zorder>descRate</zorder>
             <zorder>descent</zorder>
@@ -287,7 +294,7 @@
             </property>
            </spacer>
           </item>
-          <item row="20" column="1" colspan="2">
+          <item row="19" column="1" colspan="2">
            <widget class="QCheckBox" name="switch_at_req_stop">
             <property name="toolTip">
              <string>Postpone gas change if a stop is not required</string>
@@ -297,7 +304,7 @@
             </property>
            </widget>
           </item>
-          <item row="16" column="1" colspan="2">
+          <item row="15" column="1" colspan="2">
            <widget class="QCheckBox" name="lastStop">
             <property name="text">
              <string>Last stop at 6m</string>
@@ -327,7 +334,7 @@
             </property>
            </widget>
           </item>
-          <item row="21" column="2">
+          <item row="20" column="2">
            <widget class="QSpinBox" name="min_switch_duration">
             <property name="suffix">
              <string>min</string>
@@ -346,14 +353,14 @@
             </property>
            </widget>
           </item>
-          <item row="18" column="1" colspan="2">
+          <item row="17" column="1" colspan="2">
            <widget class="QCheckBox" name="backgasBreaks">
             <property name="text">
              <string>Plan backgas breaks</string>
             </property>
            </widget>
           </item>
-          <item row="23" column="1">
+          <item row="22" column="1">
            <spacer name="verticalSpacer_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -366,17 +373,10 @@
             </property>
            </spacer>
           </item>
-          <item row="21" column="1">
+          <item row="20" column="1">
            <widget class="QLabel" name="label_min_switch_duration">
             <property name="text">
              <string>Min. switch duration O₂% below 100%</string>
-            </property>
-           </widget>
-          </item>
-          <item row="15" column="1" colspan="2">
-           <widget class="QCheckBox" name="drop_stone_mode">
-            <property name="text">
-             <string>Drop to first depth</string>
             </property>
            </widget>
           </item>
@@ -499,14 +499,14 @@
             </property>
            </widget>
           </item>
-          <item row="22" column="1">
+          <item row="21" column="1">
            <widget class="QLabel" name="label_surface_segment">
             <property name="text">
              <string>Surface segment</string>
             </property>
            </widget>
           </item>
-          <item row="22" column="2">
+          <item row="21" column="2">
            <widget class="QSpinBox" name="surface_segment">
             <property name="suffix">
              <string>min</string>

--- a/mobile-widgets/qml/DivePlannerEdit.qml
+++ b/mobile-widgets/qml/DivePlannerEdit.qml
@@ -259,20 +259,19 @@ TemplatePage {
 			}
 		}
 		RowLayout {
-			Layout.fillWidth: true
 			spacing: Kirigami.Units.smallSpacing // Reduced spacing
 
 			// Header labels updated for new layout
 			TemplateLabel { text: qsTr("#"); Layout.preferredWidth: Kirigami.Units.gridUnit * 2; font.bold: true }
-			TemplateLabel { text: qsTr("Type"); Layout.preferredWidth: Kirigami.Units.gridUnit * 6; font.bold: true }
-			TemplateLabel { text: qsTr("Mix"); Layout.preferredWidth: Kirigami.Units.gridUnit * 4; font.bold: true }
+			TemplateLabel { text: qsTr("Type"); Layout.minimumWidth: Kirigami.Units.gridUnit * 8; Layout.maximumWidth: Kirigami.Units.gridUnit * 8; font.bold: true }
+			TemplateLabel { text: qsTr("Mix"); Layout.preferredWidth: Kirigami.Units.gridUnit * 3; font.bold: true }
 			TemplateLabel {
-				text: qsTr("Use");
-				Layout.preferredWidth: Kirigami.Units.gridUnit * 5;
+				text: qsTr("Dil");
+				Layout.preferredWidth: Kirigami.Units.gridUnit * 3;
 				visible: overallDivemode.currentIndex == 1
 				font.bold: true
 			}
-			TemplateLabel { text: qsTr("[%1]").arg(pressureUnit); Layout.fillWidth: true; font.bold: true }
+			TemplateLabel { text: qsTr("[%1]").arg(pressureUnit); Layout.preferredWidth: Kirigami.Units.gridUnit * 4; font.bold: true }
 			Item { Layout.preferredWidth: Kirigami.Units.iconSizes.medium }
 		}
 
@@ -284,7 +283,6 @@ TemplatePage {
 			model: cylinderListModel
 
 			delegate: RowLayout {
-				width: cylinderListView.width
 				spacing: Kirigami.Units.smallSpacing // Reduced spacing
 
 				TemplateLabel {
@@ -295,7 +293,8 @@ TemplatePage {
 				}
 				TemplateComboBox {
 					id: typeBox
-					Layout.preferredWidth: Kirigami.Units.gridUnit * 10
+					Layout.minimumWidth: Kirigami.Units.gridUnit * 8
+					Layout.maximumWidth: Kirigami.Units.gridUnit * 8
 					model: cylinderTypesModel
 					currentIndex: model.indexOf(type)
 					onActivated: {
@@ -310,7 +309,7 @@ TemplatePage {
 				}
 				TemplateTextField {
 					id: mixField
-					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
 					text: mix
 					onTextChanged: {
 						cylinderListModel.setProperty(index, "mix", text);
@@ -337,19 +336,20 @@ TemplatePage {
 					validator: RegExpValidator { regExp: /(EAN100|EAN\d\d|AIR|100|\d{0,2}|\d{0,2}\/\d{0,2})/i }
 					onActiveFocusChanged: cylinderListView.interactive = !activeFocus
 				}
-				TemplateComboBox {
-					Layout.preferredWidth: Kirigami.Units.gridUnit * 5
-					model: [ qsTr("OC-gas"), qsTr("diluent") ]
-					currentIndex: use
+				TemplateCheckBox {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+					// Map the model's 'use' property (0 or 1) to the checkbox state (false or true)
+					checked: use === 1
 					visible: overallDivemode.currentIndex == 1
-					onCurrentIndexChanged: {
-						cylinderListModel.setProperty(index, "use", currentIndex);
+					onClicked: {
+						// Update 'use': if checked is true, set 'use' to 1 (Diluent); otherwise, set to 0 (OC-gas)
+						cylinderListModel.setProperty(index, "use", checked ? 1 : 0);
 						generatePlan();
 					}
 				}
 				TemplateTextField {
 					id: pressureField
-					Layout.fillWidth: true
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 					text: pressure.toString()
 					validator: IntValidator { bottom: 0; top: 10000 }
 					onTextChanged: {
@@ -403,33 +403,32 @@ TemplatePage {
 		}
 
 		RowLayout {
-			Layout.fillWidth: true
 			spacing: Kirigami.Units.gridUnit
 
 			TemplateLabel {
 				text: qsTr("Depth [%1]").arg(depthUnit);
-				Layout.fillWidth: true;
+				Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 				font.bold: true
 			}
 			TemplateLabel {
-				text: qsTr("Duration [min]");
-				Layout.fillWidth: true;
+				text: qsTr("Time [min]");
+				Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 				font.bold: true
 			}
 			TemplateLabel {
 				text: qsTr("Gas");
-				Layout.fillWidth: true;
+				Layout.preferredWidth: Kirigami.Units.gridUnit * 5
 				font.bold: true;
 			}
 			TemplateLabel {
 				text: qsTr("Setpoint [bar]");
-				Layout.fillWidth: true;
+				Layout.preferredWidth: Kirigami.Units.gridUnit * 5
 				font.bold: true;
 				visible: overallDivemode.currentIndex == 1;
 			}
 			TemplateLabel {
 				text: qsTr("Dive Mode");
-				Layout.fillWidth: true;
+				Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 				font.bold: true;
 				visible: overallDivemode.currentIndex == 2;
 			}
@@ -444,11 +443,10 @@ TemplatePage {
 
 			model: segmentListModel
 			delegate: RowLayout {
-				width: segmentListView.width
 				spacing: Kirigami.Units.gridUnit
 
 				TemplateTextField {
-					Layout.fillWidth: true
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 					text: depth.toString()
 					validator: IntValidator { bottom: 0; top: 900 }
 					onTextChanged: {
@@ -459,7 +457,7 @@ TemplatePage {
 				}
 
 				TemplateTextField {
-					Layout.fillWidth: true
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
 					text: duration.toString()
 					validator: IntValidator { bottom: 1; top: 999 }
 					onTextChanged: {
@@ -470,8 +468,7 @@ TemplatePage {
 				}
 
 				TemplateComboBox {
-					Layout.fillWidth: true
-					Layout.minimumWidth: Kirigami.Units.gridUnit * 6
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 5
 					model: gasNumberModel
 					currentIndex: gas
 					onCurrentIndexChanged: {
@@ -482,7 +479,7 @@ TemplatePage {
 				}
 
 				TemplateTextField {
-					Layout.fillWidth: true
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 5
 					text: cylinderListModel.get(gas) && cylinderListModel.get(gas).use === 1 ? (setpoint / 1000.0).toFixed(2) : ""
 					validator: DoubleValidator {
 						bottom: 0.16;
@@ -502,8 +499,7 @@ TemplatePage {
 				}
 
 				TemplateComboBox {
-					Layout.fillWidth: true
-					Layout.minimumWidth: Kirigami.Units.gridUnit * 6
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 6
 					model: [ qsTr("OC"), qsTr("pSCR") ]
 					// Skip CCR (value === 1) as it's not applicable for pSCR mode
 					currentIndex: divemode === 2 ? 1 : divemode

--- a/mobile-widgets/qml/DivePlannerEdit.qml
+++ b/mobile-widgets/qml/DivePlannerEdit.qml
@@ -40,7 +40,7 @@ TemplatePage {
 					"type": item.type,
 					"mix": item.mix,
 					"pressure": item.pressure,
-					"use": diveMode.currentIndex == 1 ? item.use : 0,
+					"use": overallDivemode.currentIndex == 1 ? item.use : 0,
 				})
 			}
 
@@ -59,7 +59,7 @@ TemplatePage {
 					"duration": descentDuration,
 					"gas": firstSegment.gas,
 					"setpoint": firstSegment.setpoint,
-					"divemode": firstSegment.localDiveMode,
+					"divemode": firstSegment.divemode,
 				})
 				if (descentDuration < firstSegment.duration) {
 					segmentData.push({
@@ -67,7 +67,7 @@ TemplatePage {
 						"duration": firstSegment.duration - descentDuration,
 						"gas": firstSegment.gas,
 						"setpoint": firstSegment.setpoint,
-						"divemode": firstSegment.localDiveMode,
+						"divemode": firstSegment.divemode,
 					});
 				}
 			}
@@ -78,7 +78,7 @@ TemplatePage {
 					"duration": item.duration,
 					"gas": item.gas,
 					"setpoint": item.setpoint,
-					"divemode": item.localDiveMode,
+					"divemode": item.divemode,
 				})
 			}
 			var salinity = 0
@@ -94,7 +94,7 @@ TemplatePage {
 
 			var planResult = Backend.divePlannerPointsModel.calculatePlan(
 				cylinderData, segmentData, planDate.text, planTime.text,
-				diveMode.currentIndex, salinity, savePlan
+				overallDivemode.currentIndex, salinity, savePlan
 			)
 			if (savePlan) {
 				var newDiveId = planResult.newDiveId
@@ -199,9 +199,9 @@ TemplatePage {
 				verticalAlignment: Text.AlignVCenter
 			}
 			TemplateComboBox {
-				id: diveMode
+				id: overallDivemode
 				Layout.fillWidth: true
-				model: [qsTr("Open circuit"), qsTr("CCR"), qsTr("pSCR")]
+				model: [ qsTr("Open circuit"), qsTr("CCR"), qsTr("pSCR") ]
 				currentIndex: 0 // Default to OC
 				onCurrentIndexChanged: {
 					generatePlan();
@@ -211,7 +211,7 @@ TemplatePage {
 				text: qsTr("Deco on OC bailout")
 				Layout.columnSpan: 2
 				checked: Backend.dobailout
-				visible: diveMode.currentIndex !== 0
+				visible: overallDivemode.currentIndex !== 0
 				onClicked: {
 					Backend.dobailout = checked;
 					generatePlan();
@@ -224,7 +224,7 @@ TemplatePage {
 			TemplateComboBox {
 				id: waterTypeBox
 				Layout.fillWidth: true
-				model: [qsTr("Sea Water"), qsTr("Fresh Water"), qsTr("EN13319")]
+				model: [ qsTr("Sea Water"), qsTr("Fresh Water"), qsTr("EN13319") ]
 				currentIndex: 0 // Default to Sea water
 				onCurrentIndexChanged: {
 					generatePlan();
@@ -269,14 +269,14 @@ TemplatePage {
 			TemplateLabel {
 				text: qsTr("Use");
 				Layout.preferredWidth: Kirigami.Units.gridUnit * 5;
-				visible: diveMode.currentIndex == 1
+				visible: overallDivemode.currentIndex == 1
 				font.bold: true
 			}
 			TemplateLabel { text: qsTr("[%1]").arg(pressureUnit); Layout.fillWidth: true; font.bold: true }
 			Item { Layout.preferredWidth: Kirigami.Units.iconSizes.medium }
 		}
 
-				ListView {
+		ListView {
 			id: cylinderListView
 			Layout.fillWidth: true
 			Layout.preferredHeight: Math.min(contentHeight, Kirigami.Units.gridUnit * 8)
@@ -341,7 +341,7 @@ TemplatePage {
 					Layout.preferredWidth: Kirigami.Units.gridUnit * 5
 					model: [ qsTr("OC-gas"), qsTr("diluent") ]
 					currentIndex: use
-					visible: diveMode.currentIndex == 1
+					visible: overallDivemode.currentIndex == 1
 					onCurrentIndexChanged: {
 						cylinderListModel.setProperty(index, "use", currentIndex);
 						generatePlan();
@@ -394,7 +394,7 @@ TemplatePage {
 							"duration": 10,
 							"gas": lastSegment.gas,
 							"setpoint": lastSegment.setpoint,
-							"divemode": lastSegment.localDiveMode,
+							"divemode": lastSegment.divemode,
 						});
 						generatePlan();
 					}
@@ -406,20 +406,32 @@ TemplatePage {
 			Layout.fillWidth: true
 			spacing: Kirigami.Units.gridUnit
 
-			TemplateLabel { text: qsTr("Depth [%1]").arg(depthUnit); Layout.fillWidth: true; font.bold: true }
-			TemplateLabel { text: qsTr("Duration [min]"); Layout.fillWidth: true; font.bold: true }
-			TemplateLabel { text: qsTr("Gas"); Layout.fillWidth: true; font.bold: true }
+			TemplateLabel {
+				text: qsTr("Depth [%1]").arg(depthUnit);
+				Layout.fillWidth: true;
+				font.bold: true
+			}
+			TemplateLabel {
+				text: qsTr("Duration [min]");
+				Layout.fillWidth: true;
+				font.bold: true
+			}
+			TemplateLabel {
+				text: qsTr("Gas");
+				Layout.fillWidth: true;
+				font.bold: true;
+			}
 			TemplateLabel {
 				text: qsTr("Setpoint [bar]");
 				Layout.fillWidth: true;
 				font.bold: true;
-				visible: diveMode.currentIndex == 1
+				visible: overallDivemode.currentIndex == 1;
 			}
 			TemplateLabel {
 				text: qsTr("Dive Mode");
 				Layout.fillWidth: true;
 				font.bold: true;
-				visible: diveMode.currentIndex == 2
+				visible: overallDivemode.currentIndex == 2;
 			}
 			Item { Layout.preferredWidth: Kirigami.Units.iconSizes.medium } // Spacer
 		}
@@ -461,7 +473,6 @@ TemplatePage {
 					Layout.fillWidth: true
 					Layout.minimumWidth: Kirigami.Units.gridUnit * 6
 					model: gasNumberModel
-
 					currentIndex: gas
 					onCurrentIndexChanged: {
 						segmentListModel.setProperty(index, "gas", currentIndex)
@@ -492,14 +503,13 @@ TemplatePage {
 
 				TemplateComboBox {
 					Layout.fillWidth: true
-					model: [
-						{ value: 0, text: sTr("OC") },
-						{ value: 2, text: qsTr("pSCR") },
-					]
-					currentIndex: localDiveMode
-					visible: diveMode.currentIndex == 2
+					Layout.minimumWidth: Kirigami.Units.gridUnit * 6
+					model: [ qsTr("OC"), qsTr("pSCR") ]
+					// Skip CCR (value === 1) as it's not applicable for pSCR mode
+					currentIndex: divemode === 2 ? 1 : divemode
+					visible: overallDivemode.currentIndex == 2
 					onCurrentIndexChanged: {
-						segmentListModel.setProperty(index, "divemode", currentIndex);
+						segmentListModel.setProperty(index, "divemode", currentIndex === 1 ? 2 : currentIndex);
 						generatePlan();
 					}
 					onActiveFocusChanged: segmentListView.interactive = !activeFocus

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -62,8 +62,6 @@ TemplatePage {
 					to: 99
 					stepSize: 1
 					value: Backend.ascrate75
-					textFromValue: function (value) { return value.toString() }
-					valueFromText: function(text) { return parseInt(text) }
 					onValueModified: {
 						Backend.ascrate75 = value
 						rootItem.settingsChanged()
@@ -78,8 +76,6 @@ TemplatePage {
 					to: 99
 					stepSize: 1
 					value: Backend.ascrate50
-					textFromValue: function (value) { return value.toString() }
-					valueFromText: function(text) { return parseInt(text) }
 					onValueModified: {
 						Backend.ascrate50 = value
 						rootItem.settingsChanged()
@@ -94,8 +90,6 @@ TemplatePage {
 					to: 99
 					stepSize: 1
 					value: Backend.ascratestops
-					textFromValue: function (value) { return value.toString() }
-					valueFromText: function(text) { return parseInt(text) }
 					onValueModified: {
 						Backend.ascratestops = value
 						rootItem.settingsChanged()
@@ -110,8 +104,6 @@ TemplatePage {
 					to: 99
 					stepSize: 1
 					value: Backend.ascratelast6m
-					textFromValue: function (value) { return value.toString() }
-					valueFromText: function(text) { return parseInt(text) }
 					onValueModified: {
 						Backend.ascratelast6m = value
 						rootItem.settingsChanged()
@@ -132,8 +124,6 @@ TemplatePage {
 					stepSize: 1
 					value: Backend.descrate
 					enabled: Backend.drop_stone_mode
-					textFromValue: function (value) { return value.toString() }
-					valueFromText: function(text) { return parseInt(text) }
 					onValueModified: {
 						Backend.descrate = value
 						rootItem.settingsChanged()
@@ -338,9 +328,15 @@ TemplatePage {
 				TemplateSpinBox {
 					id: spinBottomsac
 					from: 1
-					to:  (Backend.volume === Enums.LITER) ? 85 : 300
+					to: (Backend.volume === Enums.LITER) ? 85 : 300
 					stepSize: 1
 					value: Backend.bottomsac
+					validator: DoubleValidator {
+						bottom: (Backend.volume === Enums.LITER) ? 1 : 0.01;
+						top: (Backend.volume === Enums.LITER) ? 85 : 3.00;
+						decimals: (Backend.volume === Enums.LITER) ? 0 : 2;
+						notation: DoubleValidator.StandardNotation;
+					}
 					textFromValue: function (value) {
 						return (Backend.volume === Enums.LITER) ?
 								   value.toString() : (value / 100).toFixed(2)
@@ -362,6 +358,12 @@ TemplatePage {
 					to: (Backend.volume === Enums.LITER) ? 85 : 300
 					stepSize: 1
 					value: Backend.decosac
+					validator: DoubleValidator {
+						bottom: (Backend.volume === Enums.LITER) ? 1 : 0.01;
+						top: (Backend.volume === Enums.LITER) ? 85 : 3.00;
+						decimals: (Backend.volume === Enums.LITER) ? 0 : 2;
+						notation: DoubleValidator.StandardNotation;
+					}
 					textFromValue: function (value) {
 						return (Backend.volume === Enums.LITER) ?
 								   value.toString() : (value / 100).toFixed(2)
@@ -382,6 +384,12 @@ TemplatePage {
 					to: 99
 					stepSize: 1
 					value: Backend.sacfactor
+					validator: DoubleValidator {
+						bottom: 0.1;
+						top: 9.9;
+						decimals: 1;
+						notation: DoubleValidator.StandardNotation;
+					}
 					textFromValue: function (value) {
 						return (value / 10).toFixed(1)
 					}
@@ -401,15 +409,13 @@ TemplatePage {
 					to: 9
 					stepSize: 1
 					value: Backend.problemsolvingtime
-					textFromValue: function (value) { return value.toString() }
-					valueFromText: function(text) { return parseInt(text) }
 					onValueModified: {
 						Backend.problemsolvingtime = value
 						rootItem.settingsChanged()
 					}
 				}
 				TemplateLabel {
-					text: qsTr("Bottom pO₂ [%1]").arg(pressureUnit)
+					text: qsTr("Bottom pO₂ [bar]")
 				}
 				TemplateSpinBox {
 					from: 0
@@ -428,7 +434,7 @@ TemplatePage {
 					}
 				}
 				TemplateLabel {
-					text: qsTr("Deco pO₂ [%1]").arg(pressureUnit)
+					text: qsTr("Deco pO₂ [bar]")
 				}
 				TemplateSpinBox {
 					from: 0
@@ -456,7 +462,7 @@ TemplatePage {
 					value: Backend.default_setpoint || 1300
 					validator: DoubleValidator {
 						bottom: 0.16;
-						top: 2000;
+						top: 2.00;
 						decimals: 2;
 						notation: DoubleValidator.StandardNotation;
 					}
@@ -480,8 +486,6 @@ TemplatePage {
 					to: 99
 					stepSize: 1
 					value: Backend.bestmixend
-					textFromValue: function (value) { return value.toString() }
-					valueFromText: function(text) { return parseInt(text) }
 					onValueModified: {
 						Backend.bestmixend = value
 						rootItem.settingsChanged()

--- a/mobile-widgets/qml/DivePlannerSetup.qml
+++ b/mobile-widgets/qml/DivePlannerSetup.qml
@@ -102,7 +102,7 @@ TemplatePage {
 					}
 				}
 				TemplateLabel {
-					text: qsTr("6m to surface [%1]").arg(speedUnit)
+					text: qsTr("6m / 20ft to surface [%1]").arg(speedUnit)
 				}
 				TemplateSpinBox {
 					id: spinAscratelast6m
@@ -162,12 +162,6 @@ TemplatePage {
 				TemplateLabel {
 					text: qsTr("Dive mode")
 				}
-				//Divemode moved to plan edit
-				TemplateCheckBox {
-					text: qsTr("Bailout: Deco on OC")
-					Layout.columnSpan: 2
-					checked: Backend.dobailout
-				}
 
 				TemplateRadioButton {
 					text: qsTr("Recreational mode")
@@ -224,7 +218,7 @@ TemplatePage {
 					from: 1
 					to: 150
 					stepSize: 1
-					value: Backend.planner_gflow || 30
+					value: Backend.planner_gflow || PrefTechnicalDetails.gflow
 					onValueModified: {
 						Backend.planner_gflow = value
 						rootItem.settingsChanged()
@@ -239,7 +233,7 @@ TemplatePage {
 					from: 1
 					to: 150
 					stepSize: 1
-					value: Backend.planner_gfhigh || 70
+					value: Backend.planner_gfhigh || PrefTechnicalDetails.gfhigh
 					onValueModified: {
 						Backend.planner_gfhigh = value
 						rootItem.settingsChanged()
@@ -275,8 +269,8 @@ TemplatePage {
 					text: qsTr("Last stop at 20'/6m")
 					Layout.columnSpan: 2
 					onClicked: {
-						Backend.last_stop6m = checked
-						rootItem.settingsChanged()
+						Backend.last_stop6m = checked;
+						rootItem.settingsChanged();
 					}
 				}
 
@@ -285,7 +279,7 @@ TemplatePage {
 					Layout.columnSpan: 2
 					checked: Backend.doo2breaks
 					onClicked: {
-						Backend.doo2breaks = checked
+						Backend.doo2breaks = checked;
 					}
 				}
 
@@ -294,8 +288,8 @@ TemplatePage {
 					Layout.columnSpan: 2
 					checked: Backend.switch_at_req_stop
 					onClicked: {
-						Backend.switch_at_req_stop = checked
-						rootItem.settingsChanged()
+						Backend.switch_at_req_stop = checked;
+						rootItem.settingsChanged();
 					}
 				}
 
@@ -453,6 +447,31 @@ TemplatePage {
 					}
 				}
 				TemplateLabel {
+					text: qsTr("CCR Default ppO₂ [bar]")
+				}
+				TemplateSpinBox {
+					from: 160
+					to: 2000
+					stepSize: 50
+					value: Backend.default_setpoint || 1300
+					validator: DoubleValidator {
+						bottom: 0.16;
+						top: 2000;
+						decimals: 2;
+						notation: DoubleValidator.StandardNotation;
+					}
+					textFromValue: function (value) {
+						return (value / 1000).toFixed(2)
+					}
+					valueFromText: function (text) {
+						return Math.round(parseFloat(text) * 1000)
+					}
+					onValueModified: {
+						Backend.default_setpoint = value
+						rootItem.settingsChanged()
+					}
+				}
+				TemplateLabel {
 					text: qsTr("Best mix END [%1]").arg(depthUnit)
 				}
 				TemplateSpinBox {
@@ -472,7 +491,7 @@ TemplatePage {
 					text: qsTr("O2 narcotic")
 					checked: Backend.o2narcotic
 					onClicked: {
-						Backend.o2narcotic = checked
+						Backend.o2narcotic = checked;
 						rootItem.settingsChanged()
 					}
 				}
@@ -489,7 +508,7 @@ TemplatePage {
 					text: qsTr("Display runtime")
 					checked: Backend.display_runtime
 					onClicked: {
-						Backend.display_runtime = checked
+						Backend.display_runtime = checked;
 						rootItem.settingsChanged()
 					}
 				}

--- a/mobile-widgets/qmlinterface.cpp
+++ b/mobile-widgets/qmlinterface.cpp
@@ -75,6 +75,8 @@ QMLInterface::QMLInterface()
 			this, &QMLInterface::verbatim_planChanged);
 	connect(qPrefDivePlanner::instance(), &qPrefDivePlanner::display_variationsChanged,
 			this, &QMLInterface::display_variationsChanged);
+	connect(qPrefGeneral::instance(), &qPrefGeneral::defaultsetpointChanged,
+			this, &QMLInterface::default_setpointChanged);
 
 	connect(qPrefDiveComputer::instance(), &qPrefDiveComputer::sync_dc_timeChanged,
 			this, &QMLInterface::sync_dc_timeChanged);
@@ -87,7 +89,7 @@ void QMLInterface::setup(QQmlContext *ct)
 	ct->setContextProperty("Backend", &self);
 
 	// Make enums available as types
-	qmlRegisterUncreatableType<QMLInterface>("org.subsurfacedivelog.mobile",1,0,"Enums","Enum is not a type");
+	qmlRegisterUncreatableType<QMLInterface>("org.subsurfacedivelog.mobile", 1, 0, "Enums", "Enum is not a type");
 
 	qmlRegisterUncreatableType<DivePlannerPointsModel>("org.subsurfacedivelog.mobile", 1, 0, "DivePlannerPointsModel", "Planner model cannot be created in QML.");
 	qmlRegisterUncreatableType<CylindersModel>("org.subsurfacedivelog.mobile", 1, 0, "CylindersModel", "Cylinder model cannot be created in QML.");

--- a/mobile-widgets/qmlinterface.h
+++ b/mobile-widgets/qmlinterface.h
@@ -8,6 +8,7 @@
 #include "core/settings/qPrefDivePlanner.h"
 #include "core/settings/qPrefTechnicalDetails.h"
 #include "core/settings/qPrefDiveComputer.h"
+#include "core/settings/qPrefGeneral.h"
 #include "qt-models/diveplannermodel.h"
 #include "backend-shared/plannershared.h"
 
@@ -79,6 +80,7 @@ class QMLInterface : public QObject {
 	Q_PROPERTY(bool display_transitions READ display_transitions WRITE set_display_transitions NOTIFY display_transitionsChanged);
 	Q_PROPERTY(bool verbatim_plan READ verbatim_plan WRITE set_verbatim_plan NOTIFY verbatim_planChanged);
 	Q_PROPERTY(bool display_variations READ display_variations WRITE set_display_variations NOTIFY display_variationsChanged);
+	Q_PROPERTY(int default_setpoint READ default_setpoint WRITE set_default_setpoint NOTIFY default_setpointChanged);
 
 	Q_PROPERTY(bool sync_dc_time READ sync_dc_time WRITE set_sync_dc_time NOTIFY sync_dc_timeChanged);
 
@@ -218,6 +220,7 @@ public:
 	bool display_transitions() { return prefs.display_transitions; }
 	bool verbatim_plan() { return prefs.verbatim_plan; }
 	bool display_variations() { return prefs.display_variations; }
+	int default_setpoint() { return prefs.defaultsetpoint; }
 
 	bool sync_dc_time() { return prefs.sync_dc_time; }
 
@@ -273,6 +276,7 @@ public slots:
 	void set_display_transitions(bool value) { DivePlannerPointsModel::instance()->setDisplayTransitions(value); }
 	void set_verbatim_plan(bool value) { DivePlannerPointsModel::instance()->setVerbatim(value); }
 	void set_display_variations(bool value) { DivePlannerPointsModel::instance()->setDisplayVariations(value); }
+	void set_default_setpoint(int value) { qPrefGeneral::set_defaultsetpoint(value); }
 	void set_sync_dc_time(bool value) {
 		qPrefDiveComputer::set_sync_dc_time(value);
 		DCDeviceData::instance()->setSyncTime(value);
@@ -326,6 +330,7 @@ signals:
 	void display_transitionsChanged(bool value);
 	void verbatim_planChanged(bool value);
 	void display_variationsChanged(bool value);
+	void default_setpointChanged(int value);
 
 	void sync_dc_timeChanged(bool value);
 private:

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -333,6 +333,8 @@ QMLManager::QMLManager() :
 	// get updates to the undo/redo texts
 	connect(Command::getUndoStack(), &QUndoStack::undoTextChanged, this, &QMLManager::undoTextChanged);
 	connect(Command::getUndoStack(), &QUndoStack::redoTextChanged, this, &QMLManager::redoTextChanged);
+
+	prefs.allowOcGasAsDiluent = false;
 }
 
 void QMLManager::applicationStateChanged(Qt::ApplicationState state)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- Add Rebreather Support to the Dive Planner;
- Planner add CCR default ppO2;
- Improve planner settings grouping;
- Show dive mode for first segment (except for OC).

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@fnightfox: I finally got around to doing this, please review.
It actually turned out to be less involved than expected to make this work, probably because the changes in #4616 already fixed some of the issues. But then I ended up doing quite a few minor improvements to make this work well.

One problem with the mobile planner that I discovered when working on this is concerns the planner settings: All of the settings values are stored as metric values - this means that when subsurface is set to imperial units, the values need to be converted between the UI and the backend. I suspect that this will be quite gnarly and require a lot of boilerplate to fix in the frontend, and we could probably reuse this between mobile and desktop if we pushed this into the backend, but I can't quite see how to best do this - maybe you have an idea?