### PR TITLE
Fix notifications for BLE characteristics supporting indications only

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -460,7 +460,7 @@ dc_status_t BLEObject::select_preferred_service()
 		report_info("Found service %s %s", to_str(s->serviceUuid()).c_str(), qPrintable(s->serviceName()));
 
 		for (const QLowEnergyCharacteristic &c: s->characteristics()) {
-			report_info("   c: %s", to_str(c.uuid()).c_str());
+			report_info("   c: %s 0x%02x", to_str(c.uuid()).c_str(), int(c.properties()));
 
 			for (const QLowEnergyDescriptor &d: c.descriptors())
 				report_info("        d: %s", to_str(d.uuid()).c_str());

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -716,9 +716,12 @@ dc_status_t qt_ble_open(void **io, dc_context_t *, const char *devaddr, device_d
 				}
 			}
 
-			report_info("now writing \"0x0100\" to the descriptor %s", to_str(d.uuid()).c_str());
+			const char *value = c.properties() & QLowEnergyCharacteristic::Notify ?
+				"0100" : "0200";
 
-			ble->preferredService()->writeDescriptor(d, QByteArray::fromHex("0100"));
+			report_info("now writing \"0x%s\" to the descriptor %s", value, to_str(d.uuid()).c_str());
+
+			ble->preferredService()->writeDescriptor(d, QByteArray::fromHex(value));
 			WAITFOR(ble->descriptorWritten(), 1000);
 			if (!ble->descriptorWritten()) {
 				report_info("Bluetooth: Failed to enable notifications for characteristic %s", to_str(c.uuid()).c_str());


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

This PR fixes enabling the BLE notifications for the Halcyon Symbios, which only support indications and not notifications. This a follow-up fix to PR #3956. 

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
