### PR TITLE
Add average depth input field for manual dive entry on iOS

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -24,6 +24,7 @@ Kirigami.Page {
 	property alias diveguideModel: detailsEdit.diveguideModel
 	property alias tagText: detailsEdit.tagText
 	property alias depth: detailsEdit.depthText
+	property alias averageDepth: detailsEdit.averageDepthText
 	property alias duration: detailsEdit.durationText
 	property alias location: detailsEdit.locationText
 	property alias gps: detailsEdit.gpsText
@@ -347,6 +348,7 @@ Kirigami.Page {
 		gps = modelData.gps
 		duration = modelData.duration
 		depth = modelData.depth
+		averageDepth = modelData.averageDepth !== undefined ? modelData.averageDepth : ""
 		airtemp = modelData.airTemp
 		watertemp = modelData.waterTemp
 		suitIndex = manager.suitList.indexOf(modelData.suit)

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -31,6 +31,7 @@ Item {
 	property alias notesText: txtNotes.text
 	property alias durationText: txtDuration.text
 	property alias depthText: txtDepth.text
+	property alias averageDepthText: txtAverageDepth.text
 	property alias weightText: txtWeight.text
 	property var usedGas: []
 	property var endpressure: []
@@ -62,6 +63,7 @@ Item {
 		detailsEdit.locationText = ""
 		detailsEdit.durationText = ""
 		detailsEdit.depthText = ""
+		detailsEdit.averageDepthText = ""
 		detailsEdit.airtempText = ""
 		detailsEdit.watertempText = ""
 		detailsEdit.diveguideText = ""
@@ -117,7 +119,7 @@ Item {
 
 		// apply the changes to the dive_table
 		manager.commitChanges(dive_id, detailsEdit.number, detailsEdit.dateText, locationBox.editText, detailsEdit.gpsText, detailsEdit.durationText,
-				      detailsEdit.depthText, detailsEdit.airtempText, detailsEdit.watertempText,
+				      detailsEdit.depthText, detailsEdit.averageDepthText, detailsEdit.airtempText, detailsEdit.watertempText,
 				      suitBox.editText, buddyBox.editText, diveguideBox.editText, detailsEdit.tagText,
 				      detailsEdit.weightText, detailsEdit.notesText, startpressure,
 				      endpressure, usedGas, usedCyl,
@@ -183,6 +185,19 @@ Item {
 				SsrfTextField {
 					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
 					id: txtDepth
+					validator: RegExpValidator { regExp: /[^-]*/ }
+					flickable: detailsEditFlickable
+				}
+			}
+			RowLayout {
+				TemplateLabelSmall {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+					horizontalAlignment: Text.AlignRight
+					text: qsTr("Average depth:")
+				}
+				SsrfTextField {
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+					id: txtAverageDepth
 					validator: RegExpValidator { regExp: /[^-]*/ }
 					flickable: detailsEditFlickable
 				}

--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -92,6 +92,15 @@ Item {
 				font.pointSize: subsurfaceTheme.smallPointSize
 				color: subsurfaceTheme.textColor
 			}
+			// show average depth if available
+			TemplateLabel {
+				visible: typeof averageDepth !== "undefined" && averageDepth !== ""
+				text: visible ? qsTr("Avg: %1").arg(averageDepth) : ""
+				width: visible ? Math.max(Kirigami.Units.gridUnit * 4, paintedWidth) : 0
+				font.pointSize: subsurfaceTheme.smallPointSize
+				color: subsurfaceTheme.textColor
+				opacity: 0.8
+			}
 		}
 		TemplateLabel {
 			id: numberText

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1167,6 +1167,24 @@ bool QMLManager::checkDepth(dive *d, QString depth)
 	return false;
 }
 
+bool QMLManager::checkMeanDepth(dive *d, QString averageDepth)
+{
+	if (get_depth_string(d->dcs[0].meandepth.mm, true, true) != averageDepth) {
+		int depthValue = parseLengthToMm(averageDepth);
+		// the QML code should stop negative depth, but massively huge depth can make
+		// the profile extremely slow or even run out of memory and crash, so keep
+		// the depth <= 500m
+		if (0 <= depthValue && depthValue <= 500000) {
+			d->meandepth.mm = depthValue;
+			if (is_dc_manually_added_dive(&d->dcs[0])) {
+				d->dcs[0].meandepth.mm = d->meandepth.mm;
+			}
+			return true;
+		}
+	}
+	return false;
+}
+
 static weight_t parseWeight(const QString &text)
 {
 	QString numOnly = text;
@@ -1191,7 +1209,7 @@ static weight_t parseWeight(const QString &text)
 }
 
 // update the dive and return the notes field, stripped of the HTML junk
-void QMLManager::commitChanges(QString diveId, QString number, QString date, QString location, QString gps, QString duration, QString depth,
+void QMLManager::commitChanges(QString diveId, QString number, QString date, QString location, QString gps, QString duration, QString depth, QString averageDepth,
 			       QString airtemp, QString watertemp, QString suit, QString buddy, QString diveGuide, QString tags, QString weight, QString notes,
 			       QStringList startpressure, QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility, QString state)
 {
@@ -1209,6 +1227,7 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 		report_info("gps     :'%s'", qPrintable(gps));
 		report_info("duration:'%s'", qPrintable(duration));
 		report_info("depth   :'%s'", qPrintable(depth));
+		report_info("avgdepth:'%s'", qPrintable(averageDepth));
 		report_info("airtemp :'%s'", qPrintable(airtemp));
 		report_info("watertmp:'%s'", qPrintable(watertemp));
 		report_info("suit    :'%s'", qPrintable(suit));
@@ -1238,6 +1257,7 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 	diveChanged |= checkDuration(d, duration);
 
 	diveChanged |= checkDepth(d, depth);
+	diveChanged |= checkMeanDepth(d, averageDepth);
 
 	if (QString::number(d->number) != number) {
 		diveChanged = true;
@@ -1383,9 +1403,14 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 			// so we have depth > 0, a manually added dive and no samples
 			// let's create an actual profile so the desktop version can work it
 			// first clear out the mean depth (or the fake_dc() function tries
-			// to be too clever)
+			// to be too clever), but preserve user-entered mean depth
+			depth_t saved_meandepth = d->meandepth;
 			d->meandepth = d->dcs[0].meandepth = 0_m;
 			fake_dc(&d->dcs[0]);
+			// restore user-entered mean depth if it was set
+			if (saved_meandepth.mm > 0) {
+				d->meandepth = d->dcs[0].meandepth = saved_meandepth;
+			}
 		}
 		divelog.dives.fixup_dive(*d);
 		Command::editDive(orig, d_ptr.release(), dsChange.createdDs.release(), dsChange.editDs, dsChange.location); // With release() we're giving up ownership

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -189,7 +189,7 @@ public slots:
 	void applicationStateChanged(Qt::ApplicationState state);
 	void saveCloudCredentials(const QString &email, const QString &password, const QString &pin);
 	void commitChanges(QString diveId, QString number, QString date, QString location, QString gps,
-			   QString duration, QString depth, QString airtemp,
+			   QString duration, QString depth, QString averageDepth, QString airtemp,
 			   QString watertemp, QString suit, QString buddy,
 			   QString diveGuide, QString tags, QString weight, QString notes, QStringList startpressure,
 			   QStringList endpressure, QStringList gasmix, QStringList usedCylinder, int rating, int visibility, QString state);
@@ -259,6 +259,7 @@ private:
 	bool checkLocation(DiveSiteChange &change, struct dive *d, QString location, QString gps);
 	bool checkDuration(struct dive *d, QString duration);
 	bool checkDepth(struct dive *d, QString depth);
+	bool checkMeanDepth(struct dive *d, QString averageDepth);
 	bool currentGitLocalOnly;
 	bool localChanges;
 	QString m_progressMessage;

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -281,6 +281,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 	case MobileListModel::NumberRole: return d->number;
 	case MobileListModel::LocationRole: return QString::fromStdString(d->get_location());
 	case MobileListModel::DepthRole: return get_depth_string(d->dcs[0].maxdepth.mm, true, true);
+	case MobileListModel::AverageDepthRole: return get_depth_string(d->dcs[0].meandepth.mm, true, true);
 	case MobileListModel::DurationRole: return formatDiveDuration(d);
 	case MobileListModel::DepthDurationRole: return QStringLiteral("%1 / %2").arg(get_depth_string(d->dcs[0].maxdepth.mm, true, true),
 										      formatDiveDuration(d));

--- a/qt-models/mobilelistmodel.cpp
+++ b/qt-models/mobilelistmodel.cpp
@@ -22,6 +22,7 @@ QHash<int, QByteArray> MobileListModelBase::roleNames() const
 	roles[NumberRole] = "number";
 	roles[LocationRole] = "location";
 	roles[DepthRole] = "depth";
+	roles[AverageDepthRole] = "averageDepth";
 	roles[DurationRole] = "duration";
 	roles[DepthDurationRole] = "depthDuration";
 	roles[RatingRole] = "rating";

--- a/qt-models/mobilelistmodel.h
+++ b/qt-models/mobilelistmodel.h
@@ -30,6 +30,7 @@ public:
 		NumberRole,
 		LocationRole,
 		DepthRole,
+		AverageDepthRole,
 		DurationRole,
 		DepthDurationRole,
 		RatingRole,


### PR DESCRIPTION
Currently, the iOS version of Subsurface does not allow users to input an average depth when manually adding a dive. This prevents proper SAC (Surface Air Consumption) calculation, which depends on the average depth.

This change adds:
- Average depth input field in the dive edit UI
- Model support to expose average depth data
- Display of average depth in the dive view
- Backend validation and storage of average depth
- Preservation of user-entered average depth when generating dive profiles

The implementation follows the same pattern as the max depth field and allows users to clear the average depth by leaving the field empty.

### Describe the pull request:
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

This PR adds the ability for iOS users to input an average depth when manually adding or editing a dive. Previously, this field was missing from the mobile UI, which prevented proper SAC rate calculations for manually entered dives.

**Problem:**
- SAC calculation requires average depth to compute gas consumption rates
- Without average depth input, manually added dives could not have accurate SAC values

**Solution:**
The implementation adds average depth support throughout the mobile stack:
1. **UI Layer**: Added "Average depth" input field in the dive edit form, positioned after the max depth field
2. **Model Layer**: Added `AverageDepthRole` to expose mean depth data from the dive structure
3. **View Layer**: Added display of average depth in the dive view (shown as "Avg: [depth]" when available)
4. **Backend Layer**: Added `checkMeanDepth()` function to validate and store average depth, following the same pattern as `checkDepth()`
5. **Data Preservation**: User-entered average depth is preserved when `fake_dc()` generates dive profiles

The field is optional.

### Changes made:

1) **UI Components** (`mobile-widgets/qml/DiveDetailsEdit.qml`):
   - Added "Average depth:" input field with validation
   - Added property alias `averageDepthText` for data binding
   - Updated `clearDetailsEdit()` to reset average depth field
   - Updated `saveData()` to pass average depth to backend

2) **View Components** (`mobile-widgets/qml/DiveDetailsView.qml`):
   - Added conditional display of average depth in dive view
   - Shows "Avg: [depth]" when average depth data is available

3) **Data Binding** (`mobile-widgets/qml/DiveDetails.qml`):
   - Added property alias for average depth
   - Populates average depth field when editing existing dives

4) **Model Layer** (`qt-models/mobilelistmodel.h`, `qt-models/mobilelistmodel.cpp`, `qt-models/divetripmodel.cpp`):
   - Added `AverageDepthRole` enum value
   - Added role name mapping "averageDepth"
   - Implemented data retrieval from dive structure's `meandepth` field

5) **Backend Validation** (`mobile-widgets/qmlmanager.h`, `mobile-widgets/qmlmanager.cpp`):
   - Added `checkMeanDepth()` function declaration and implementation
   - Validates average depth input (0-500m range, same as max depth)
   - Updates both `dive.meandepth` and `dive.dcs[0].meandepth` for consistency
   - Updated `commitChanges()` signature to accept `averageDepth` parameter
   - Added call to `checkMeanDepth()` in commit flow
   - Preserves user-entered average depth when `fake_dc()` generates profiles

### Related issues:

<!-- If there's a related GitHub issue, add it here. Otherwise leave empty. -->

### Additional information:


### Documentation change:

**User Experience Changes:**
- iOS users can now input average depth when manually adding or editing dives
- Average depth is displayed in the dive view when available
- This enables proper SAC calculation for manually entered dives
- The field appears in the edit form between "Depth" and "Duration" fields

**Documentation Updates Needed:**
- Mobile user manual should mention the average depth field in the manual dive entry section
- Consider adding a note about how average depth affects SAC calculations

### Mentions:

<!-- Add maintainers or reviewers if you know who should review this -->

