### PR TITLE
Planner: Fixup CCR Segment Default Setpoints.

### DIFF
--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -517,6 +517,14 @@ DivePlannerPointsModel *DivePlannerPointsModel::instance()
 
 void DivePlannerPointsModel::emitDataChanged()
 {
+	// add a reasonable setpoint for CCR segments that don't have one yet
+	if (d)
+		for (int j = 0; j < rowCount(); j++) {
+			divedatapoint &p = divepoints[j];
+			if (d->get_cylinder(p.cylinderid)->cylinder_use == DILUENT && p.setpoint == 0)
+				p.setpoint = prefs.defaultsetpoint;
+		}
+
 	updateDiveProfile();
 	emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, COLUMNS - 1));
 }
@@ -1083,7 +1091,7 @@ DivePlannerPointsModel::Mode DivePlannerPointsModel::currentMode() const
 bool DivePlannerPointsModel::tankInUse(int cylinderid) const
 {
 	for (int j = 0; j < rowCount(); j++) {
-		const divedatapoint &p = divepoints[j];
+		const divedatapoint p = at(j);
 		if (p.time == 0) // special entries that hold the available gases
 			continue;
 		if (!p.entered) // removing deco gases is ok


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix the default for setpoints when changing a segment to CCR in the
planner.
When the gas use is switched to diluent for the gas used in one or more
segments of the planned dive, apply the default setpoint to these
segments if the current setpoint is '0'.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Reported-in: https://groups.google.com/g/subsurface-divelog/c/55qGS1zDYPM

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
