### PR TITLE
fix copr build

### DIFF
--- a/packaging/OBS/subsurfacedaily.spec
+++ b/packaging/OBS/subsurfacedaily.spec
@@ -23,7 +23,7 @@ BuildRequires:	fdupes
 BuildRequires:	gcc-c++
 BuildRequires:	make
 BuildRequires:	asciidoctor
-BuildRequires:  rubygem-asciidoctor-pdf.noarch
+BuildRequires:  rubygem-asciidoctor.noarch
 BuildRequires:	autoconf
 BuildRequires:	automake
 BuildRequires:	libtool

--- a/packaging/copr/subsurface.spec
+++ b/packaging/copr/subsurface.spec
@@ -24,7 +24,7 @@ BuildRequires:  fdupes
 BuildRequires:  gcc-c++
 BuildRequires:  make
 BuildRequires:  asciidoctor
-BuildRequires:  rubygem-asciidoctor-pdf.noarch
+BuildRequires:  rubygem-asciidoctor.noarch
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool


### PR DESCRIPTION
Well, maybe - we won't know until it is merged since we don't do copr builds on pull requests.

This also updates the OBS spec file - but when looking into this I noticed that we have stopped triggering OBS builds more than 2 years ago and apparently no one ever noticed or cared. Oops. Maybe it's time to stop pretending we build for opensuse?

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Not sure where I found that incorrect package name. Embarrassing...

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mikeller -- the automation of builds for this PR won't help, it doesn't test the COPR build. Maybe we need to create a 'simulated' COPR build on GitHub? Not sure. Definitely not something that I'll try on this crawling internet connection.

Which means for now, short of merging this, there's no way to know if this really fixes things.