### PR TITLE
Qt6 warning cleanup

### DIFF
--- a/core/metadata.cpp
+++ b/core/metadata.cpp
@@ -284,8 +284,12 @@ static bool parseDate(const QString &s_in, timestamp_t &timestamp)
 	s.replace('-', ':');
 	QDateTime datetime = QDateTime::fromString(s, "yyyy:M:d h:m:s");
 	if (datetime.isValid()) {
-		// Not knowing any better, we suppose that time is give in UTC
-		datetime.setTimeSpec(Qt::UTC);
+		// Not knowing any better, we suppose that time is given in UTC
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+		datetime = QDateTime(datetime.date(), datetime.time(), QTimeZone(QTimeZone::UTC));
+#else
+		datetime = QDateTime(datetime.date(), datetime.time(), Qt::UTC);
+#endif
 		timestamp = dateTimeToTimestamp(datetime);
 		return true;
 	}
@@ -325,7 +329,11 @@ static bool parseDate(const QString &s_in, timestamp_t &timestamp)
 		return false;
 
 	// Not knowing any better, we suppose that time is give in UTC
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+	datetime = QDateTime(date, time, QTimeZone(QTimeZone::UTC));
+#else
 	datetime = QDateTime(date, time, Qt::UTC);
+#endif
 	if (datetime.isValid()) {
 		timestamp = dateTimeToTimestamp(datetime);
 		return true;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1402,7 +1402,9 @@ void parse_seabear_header(const char *filename, struct xml_params *params)
 {
 	QFile f(filename);
 
-	f.open(QFile::ReadOnly);
+	if (!f.open(QFile::ReadOnly))
+		return;
+
 	QString parseLine = f.readLine();
 
 	/*

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -691,7 +691,11 @@ QDateTime timestampToDateTime(timestamp_t when)
 {
 	// Subsurface always uses "local time" as in "whatever was the local time at the location"
 	// so all time stamps have no time zone information and are in UTC
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+	return QDateTime::fromMSecsSinceEpoch(1000 * when, QTimeZone::utc());
+#else
 	return QDateTime::fromMSecsSinceEpoch(1000 * when, Qt::UTC);
+#endif
 }
 
 timestamp_t dateTimeToTimestamp(const QDateTime &t)
@@ -701,10 +705,17 @@ timestamp_t dateTimeToTimestamp(const QDateTime &t)
 
 QString render_seconds_to_string(int seconds)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+	if (seconds % 60 == 0)
+		return QDateTime::fromSecsSinceEpoch(seconds, QTimeZone::utc()).toUTC().toString("h:mm");
+	else
+		return QDateTime::fromSecsSinceEpoch(seconds, QTimeZone::utc()).toUTC().toString("h:mm:ss");
+#else
 	if (seconds % 60 == 0)
 		return QDateTime::fromSecsSinceEpoch(seconds, Qt::UTC).toUTC().toString("h:mm");
 	else
 		return QDateTime::fromSecsSinceEpoch(seconds, Qt::UTC).toUTC().toString("h:mm:ss");
+#endif
 }
 
 int parseDurationToSeconds(const QString &text)

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -138,8 +138,13 @@ ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(const QString &filename
 	connect(ui.resetButton_4, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::resetSettings);
 	ui.chooseLogFile->setEnabled(ui.logToFile->isChecked());
 	connect(ui.chooseLogFile, &QToolButton::clicked, this, &ConfigureDiveComputerDialog::pickLogFile);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+	connect(ui.dateTimeSyncCheckBox, &QCheckBox::checkStateChanged, this, &ConfigureDiveComputerDialog::changeTimeSync);
+	connect(ui.logToFile, &QCheckBox::checkStateChanged, this, &ConfigureDiveComputerDialog::checkLogFile);
+#else
 	connect(ui.dateTimeSyncCheckBox, &QCheckBox::stateChanged, this, &ConfigureDiveComputerDialog::changeTimeSync);
 	connect(ui.logToFile, &QCheckBox::stateChanged, this, &ConfigureDiveComputerDialog::checkLogFile);
+#endif
 	connect(ui.connectButton, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::dc_open);
 	connect(ui.disconnectButton, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::dc_close);
 #ifdef BT_SUPPORT

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -448,21 +448,23 @@ void DiveLogImportDialog::loadFileContents(int value, whatChanged triggeredBy)
 	QPair<QString, QString> pair = poseidonFileNames(fileName);
 	if (!pair.second.isEmpty()) {
 		QFile f_txt(pair.second);
-		f_txt.open(QFile::ReadOnly);
-		QString firstLine = f_txt.readLine();
-		if (firstLine.startsWith("MkVI_Config ")) {
-			poseidon = true;
-			fileName = pair.first; // Read data from CSV
-			headers.append("Time");
-			headers.append("Depth");
-			blockSignals(true);
-			ui->knownImports->setCurrentText("Poseidon MkVI");
-			blockSignals(false);
+		if (f_txt.open(QFile::ReadOnly)) {
+			QString firstLine = f_txt.readLine();
+			if (firstLine.startsWith("MkVI_Config ")) {
+				poseidon = true;
+				fileName = pair.first; // Read data from CSV
+				headers.append("Time");
+				headers.append("Depth");
+				blockSignals(true);
+				ui->knownImports->setCurrentText("Poseidon MkVI");
+				blockSignals(false);
+			}
 		}
 	}
 
 	QFile f(fileName);
-	f.open(QFile::ReadOnly);
+	if (!f.open(QFile::ReadOnly))
+		return;
 	QString firstLine = f.readLine();
 	if (firstLine.contains("SEABEAR")) {
 		seabear = true;
@@ -844,7 +846,8 @@ void DiveLogImportDialog::parseTxtHeader(QString fileName, xml_params &params)
 	QString time;
 	QString line;
 
-	f.open(QFile::ReadOnly);
+	if (!f.open(QFile::ReadOnly))
+		return;
 	while ((line = f.readLine().trimmed()).length() >= 0 && !f.atEnd()) {
 		if (line.contains("Dive Profile")) {
 			f.readLine();

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -177,7 +177,11 @@ void ColumnNameView::dragEnterEvent(QDragEnterEvent *event)
 
 void ColumnNameView::dragMoveEvent(QDragMoveEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QModelIndex curr = indexAt(event->position().toPoint());
+#else
 	QModelIndex curr = indexAt(event->pos());
+#endif
 	if (!curr.isValid() || curr.row() != 0)
 		return;
 	event->acceptProposedAction();
@@ -212,7 +216,11 @@ void ColumnDropCSVView::dragEnterEvent(QDragEnterEvent *event)
 
 void ColumnDropCSVView::dragMoveEvent(QDragMoveEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QModelIndex curr = indexAt(event->position().toPoint());
+#else
 	QModelIndex curr = indexAt(event->pos());
+#endif
 	if (!curr.isValid() || curr.row() != 0)
 		return;
 	event->acceptProposedAction();
@@ -220,7 +228,11 @@ void ColumnDropCSVView::dragMoveEvent(QDragMoveEvent *event)
 
 void ColumnDropCSVView::dropEvent(QDropEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QModelIndex curr = indexAt(event->position().toPoint());
+#else
 	QModelIndex curr = indexAt(event->pos());
+#endif
 	if (!curr.isValid() || curr.row() != 0)
 		return;
 

--- a/desktop-widgets/divelogimportdialog.cpp
+++ b/desktop-widgets/divelogimportdialog.cpp
@@ -190,7 +190,7 @@ void ColumnNameView::dragMoveEvent(QDragMoveEvent *event)
 void ColumnNameView::dropEvent(QDropEvent *event)
 {
 	const QMimeData *mimeData = event->mimeData();
-	if (mimeData->data(subsurface_mimedata).count()) {
+	if (mimeData->data(subsurface_mimedata).size()) {
 		if (event->source() != this) {
 			event->acceptProposedAction();
 			QVariant value = QString(mimeData->data(subsurface_mimedata));
@@ -237,7 +237,7 @@ void ColumnDropCSVView::dropEvent(QDropEvent *event)
 		return;
 
 	const QMimeData *mimeData = event->mimeData();
-	if (!mimeData->data(subsurface_mimedata).count())
+	if (!mimeData->data(subsurface_mimedata).size())
 		return;
 
 	if (event->source() == this ) {

--- a/desktop-widgets/divepicturewidget.cpp
+++ b/desktop-widgets/divepicturewidget.cpp
@@ -14,7 +14,11 @@ DivePictureWidget::DivePictureWidget(QWidget *parent) : QListView(parent)
 void DivePictureWidget::mouseDoubleClickEvent(QMouseEvent *event)
 {
 	if (event->button() == Qt::LeftButton) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		QString filePath = model()->data(indexAt(event->position().toPoint()), Qt::DisplayPropertyRole).toString();
+#else
 		QString filePath = model()->data(indexAt(event->pos()), Qt::DisplayPropertyRole).toString();
+#endif
 		emit photoDoubleClicked(localFilePath(filePath));
 	}
 }
@@ -22,13 +26,21 @@ void DivePictureWidget::mouseDoubleClickEvent(QMouseEvent *event)
 void DivePictureWidget::mousePressEvent(QMouseEvent *event)
 {
 	if (event->button() == Qt::LeftButton && event->modifiers() == Qt::NoModifier) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		QModelIndex index = indexAt(event->position().toPoint());
+#else
 		QModelIndex index = indexAt(event->pos());
+#endif
 		QString filename = model()->data(index, Qt::DisplayPropertyRole).toString();
 
 		if (!filename.isEmpty()) {
 			int dim = lrint(defaultIconMetrics().sz_pic * 0.2);
-			
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+			QPixmap pixmap = model()->data(indexAt(event->position().toPoint()), Qt::DecorationRole).value<QPixmap>();
+#else
 			QPixmap pixmap = model()->data(indexAt(event->pos()), Qt::DecorationRole).value<QPixmap>();
+#endif
 			pixmap = pixmap.scaled(dim, dim, Qt::KeepAspectRatio);
 			
 			QByteArray itemData;

--- a/desktop-widgets/filterconstraintwidget.cpp
+++ b/desktop-widgets/filterconstraintwidget.cpp
@@ -68,7 +68,11 @@ static QDateEdit *makeDateEdit()
 {
 	QDateEdit *res = new QDateEdit;
 	res->setCalendarPopup(true);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	res->setTimeZone(QTimeZone::utc());
+#else
 	res->setTimeSpec(Qt::UTC);
+#endif
 	return res;
 }
 
@@ -76,7 +80,11 @@ static QDateEdit *makeDateEdit()
 static QTimeEdit *makeTimeEdit()
 {
 	QTimeEdit *res = new QTimeEdit;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	res->setTimeZone(QTimeZone::utc());
+#else
 	res->setTimeSpec(Qt::UTC);
+#endif
 	return res;
 }
 

--- a/desktop-widgets/importgps.cpp
+++ b/desktop-widgets/importgps.cpp
@@ -15,6 +15,13 @@ ImportGPS::ImportGPS(QWidget *parent, QString fileName, class Ui::LocationInform
 	fileName(fileName), LocationUI(LocationUI)
 {
 	ui.setupUi(this);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	ui.timeZoneEdit->setTimeZone(QTimeZone::systemTimeZone());
+	ui.timeDiffEdit->setTimeZone(QTimeZone::systemTimeZone());
+#else
+	ui.timeZoneEdit->setTimeSpec(Qt::LocalTime);
+	ui.timeDiffEdit->setTimeSpec(Qt::LocalTime);
+#endif
 	connect(ui.timeDiffEdit, &QTimeEdit::timeChanged, this, &ImportGPS::timeDiffEditChanged);
 	connect(ui.timeZoneEdit, &QTimeEdit::timeChanged, this, &ImportGPS::timeZoneEditChanged);
 	connect(ui.timezone_backwards, &QRadioButton::toggled, this, &ImportGPS::changeZoneBackwards);

--- a/desktop-widgets/importgps.ui
+++ b/desktop-widgets/importgps.ui
@@ -373,9 +373,6 @@
             <property name="displayFormat">
              <string>h:mm</string>
             </property>
-            <property name="timeSpec">
-             <enum>Qt::LocalTime</enum>
-            </property>
            </widget>
           </item>
 
@@ -497,9 +494,6 @@
              </property>
              <property name="displayFormat">
               <string>h:mm</string>
-             </property>
-             <property name="timeSpec">
-              <enum>Qt::LocalTime</enum>
              </property>
             </widget>
            </item>

--- a/desktop-widgets/printdialog.cpp
+++ b/desktop-widgets/printdialog.cpp
@@ -130,9 +130,9 @@ PrintDialog::PrintDialog(dive *singleDive, const QString &filename, QWidget *par
 	setWindowTitle(tr("Print"));
 	setWindowIcon(QIcon(":subsurface-icon"));
 
-	QShortcut *close = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this);
+	QShortcut *close = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_W), this);
 	connect(close, SIGNAL(activated()), this, SLOT(close()));
-	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this);
+	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this);
 	connect(quit, SIGNAL(activated()), parent, SLOT(close()));
 
 	// seems to be the most reliable way to track for all sorts of dialog disposal.

--- a/desktop-widgets/shifttimes.ui
+++ b/desktop-widgets/shifttimes.ui
@@ -125,9 +125,6 @@
         <property name="displayFormat">
          <string>h:mm</string>
         </property>
-        <property name="timeSpec">
-         <enum>Qt::LocalTime</enum>
-        </property>
        </widget>
       </item>
       <item>

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -144,7 +144,11 @@ void ShiftImageTimesDialog::syncCameraClicked()
 	ui.DCImage->setScene(scene);
 
 	dcImageEpoch = picture_get_timestamp(qPrintable(fileNames.at(0)));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+	QDateTime dcDateTime = QDateTime::fromSecsSinceEpoch(dcImageEpoch, QTimeZone::utc());
+#else
 	QDateTime dcDateTime = QDateTime::fromSecsSinceEpoch(dcImageEpoch, Qt::UTC);
+#endif
 	ui.dcTime->setDateTime(dcDateTime);
 	connect(ui.dcTime, SIGNAL(dateTimeChanged(const QDateTime &)), this, SLOT(dcDateTimeChanged(const QDateTime &)));
 }
@@ -217,8 +221,13 @@ void ShiftImageTimesDialog::updateInvalid()
 	bool allValid = true;
 	ui.warningLabel->hide();
 	ui.invalidFilesText->hide();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+	QDateTime time_first = QDateTime::fromSecsSinceEpoch(first_selected_dive()->when, QTimeZone::utc());
+	QDateTime time_last = QDateTime::fromSecsSinceEpoch(last_selected_dive()->when, QTimeZone::utc());
+#else
 	QDateTime time_first = QDateTime::fromSecsSinceEpoch(first_selected_dive()->when, Qt::UTC);
 	QDateTime time_last = QDateTime::fromSecsSinceEpoch(last_selected_dive()->when, Qt::UTC);
+#endif
 	if (first_selected_dive() == last_selected_dive()) {
 		ui.invalidFilesText->setPlainText(tr("Selected dive date/time") + ": " + time_first.toString());
 	} else {

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -149,7 +149,11 @@ void ShiftImageTimesDialog::dcDateTimeChanged(const QDateTime &newDateTime)
 	QDateTime newtime(newDateTime);
 	if (!dcImageEpoch)
 		return;
-	newtime.setTimeSpec(Qt::UTC);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+	newtime = QDateTime(newtime.date(), newtime.time(), QTimeZone(QTimeZone::UTC));
+#else
+	newtime = QDateTime(newtime.date(), newtime.time(), Qt::UTC);
+#endif
 
 	m_amount = dateTimeToTimestamp(newtime) - dcImageEpoch;
 	if (m_amount)

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -105,6 +105,11 @@ ShiftTimesDialog::ShiftTimesDialog(std::vector<dive *> dives_in, QWidget *parent
 	when(0), dives(std::move(dives_in))
 {
 	ui.setupUi(this);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	ui.timeEdit->setTimeZone(QTimeZone::systemTimeZone());
+#else
+	ui.timeEdit->setTimeSpec(Qt::LocalTime);
+#endif
 	connect(ui.buttonBox, SIGNAL(clicked(QAbstractButton *)), this, SLOT(buttonClicked(QAbstractButton *)));
 	connect(ui.timeEdit, SIGNAL(timeChanged(const QTime)), this, SLOT(changeTime()));
 	connect(ui.backwards, SIGNAL(toggled(bool)), this, SLOT(changeTime()));

--- a/desktop-widgets/starwidget.cpp
+++ b/desktop-widgets/starwidget.cpp
@@ -47,7 +47,11 @@ void StarWidget::mouseReleaseEvent(QMouseEvent *event)
 		return;
 	}
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	int starClicked = event->position().toPoint().x() / defaultIconMetrics().sz_small + 1;
+#else
 	int starClicked = event->pos().x() / defaultIconMetrics().sz_small + 1;
+#endif
 	if (starClicked > TOTALSTARS)
 		starClicked = TOTALSTARS;
 

--- a/desktop-widgets/statswidget.cpp
+++ b/desktop-widgets/statswidget.cpp
@@ -153,7 +153,11 @@ void StatsWidget::updateUi()
 		QCheckBox *check = features.back().get();
 		check->setChecked(f.selected);
 		int id = f.id;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+		connect(check, &QCheckBox::checkStateChanged, [this,id] (Qt::CheckState state) { featureChanged(id, state); });
+#else
 		connect(check, &QCheckBox::stateChanged, [this,id] (int state) { featureChanged(id, state); });
+#endif
 		ui.features->addWidget(check);
 	}
 	StatsView *view = getView();

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -27,6 +27,13 @@ TabDiveNotes::TabDiveNotes(MainTab *parent) : TabBase(parent),
 	currentTrip(0)
 {
 	ui.setupUi(this);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	ui.dateEdit->setTimeZone(QTimeZone::utc());
+	ui.timeEdit->setTimeZone(QTimeZone::utc());
+#else
+	ui.dateEdit->setTimeSpec(Qt::UTC);
+	ui.timeEdit->setTimeSpec(Qt::UTC);
+#endif
 
 	updateDateTimeFields();
 

--- a/desktop-widgets/tab-widgets/TabDiveNotes.ui
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.ui
@@ -145,9 +145,6 @@
            <property name="calendarPopup">
             <bool>true</bool>
            </property>
-           <property name="timeSpec">
-            <enum>Qt::UTC</enum>
-           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
              <horstretch>1</horstretch>
@@ -163,9 +160,6 @@
              <horstretch>1</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
-           </property>
-           <property name="timeSpec">
-            <enum>Qt::UTC</enum>
            </property>
            </widget>
          </item>

--- a/desktop-widgets/usermanual.cpp
+++ b/desktop-widgets/usermanual.cpp
@@ -44,13 +44,13 @@ void SearchBar::enableButtons(const QString &s)
 
 UserManual::UserManual(QWidget *parent) : QDialog(parent)
 {
-	QShortcut *closeKey = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this);
+	QShortcut *closeKey = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_W), this);
 	connect(closeKey, SIGNAL(activated()), this, SLOT(close()));
-	QShortcut *quitKey = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q), this);
+	QShortcut *quitKey = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this);
 	connect(quitKey, SIGNAL(activated()), qApp, SLOT(quit()));
 
 	QAction *actionShowSearch = new QAction(this);
-	actionShowSearch->setShortcut(Qt::CTRL + Qt::Key_F);
+	actionShowSearch->setShortcut(Qt::CTRL | Qt::Key_F);
 	actionShowSearch->setShortcutContext(Qt::WindowShortcut);
 	addAction(actionShowSearch);
 
@@ -277,9 +277,9 @@ void UserManual::showEvent(QShowEvent *e)
 void UserManual::hideEvent(QHideEvent *e)
 {
 	if (closeAction != NULL)
-		closeAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_W));
+		closeAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_W));
 	if (filterAction != NULL)
-		filterAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F));
+		filterAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_F));
 	closeAction = filterAction = NULL;
 }
 #endif

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -950,7 +950,11 @@ bool QMLManager::checkDate(struct dive *d, QString date)
 		}
 		// set date from string and make sure it's treated as UTC (like all our time stamps)
 		newDate = QDateTime::fromString(date, format);
-		newDate.setTimeSpec(Qt::UTC);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+		newDate = QDateTime(newDate.date(), newDate.time(), QTimeZone(QTimeZone::UTC));
+#else
+		newDate = QDateTime(newDate.date(), newDate.time(), Qt::UTC);
+#endif
 		if (!newDate.isValid()) {
 			appendTextToLog("unable to parse date " + date + " with the given format " + format);
 			QRegularExpression isoDate("\\d+-\\d+-\\d+[^\\d]+\\d+:\\d+");

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -294,7 +294,11 @@ void ProfileWidget2::mousePressEvent(QMouseEvent *event)
 
 	if (!event->isAccepted()) {
 		panning = true;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		panningOriginalMousePosition = mapToScene(event->position().toPoint()).x();
+#else
 		panningOriginalMousePosition = mapToScene(event->pos()).x();
+#endif
 		panningOriginalProfilePosition = zoomedPosition;
 		viewport()->setCursor(Qt::ClosedHandCursor);
 	}
@@ -359,7 +363,11 @@ void ProfileWidget2::wheelEvent(QWheelEvent *event)
 void ProfileWidget2::mouseDoubleClickEvent(QMouseEvent *event)
 {
 	if ((currentState == PLAN || currentState == EDIT) && plannerModel) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		QPointF mappedPos = mapToScene(event->position().toPoint());
+#else
 		QPointF mappedPos = mapToScene(event->pos());
+#endif
 		if (!profileScene->pointOnProfile(mappedPos))
 			return;
 
@@ -375,7 +383,11 @@ void ProfileWidget2::mouseMoveEvent(QMouseEvent *event)
 {
 	QGraphicsView::mouseMoveEvent(event);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QPointF pos = mapToScene(event->position().toPoint());
+#else
 	QPointF pos = mapToScene(event->pos());
+#endif
 	if (panning) {
 		double oldPos = zoomedPosition;
 		zoomedPosition = profileScene->calcZoomPosition(calcZoom(zoomLevel),
@@ -1319,7 +1331,11 @@ void ProfileWidget2::dropEvent(QDropEvent *event)
 
 		QString filename;
 		dataStream >> filename;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		QPointF mappedPos = mapToScene(event->position().toPoint());
+#else
 		QPointF mappedPos = mapToScene(event->pos());
+#endif
 		offset_t offset { .seconds = (int32_t)lrint(profileScene->timeAxis->valueAt(mappedPos)) };
 		Command::setPictureOffset(mutable_dive(), filename, offset);
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -499,7 +499,11 @@ DivePlannerPointsModel::DivePlannerPointsModel(QObject *parent) : QAbstractTable
 	cylinders(true),
 	mode(NOTHING)
 {
-	startTime.setTimeSpec(Qt::UTC);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+	startTime = QDateTime(startTime.date(), startTime.time(), QTimeZone(QTimeZone::UTC));
+#else
+	startTime = QDateTime(startTime.date(), startTime.time(), Qt::UTC);
+#endif
 	// use a Qt-connection to send the variations text across thread boundary (in case we
 	// are calculating the variations in a background thread).
 	connect(this, &DivePlannerPointsModel::variationsComputed, this, &DivePlannerPointsModel::computeVariationsDone);
@@ -1417,7 +1421,11 @@ QVariantMap DivePlannerPointsModel::calculatePlan(const QVariantList &cylindersD
 	// Set Date, Time, and Dive Mode from parameters
 	QString dateTimeString = date + " " + time;
 	QDateTime plannedDateTime = QDateTime::fromString(dateTimeString, "yyyy-MM-dd hh:mm:ss");
-	plannedDateTime.setTimeSpec(Qt::UTC);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+	plannedDateTime = QDateTime(plannedDateTime.date(), plannedDateTime.time(), QTimeZone(QTimeZone::UTC));
+#else
+	plannedDateTime = QDateTime(plannedDateTime.date(), plannedDateTime.time(), Qt::UTC);
+#endif
 	d->when = static_cast<time_t>(plannedDateTime.toSecsSinceEpoch());
 	diveplan.when = d->when;
 

--- a/stats/statsview.cpp
+++ b/stats/statsview.cpp
@@ -67,7 +67,11 @@ StatsView::~StatsView()
 
 void StatsView::mousePressEvent(QMouseEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QPointF pos = event->position();
+#else
 	QPointF pos = event->localPos();
+#endif
 
 	// Currently, we only support dragging of the legend. If other objects
 	// should be made draggable, this needs to be generalized.
@@ -408,12 +412,20 @@ void StatsView::mouseMoveEvent(QMouseEvent *event)
 		QSizeF sceneSize = size();
 		if (sceneSize.width() <= 1.0 || sceneSize.height() <= 1.0)
 			return;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		draggedItem->setPos(event->position() - dragStartMouse + dragStartItem);
+#else
 		draggedItem->setPos(event->pos() - dragStartMouse + dragStartItem);
+#endif
 		update();
 	}
 
 	if (selectionRect) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		QPointF p1 = event->position();
+#else
 		QPointF p1 = event->pos();
+#endif
 		QPointF p2 = dragStartMouse;
 		selectionRect->setLine(p1, p2);
 		QRectF rect(std::min(p1.x(), p2.x()), std::min(p1.y(), p2.y()),
@@ -432,7 +444,11 @@ void StatsView::hoverEnterEvent(QHoverEvent *)
 
 void StatsView::hoverMoveEvent(QHoverEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QPointF pos = event->position();
+#else
 	QPointF pos = event->pos();
+#endif
 
 	for (auto &series: series) {
 		if (series->hover(pos)) {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Code cleanup

### Pull request long description:
<!-- Describe your pull request in detail. -->
This should be fairly mechanical, simply aiming to get rid of many of the warnings that are cluttering the build (and avoid future problems), but of course I always worry that a change like this introduces a subtle change that I don't see and that comes back to bite us in the future.

### Changes made:
See commits, simply did a Qt 6 build and tried to address the warnings (and do Qt 5 builds to make sure I didn't break things) until I ran out of patience...

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Code reviews would be nice, but of course this just as much requires actual testing of both Qt5 and Qt6 builds...