### PR TITLE
Ruler fixes and tests

### DIFF
--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -1474,8 +1474,6 @@ std::vector<std::string> compare_samples(const struct dive *d, const struct plot
 	depth_t max_depth;
 	depth_t min_depth { .mm = INT_MAX };
 
-	int last_sec = start.sec;
-
 	volume_t cylinder_volume;
 	std::vector<int> start_pressures(pi.nr_cylinders, 0);
 	std::vector<int> last_pressures(pi.nr_cylinders, 0);
@@ -1483,13 +1481,15 @@ std::vector<std::string> compare_samples(const struct dive *d, const struct plot
 	std::vector<int> volumes_used(pi.nr_cylinders, 0);
 	std::vector<char> cylinder_is_used(pi.nr_cylinders, false);
 
-	for (int i = idx1; i < idx2; ++i) {
+	for (int i = idx1, last_idx = idx1; i <= idx2; ++i) {
+		const struct plot_data &last_data = pi.entry[last_idx];
 		const struct plot_data &data = pi.entry[i];
+
 		if (sum)
-			avg_speed += abs(data.speed) * (data.sec - last_sec);
+			avg_speed += abs(data.speed) * (data.sec - last_data.sec);
 		else
-			avg_speed += data.speed * (data.sec - last_sec);
-		avg_depth += data.depth * (data.sec - last_sec);
+			avg_speed += data.speed * (data.sec - last_data.sec);
+		avg_depth += data.depth * (data.sec - last_data.sec);
 
 		if (data.speed > max_desc_speed)
 			max_desc_speed = data.speed;
@@ -1526,7 +1526,7 @@ std::vector<std::string> compare_samples(const struct dive *d, const struct plot
 			last_pressures[cylinder_index] = next_pressure;
 		}
 
-		last_sec = data.sec;
+		last_idx = i;
 	}
 
 	avg_depth /= stop.sec - start.sec;

--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -1489,7 +1489,7 @@ std::vector<std::string> compare_samples(const struct dive *d, const struct plot
 			avg_speed += abs(data.speed) * (data.sec - last_data.sec);
 		else
 			avg_speed += data.speed * (data.sec - last_data.sec);
-		avg_depth += data.depth * (data.sec - last_data.sec);
+		avg_depth += ((data.depth + last_data.depth) / 2) * (data.sec - last_data.sec);
 
 		if (data.speed > max_desc_speed)
 			max_desc_speed = data.speed;

--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -1453,6 +1453,9 @@ std::vector<std::string> compare_samples(const struct dive *d, const struct plot
 	if (idx1 < 0 || idx2 < 0)
 		return res;
 
+	if ((unsigned)idx1 >= pi.entry.size() || (unsigned)idx2 >= pi.entry.size())
+		return res;
+
 	if (pi.entry[idx1].sec > pi.entry[idx2].sec) {
 		int tmp = idx2;
 		idx2 = idx1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,6 +151,7 @@ TEST(TestQPrefTechnicalDetails testqPrefTechnicalDetails.cpp)
 TEST(TestQPrefUnits testqPrefUnits.cpp)
 TEST(TestQPrefUpdateManager testqPrefUpdateManager.cpp)
 TEST(TestformatDiveGasString testformatDiveGasString.cpp)
+TEST(TestRuler testruler.cpp)
 add_test(NAME TestQML COMMAND $<TARGET_FILE:TestQML> -input ${SUBSURFACE_SOURCE}/tests)
 
 # this is currently broken
@@ -188,6 +189,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
 	TestQPrefUnits
 	TestQPrefUpdateManager
 	TestQML
+	TestRuler
 )
 
 # useful for debugging CMake issues

--- a/tests/testruler.cpp
+++ b/tests/testruler.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "testruler.h"
+#include "core/profile.h"
+#include "core/device.h"
+#include "core/dive.h"
+#include "core/divelog.h"
+#include "core/divesite.h"
+#include "core/trip.h"
+#include "core/file.h"
+#include "core/save-profiledata.h"
+#include "core/pref.h"
+#include "QTextCodec"
+
+void TestRuler::init()
+{
+	QLocale::setDefault(QLocale::C);
+
+	// Set UTF8 text codec as in real applications
+	QTextCodec::setCodecForLocale(QTextCodec::codecForMib(106));
+
+	// first, setup the preferences
+	prefs = default_prefs;
+
+	QCoreApplication::setOrganizationName("Subsurface");
+	QCoreApplication::setOrganizationDomain("subsurface.hohndel.org");
+	QCoreApplication::setApplicationName("Subsurface");
+}
+
+/* This test loads a known synthetic dive and verifies the values
+ * calculated by the ruler code against easily hand calculated values
+ * to verify it's correctness.
+ */
+void TestRuler::testRuler()
+{
+	verbose = 1;
+
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test13.xml", &divelog), 0);
+
+	QVERIFY(divelog.dives.size() == 1);
+	const struct dive *dive = divelog.dives[0].get();
+	const struct divecomputer *dc = &dive->dcs[0];
+
+	const struct plot_info pi = create_plot_info_new(dive, dc, NULL);
+
+	/* First string is the one with now good values.
+	 * Speeds has rounding issues and ΔP / SAC has issues due to
+	 * pressures being linearly applied as depth*time/pressure but
+	 * volume calculations takes non linear compression into conciliation
+	 */
+
+	// Verify that we don't explode on a zero with measurement
+	QVERIFY(compare_samples(dive, pi, 0, 0, false).size() == 0);
+
+	// Verify that we don't explode on negative indices
+	QVERIFY(compare_samples(dive, pi, -1, 0, false).size() == 0);
+	QVERIFY(compare_samples(dive, pi, 0, -1, false).size() == 0);
+
+	// Verify the edge case with only the first sample
+	// ( We have a duplicate sample in the beginning, so somethings odd is going on)
+	QVERIFY(compare_samples(dive, pi, 0, 1, false).size() == 0);
+
+	// Verify the edge case with only the first real sample
+	QCOMPARE(compare_samples(dive, pi, 1, 2, false)[0].c_str(),
+			"ΔT:0:10min ΔD:0.8m ↓D:0.0m ↑D:0.8m øD:0.4m");
+
+	// Verify that we get the right average for the whole linear decent
+	auto idx_at_6_min = std::get<0>(get_plot_details_new(dive, pi, 6*60));
+	QCOMPARE(compare_samples(dive, pi, 0, idx_at_6_min, false)[0].c_str(),
+			"ΔT:6:00min ΔD:30.0m ↓D:0.0m ↑D:30.0m øD:15.0m");
+
+	// Verify that it works the same with start and end reversed
+	QCOMPARE(compare_samples(dive, pi, idx_at_6_min, 0, false)[0].c_str(),
+			"ΔT:6:00min ΔD:30.0m ↓D:0.0m ↑D:30.0m øD:15.0m");
+
+	// Verify that we get the right values for a single step
+	QCOMPARE(compare_samples(dive, pi, idx_at_6_min - 1, idx_at_6_min, false)[0].c_str(),
+			"ΔT:0:10min ΔD:0.8m ↓D:29.2m ↑D:30.0m øD:29.6m");
+
+	// Verify that we get the right results for a straight and level bottom segment
+	auto idx_at_13_00 = std::get<0>(get_plot_details_new(dive, pi, 13*60));
+	QCOMPARE(compare_samples(dive, pi, idx_at_6_min, idx_at_13_00, false)[0].c_str(),
+			"ΔT:7:00min ΔD:0.0m ↓D:30.0m ↑D:30.0m øD:30.0m");
+
+	// Verify that we get the right average for a something containing both
+	// a accent and a decent.
+	auto idx_at_15_30 = std::get<0>(get_plot_details_new(dive, pi, 15*60 + 30));
+	auto idx_at_17_00 = std::get<0>(get_plot_details_new(dive, pi, 17*60));
+	QCOMPARE(compare_samples(dive, pi, idx_at_15_30, idx_at_17_00, false)[0].c_str(),
+			"ΔT:1:30min ΔD:0.0m ↓D:5.0m ↑D:10.0m øD:7.5m");
+
+	// Make sure that it works in the edge case, the last sample
+	auto max_idx = pi.entry.size();
+	QCOMPARE(compare_samples(dive, pi, max_idx - 2, max_idx - 1, false)[0].c_str(),
+			"ΔT:0:01min ΔD:0.0m ↓D:0.0m ↑D:0.0m øD:0.0m");
+
+	// Make sure we can calculate over all the samples
+	QCOMPARE(compare_samples(dive, pi, 0, max_idx - 1, false)[0].c_str(),
+			"ΔT:30:02min ΔD:0.0m ↓D:0.0m ↑D:30.0m øD:14.4m");
+
+	// Verify that we don't explode on indexes larger than the amount of samples
+	QVERIFY(compare_samples(dive, pi, max_idx - 1, max_idx, false).size() == 0);
+}
+
+QTEST_GUILESS_MAIN(TestRuler)

--- a/tests/testruler.h
+++ b/tests/testruler.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#ifndef TESTPROFILE_H
+#define TESTPROFILE_H
+
+#include "testbase.h"
+
+class TestRuler : public TestBase {
+	Q_OBJECT
+private slots:
+	void init();
+	void testRuler();
+};
+
+#endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This reworks compare_samples(), the backend for the ruler feature to produce correct average depth, and adds tests to verify that it works as expected.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Instead of attributing the time between two samples as being at one of the samples dept, this now calculates the total average as being at the average of the two samples depths for the interval between the two samples.

This makes the calculated average depth line up with what can be easily calculated for a synthetic test dive and uses one such test dive to verify the calculations.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

This fixes #4575 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
The speed values are still off due to rounding errors where they are calculated, so they're not checked in the tests.
The SAC and delta-P values calculated are also not checked, and both reasons are documented in the test not checking them.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
