### PR TITLE
Make dive::when private as first step for "timezone" support

### DIFF
--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -49,7 +49,7 @@ static QString profileText(const struct dive &dive)
 
 	if (dive.dive_site && dive.dive_site->name.length() > 0)
 		text += "🗺 " + QString::fromStdString(dive.dive_site->name) + " \n";
-	if (dive.when) {
+	if (dive.get_time_local()) {
 		text += "🗓 " + formatDiveDateTime(&dive) + "\n";
 	}
 	text += "⏱: " + formatDiveDuration(&dive) + "\n";
@@ -172,7 +172,7 @@ void export_TeX(const char *filename, bool selected_only, bool plain, ExportCall
 		cb.setProgress(done++ * 1000 / todo);
 		exportProfile(*profile, *dive, texdir.filePath(QString("profile%1.png").arg(dive->number)), false);
 		struct tm tm;
-		utc_mkdate(dive->when, &tm);
+		utc_mkdate(dive->get_time_local(), &tm);
 
 		std::string country;
 		dive_site *site = dive->dive_site;

--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -33,6 +33,11 @@ void shiftTime(const std::vector<dive *> &changedDives, int amount)
 	execute(new ShiftTime(changedDives, amount));
 }
 
+void setUtcOffset(const std::vector<dive *> &changedDives, std::optional<int32_t> offset)
+{
+	execute(new SetUtcOffset(changedDives, offset));
+}
+
 void renumberDives(const QVector<QPair<dive *, int>> &divesToRenumber)
 {
 	execute(new RenumberDives(divesToRenumber));

--- a/commands/command.h
+++ b/commands/command.h
@@ -45,6 +45,7 @@ void addDive(std::unique_ptr<dive> d, bool autogroup, bool newNumber);
 void importDives(struct divelog *log, int flags, const QString &source); // The tables are consumed!
 void deleteDive(const QVector<struct dive*> &divesToDelete);
 void shiftTime(const std::vector<dive *> &changedDives, int amount);
+void setUtcOffset(const std::vector<dive *> &changedDives, std::optional<int32_t> offset);
 void renumberDives(const QVector<QPair<dive *, int>> &divesToRenumber);
 void removeDivesFromTrip(const QVector<dive *> &divesToRemove);
 void removeAutogenTrips();

--- a/commands/command_base.cpp
+++ b/commands/command_base.cpp
@@ -56,7 +56,7 @@ QString diveNumberOrDate(struct dive *d)
 	if (d->number != 0)
 		return QStringLiteral("#%1").arg(d->number);
 	else
-		return QStringLiteral("@%1").arg(get_short_dive_date_string(d->when));
+		return QStringLiteral("@%1").arg(get_short_dive_date_string(d->get_time_local()));
 }
 
 QString getListOfDives(const std::vector<struct dive*> &dives)

--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -630,7 +630,7 @@ void ShiftTime::redoit()
 
 	// Send signals
 	QVector<dive *> dives = stdToQt<dive *>(diveList);
-	emit diveListNotifier.divesTimeChanged(timeChanged, dives);
+	emit diveListNotifier.divesTimeChanged(dives);
 	emit diveListNotifier.divesChanged(dives, DiveField::DATETIME);
 
 	// Select the changed dives

--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -598,7 +598,7 @@ void DeleteDive::redoit()
 	// Deselect all dives and select dive that was close to the first deleted dive
 	dive *newCurrent = nullptr;
 	if (!divesToAdd.dives.empty()) {
-		timestamp_t when = divesToAdd.dives[0].dive->get_time_local();
+		datetime_t when = divesToAdd.dives[0].dive->get_time();
 		newCurrent = divelog.dives.find_next_visible_dive(when);
 	}
 	select_single_dive(newCurrent);

--- a/commands/command_divelist.h
+++ b/commands/command_divelist.h
@@ -66,6 +66,8 @@ protected:
 	// Register dive sites where counts changed so that we can signal the frontend later.
 	void diveSiteCountChanged(struct dive_site *ds);
 
+	// Reorder dives and trips, when time of dives changed
+	static void updateDiveAndTripLists(const std::vector<dive *> &dives, const std::vector<dive_trip *> &trips);
 private:
 	// Keep track of dive sites where the number of dives changed
 	std::vector<dive_site *> sitesCountChanged;
@@ -148,6 +150,19 @@ private:
 	// For redo and undo
 	std::vector<dive *> diveList;
 	int timeChanged;
+};
+
+// Since changing the UtcOffset may change the order of dives, this is a divelist-command
+class SetUtcOffset : public DiveListBase {
+public:
+	SetUtcOffset(const std::vector<dive *> &changedDives, std::optional<int32_t> offset);
+private:
+	void undoit() override;
+	void redoit() override;
+	bool workToBeDone() override;
+
+	// For redo and undo: pairs of dive / offset
+	std::vector<std::pair<dive *, std::optional<int32_t>>> diveList;
 };
 
 class RenumberDives : public DiveListBase {

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1494,7 +1494,7 @@ void EditDive::exchangeDives()
 			qWarning("Command::EditDive::redo(): This command does not support moving between trips!");
 		if (oldDive->divetrip)
 			newDive->divetrip->sort_dives(); // Keep the trip-table in order
-		emit diveListNotifier.divesTimeChanged(delta, dives);
+		emit diveListNotifier.divesTimeChanged(dives);
 	}
 
 	// Send signals

--- a/core/cochran.cpp
+++ b/core/cochran.cpp
@@ -694,7 +694,8 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 		tm.tm_sec = log[CMD_SEC];
 		tm.tm_isdst = -1;
 
-		dive->when = dc->when = utc_mktime(&tm);
+		dc->when = utc_mktime(&tm);
+		dive->set_time_local(dc->when);
 		dive->number = log[CMD_NUMBER] + log[CMD_NUMBER + 1] * 256 + 1;
 		dc->duration.seconds = (log[CMD_BT] + log[CMD_BT + 1] * 256) * 60;
 		dc->surfacetime.seconds = (log[CMD_SIT] + log[CMD_SIT + 1] * 256) * 60;
@@ -738,7 +739,8 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 		tm.tm_sec = log[EMC_SEC];
 		tm.tm_isdst = -1;
 
-		dive->when = dc->when = utc_mktime(&tm);
+		dc->when = utc_mktime(&tm);
+		dive->set_time_local(dc->when);
 		dive->number = log[EMC_NUMBER] + log[EMC_NUMBER + 1] * 256 + 1;
 		dc->duration.seconds = (log[EMC_BT] + log[EMC_BT + 1] * 256) * 60;
 		dc->surfacetime.seconds = (log[EMC_SIT] + log[EMC_SIT + 1] * 256) * 60;

--- a/core/cochran.cpp
+++ b/core/cochran.cpp
@@ -694,8 +694,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 		tm.tm_sec = log[CMD_SEC];
 		tm.tm_isdst = -1;
 
-		dc->when = utc_mktime(&tm);
-		dive->set_time_local(dc->when);
+		dive->set_time_local_dc(utc_mktime(&tm));
 		dive->number = log[CMD_NUMBER] + log[CMD_NUMBER + 1] * 256 + 1;
 		dc->duration.seconds = (log[CMD_BT] + log[CMD_BT + 1] * 256) * 60;
 		dc->surfacetime.seconds = (log[CMD_SIT] + log[CMD_SIT + 1] * 256) * 60;
@@ -739,8 +738,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 		tm.tm_sec = log[EMC_SEC];
 		tm.tm_isdst = -1;
 
-		dc->when = utc_mktime(&tm);
-		dive->set_time_local(dc->when);
+		dive->set_time_local_dc(utc_mktime(&tm));
 		dive->number = log[EMC_NUMBER] + log[EMC_NUMBER + 1] * 256 + 1;
 		dc->duration.seconds = (log[EMC_BT] + log[EMC_BT + 1] * 256) * 60;
 		dc->surfacetime.seconds = (log[EMC_SIT] + log[EMC_SIT + 1] * 256) * 60;

--- a/core/datatrak.cpp
+++ b/core/datatrak.cpp
@@ -191,8 +191,7 @@ static char *dt_dive_parser(unsigned char *runner, struct dive *dt_dive, struct 
 	 * Next, Time in minutes since 00:00
 	 */
 	read_bytes(2);
-	dt_dive->dcs[0].when = (timestamp_t)date_time_to_ssrfc(tmp_4bytes, tmp_2bytes);
-	dt_dive->set_time_local(dt_dive->dcs[0].when);
+	dt_dive->set_time_local_dc((timestamp_t)date_time_to_ssrfc(tmp_4bytes, tmp_2bytes));
 
 	/*
 	 * Now, Locality, 1st byte is long of string, rest is string

--- a/core/datatrak.cpp
+++ b/core/datatrak.cpp
@@ -191,7 +191,8 @@ static char *dt_dive_parser(unsigned char *runner, struct dive *dt_dive, struct 
 	 * Next, Time in minutes since 00:00
 	 */
 	read_bytes(2);
-	dt_dive->dcs[0].when = dt_dive->when = (timestamp_t)date_time_to_ssrfc(tmp_4bytes, tmp_2bytes);
+	dt_dive->dcs[0].when = (timestamp_t)date_time_to_ssrfc(tmp_4bytes, tmp_2bytes);
+	dt_dive->set_time_local(dt_dive->dcs[0].when);
 
 	/*
 	 * Now, Locality, 1st byte is long of string, rest is string

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -2426,6 +2426,11 @@ timestamp_t dive::endtime_local() const
 	return get_time_local() + totaltime().seconds;
 }
 
+timestamp_t dive::endtime_utc() const
+{
+	return get_time_utc() + totaltime().seconds;
+}
+
 bool dive::time_during_dive_with_offset(timestamp_t local_time, timestamp_t offset) const
 {
 	timestamp_t start = get_time_local();
@@ -2539,6 +2544,11 @@ bool dive::cache_is_valid() const
 pressure_t dive::get_surface_pressure() const
 {
 	return surface_pressure.mbar > 0 ? surface_pressure : 1_atm;
+}
+
+datetime_t dive::get_time() const
+{
+	return when;
 }
 
 timestamp_t dive::get_time_local() const

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -2551,6 +2551,15 @@ void dive::set_time_local(timestamp_t local_time)
 	when = local_time;
 }
 
+/* Set time and also time of the first dc.
+ * Note that we are not very consistent about setting the time of the first dc.
+ */
+void dive::set_time_local_dc(timestamp_t local_time)
+{
+	when = local_time;
+	dcs[0].when = local_time;
+}
+
 void dive::shift_time(timestamp_t delta)
 {
 	when += delta;

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -2561,6 +2561,11 @@ timestamp_t dive::get_time_utc() const
 	return when.in_utc();
 }
 
+void dive::set_time(datetime_t time)
+{
+	when = time;
+}
+
 /* Set the local time. Doesn't change timezone information */
 void dive::set_time_local(timestamp_t local_time)
 {
@@ -2570,10 +2575,19 @@ void dive::set_time_local(timestamp_t local_time)
 /* Set time and also time of the first dc.
  * Note that we are not very consistent about setting the time of the first dc.
  */
+void dive::set_time_dc(datetime_t time)
+{
+	when = time;
+	dcs[0].when = time;
+}
+
+/* Set time and also time of the first dc.
+ * Note that we are not very consistent about setting the time of the first dc.
+ */
 void dive::set_time_local_dc(timestamp_t local_time)
 {
 	set_time_local(local_time);
-	dcs[0].when = local_time;
+	dcs[0].when = when;
 }
 
 void dive::shift_time(timestamp_t delta)

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -2157,7 +2157,11 @@ bool dive::likely_same(const struct dive &b) const
 	int fuzz = std::max(duration.seconds, b.duration.seconds) / 2;
 	fuzz = std::max(fuzz, 60);
 
-	return (when <= b.when + fuzz) && (when >= b.when - fuzz);
+	/*
+	 * Probably not worth considering global time, here.
+	 */
+	return (get_time_local() <= b.get_time_local() + fuzz) &&
+	       (get_time_local() >= b.get_time_local() - fuzz);
 }
 
 static bool operator==(const sample &a, const sample &b)
@@ -2417,15 +2421,15 @@ duration_t dive::totaltime() const
 	return { .seconds = time };
 }
 
-timestamp_t dive::endtime() const
+timestamp_t dive::endtime_local() const
 {
-	return when + totaltime().seconds;
+	return get_time_local() + totaltime().seconds;
 }
 
-bool dive::time_during_dive_with_offset(timestamp_t when, timestamp_t offset) const
+bool dive::time_during_dive_with_offset(timestamp_t local_time, timestamp_t offset) const
 {
-	timestamp_t start = when;
-	timestamp_t end = endtime();
+	timestamp_t start = get_time_local();
+	timestamp_t end = endtime_local();
 	return start - offset <= when && when <= end + offset;
 }
 
@@ -2535,6 +2539,21 @@ bool dive::cache_is_valid() const
 pressure_t dive::get_surface_pressure() const
 {
 	return surface_pressure.mbar > 0 ? surface_pressure : 1_atm;
+}
+
+timestamp_t dive::get_time_local() const
+{
+	return when;
+}
+
+void dive::set_time_local(timestamp_t local_time)
+{
+	when = local_time;
+}
+
+void dive::shift_time(timestamp_t delta)
+{
+	when += delta;
 }
 
 /* This returns the conversion factor that you need to multiply

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -2561,6 +2561,11 @@ timestamp_t dive::get_time_utc() const
 	return when.in_utc();
 }
 
+std::optional<int32_t> dive::get_offset_to_utc() const
+{
+	return when.offset_to_utc;
+}
+
 void dive::set_time(datetime_t time)
 {
 	when = time;
@@ -2579,6 +2584,11 @@ void dive::set_time_dc(datetime_t time)
 {
 	when = time;
 	dcs[0].when = time;
+}
+
+void dive::set_offset_to_utc(std::optional<int32_t> offset)
+{
+	when.offset_to_utc = offset;
 }
 
 /* Set time and also time of the first dc.

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -2430,7 +2430,7 @@ bool dive::time_during_dive_with_offset(timestamp_t local_time, timestamp_t offs
 {
 	timestamp_t start = get_time_local();
 	timestamp_t end = endtime_local();
-	return start - offset <= when && when <= end + offset;
+	return start - offset <= get_time_local() && get_time_local() <= end + offset;
 }
 
 /* this sets a usually unused copy of the preferences with the units
@@ -2543,12 +2543,18 @@ pressure_t dive::get_surface_pressure() const
 
 timestamp_t dive::get_time_local() const
 {
-	return when;
+	return when.local_time;
 }
 
+timestamp_t dive::get_time_utc() const
+{
+	return when.in_utc();
+}
+
+/* Set the local time. Doesn't change timezone information */
 void dive::set_time_local(timestamp_t local_time)
 {
-	when = local_time;
+	when.local_time = local_time;
 }
 
 /* Set time and also time of the first dc.
@@ -2556,13 +2562,13 @@ void dive::set_time_local(timestamp_t local_time)
  */
 void dive::set_time_local_dc(timestamp_t local_time)
 {
-	when = local_time;
+	set_time_local(local_time);
 	dcs[0].when = local_time;
 }
 
 void dive::shift_time(timestamp_t delta)
 {
-	when += delta;
+	when.local_time += delta;
 }
 
 /* This returns the conversion factor that you need to multiply

--- a/core/dive.h
+++ b/core/dive.h
@@ -95,12 +95,14 @@ public:
 	void fixup_dive_dc(struct divecomputer &dc);
 
 	// Time is accessed by accessor functions, so that we might implement timezones later on.
+	datetime_t get_time() const;
 	timestamp_t get_time_local() const;
 	timestamp_t get_time_utc() const;
 	void set_time_local(timestamp_t local_time);
 	void set_time_local_dc(timestamp_t local_time);
 	void shift_time(timestamp_t delta);
 	timestamp_t endtime_local() const;	/* maximum over divecomputers (with samples) */
+	timestamp_t endtime_utc() const;	/* maximum over divecomputers (with samples) */
 	duration_t totaltime() const;		/* maximum over divecomputers (with samples) */
 	temperature_t dc_airtemp() const;	/* average over divecomputers */
 	temperature_t dc_watertemp() const;	/* average over divecomputers */

--- a/core/dive.h
+++ b/core/dive.h
@@ -98,10 +98,12 @@ public:
 	datetime_t get_time() const;
 	timestamp_t get_time_local() const;
 	timestamp_t get_time_utc() const;
+	std::optional<int32_t> get_offset_to_utc() const;
 	void set_time(datetime_t time);
 	void set_time_dc(datetime_t time);
 	void set_time_local(timestamp_t local_time);
 	void set_time_local_dc(timestamp_t local_time);
+	void set_offset_to_utc(std::optional<int32_t> offset);
 	void shift_time(timestamp_t delta);
 	timestamp_t endtime_local() const;	/* maximum over divecomputers (with samples) */
 	timestamp_t endtime_utc() const;	/* maximum over divecomputers (with samples) */

--- a/core/dive.h
+++ b/core/dive.h
@@ -97,6 +97,7 @@ public:
 	// Time is accessed by accessor functions, so that we might implement timezones later on.
 	timestamp_t get_time_local() const;
 	void set_time_local(timestamp_t local_time);
+	void set_time_local_dc(timestamp_t local_time);
 	void shift_time(timestamp_t delta);
 	timestamp_t endtime_local() const;	/* maximum over divecomputers (with samples) */
 	duration_t totaltime() const;		/* maximum over divecomputers (with samples) */

--- a/core/dive.h
+++ b/core/dive.h
@@ -44,7 +44,9 @@ struct non_copying_unique_ptr : public std::unique_ptr<T> {
 
 struct dive {
 	struct dive_trip *divetrip = nullptr;
-	timestamp_t when = 0;
+private:
+	timestamp_t when = 0;			// To be accessed by accessor functions
+public:
 	struct dive_site *dive_site = nullptr;
 	std::string notes;
 	std::string diveguide, buddy;
@@ -91,11 +93,17 @@ struct dive {
 	int number_of_computers() const;
 	void fixup_dive();
 	void fixup_dive_dc(struct divecomputer &dc);
-	timestamp_t endtime() const;		/* maximum over divecomputers (with samples) */
+
+	// Time is accessed by accessor functions, so that we might implement timezones later on.
+	timestamp_t get_time_local() const;
+	void set_time_local(timestamp_t local_time);
+	void shift_time(timestamp_t delta);
+	timestamp_t endtime_local() const;	/* maximum over divecomputers (with samples) */
 	duration_t totaltime() const;		/* maximum over divecomputers (with samples) */
 	temperature_t dc_airtemp() const;	/* average over divecomputers */
 	temperature_t dc_watertemp() const;	/* average over divecomputers */
 	pressure_t get_surface_pressure() const;
+
 
 	struct get_maximal_gas_result { int o2_p; int he_p; int o2low_p; };
 	get_maximal_gas_result get_maximal_gas() const;
@@ -114,7 +122,7 @@ struct dive {
 	const cylinder_t *get_cylinder(int idx) const;
 	weight_t total_weight() const;
 	int get_salinity() const;
-	bool time_during_dive_with_offset(timestamp_t when, timestamp_t offset) const;
+	bool time_during_dive_with_offset(timestamp_t local_time, timestamp_t offset) const;
 	std::string get_country() const;
 	std::string get_location() const;
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -45,7 +45,7 @@ struct non_copying_unique_ptr : public std::unique_ptr<T> {
 struct dive {
 	struct dive_trip *divetrip = nullptr;
 private:
-	timestamp_t when = 0;			// To be accessed by accessor functions
+	datetime_t when;			// To be accessed by accessor functions
 public:
 	struct dive_site *dive_site = nullptr;
 	std::string notes;
@@ -96,6 +96,7 @@ public:
 
 	// Time is accessed by accessor functions, so that we might implement timezones later on.
 	timestamp_t get_time_local() const;
+	timestamp_t get_time_utc() const;
 	void set_time_local(timestamp_t local_time);
 	void set_time_local_dc(timestamp_t local_time);
 	void shift_time(timestamp_t delta);

--- a/core/dive.h
+++ b/core/dive.h
@@ -98,6 +98,8 @@ public:
 	datetime_t get_time() const;
 	timestamp_t get_time_local() const;
 	timestamp_t get_time_utc() const;
+	void set_time(datetime_t time);
+	void set_time_dc(datetime_t time);
 	void set_time_local(timestamp_t local_time);
 	void set_time_local_dc(timestamp_t local_time);
 	void shift_time(timestamp_t delta);

--- a/core/divecomputer.h
+++ b/core/divecomputer.h
@@ -30,7 +30,7 @@ struct tank_sensor_mapping;
  * A deviceid or diveid of zero is assumed to be "no ID".
  */
 struct divecomputer {
-	timestamp_t when = 0;
+	datetime_t when;
 	duration_t duration, surfacetime, last_manual_time;
 	depth_t maxdepth, meandepth;
 	temperature_t airtemp, watertemp;

--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -994,7 +994,7 @@ std::array<std::unique_ptr<dive>, 2> dive_table::split_dive_at(const struct dive
 	auto it1 = d1->dcs.begin();
 	auto it2 = d2->dcs.begin();
 	while (it1 != d1->dcs.end() && it2 != d2->dcs.end()) {
-		it2->when += t;
+		it2->when.local_time += t;
 		for (auto &sample: it2->samples)
 			sample.time.seconds -= t;
 

--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -259,20 +259,20 @@ int dive_table::calculate_cns(struct dive &dive) const
 #endif
 	/* Look at next dive in dive list table and correct i when needed */
 	while (i < nr_dives - 1) {
-		if ((*this)[i]->get_time_local() > dive.get_time_local())
+		if ((*this)[i]->get_time_utc() > dive.get_time_utc())
 			break;
 		i++;
 	}
 	/* Look at previous dive in dive list table and correct i when needed */
 	while (i > 0) {
-		if ((*this)[i - 1]->get_time_local() < dive.get_time_local())
+		if ((*this)[i - 1]->get_time_utc() < dive.get_time_utc())
 			break;
 		i--;
 	}
 #if DECO_CALC_DEBUG & 2
 	printf("Dive number corrected to #%d\n", i);
 #endif
-	last_starttime = dive.get_time_local();
+	last_starttime = dive.get_time_utc();
 	/* Walk backwards to check previous dives - how far do we need to go back? */
 	while (i--) {
 		if (static_cast<size_t>(i) == divenr && i > 0)
@@ -289,13 +289,13 @@ int dive_table::calculate_cns(struct dive &dive) const
 #endif
 			continue;
 		}
-		if (pdive.get_time_local() >= dive.get_time_local() || pdive.endtime_local() + 12 * 60 * 60 < last_starttime) {
+		if (pdive.get_time_utc() >= dive.get_time_utc() || pdive.endtime_utc() + 12 * 60 * 60 < last_starttime) {
 #if DECO_CALC_DEBUG & 2
 			printf("No\n");
 #endif
 			break;
 		}
-		last_starttime = pdive.get_time_local();
+		last_starttime = pdive.get_time_utc();
 #if DECO_CALC_DEBUG & 2
 		printf("Yes\n");
 #endif
@@ -314,7 +314,7 @@ int dive_table::calculate_cns(struct dive &dive) const
 			continue;
 		}
 		/* Don't add future dives */
-		if (pdive.get_time_local() >= dive.get_time_local()) {
+		if (pdive.get_time_utc() >= dive.get_time_utc()) {
 #if DECO_CALC_DEBUG & 2
 			printf("No - future or same dive\n");
 #endif
@@ -333,7 +333,7 @@ int dive_table::calculate_cns(struct dive &dive) const
 
 		/* CNS reduced with 90min halftime during surface interval */
 		if (last_endtime)
-			cns /= pow(2, (pdive.get_time_local() - last_endtime) / (90.0 * 60.0));
+			cns /= pow(2, (pdive.get_time_utc() - last_endtime) / (90.0 * 60.0));
 #if DECO_CALC_DEBUG & 2
 		printf("CNS after surface interval: %f\n", cns);
 #endif
@@ -343,13 +343,13 @@ int dive_table::calculate_cns(struct dive &dive) const
 		printf("CNS after previous dive: %f\n", cns);
 #endif
 
-		last_starttime = pdive.get_time_local();
-		last_endtime = pdive.endtime_local();
+		last_starttime = pdive.get_time_utc();
+		last_endtime = pdive.endtime_utc();
 	}
 
 	/* CNS reduced with 90min halftime during surface interval */
 	if (last_endtime)
-		cns /= pow(2, (dive.get_time_local() - last_endtime) / (90.0 * 60.0));
+		cns /= pow(2, (dive.get_time_utc() - last_endtime) / (90.0 * 60.0));
 #if DECO_CALC_DEBUG & 2
 	printf("CNS after last surface interval: %f\n", cns);
 #endif
@@ -472,20 +472,20 @@ int dive_table::init_decompression(struct deco_state *ds, const struct dive *div
 #endif
 	/* Look at next dive in dive list table and correct i when needed */
 	while (i + 1 < nr_dives) {
-		if ((*this)[i]->get_time_local() > dive->get_time_local())
+		if ((*this)[i]->get_time_utc() > dive->get_time_utc())
 			break;
 		i++;
 	}
 	/* Look at previous dive in dive list table and correct i when needed */
 	while (i > 0) {
-		if ((*this)[i - 1]->get_time_local() < dive->get_time_local())
+		if ((*this)[i - 1]->get_time_utc() < dive->get_time_utc())
 			break;
 		i--;
 	}
 #if DECO_CALC_DEBUG & 2
 	printf("Dive number corrected to #%d\n", i);
 #endif
-	last_starttime = dive->get_time_local();
+	last_starttime = dive->get_time_utc();
 	/* Walk backwards to check previous dives - how far do we need to go back? */
 	while (i--) {
 		if (static_cast<size_t>(i) == divenr && i > 0)
@@ -502,13 +502,13 @@ int dive_table::init_decompression(struct deco_state *ds, const struct dive *div
 #endif
 			continue;
 		}
-		if (pdive.get_time_local() >= dive->get_time_local() || pdive.endtime_local() + 48 * 60 * 60 < last_starttime) {
+		if (pdive.get_time_utc() >= dive->get_time_utc() || pdive.endtime_utc() + 48 * 60 * 60 < last_starttime) {
 #if DECO_CALC_DEBUG & 2
 			printf("No\n");
 #endif
 			break;
 		}
-		last_starttime = pdive.get_time_local();
+		last_starttime = pdive.get_time_utc();
 #if DECO_CALC_DEBUG & 2
 		printf("Yes\n");
 #endif
@@ -527,7 +527,7 @@ int dive_table::init_decompression(struct deco_state *ds, const struct dive *div
 			continue;
 		}
 		/* Don't add future dives */
-		if (pdive.get_time_local() >= dive->get_time_local()) {
+		if (pdive.get_time_utc() >= dive->get_time_utc()) {
 #if DECO_CALC_DEBUG & 2
 			printf("No - future or same dive\n");
 #endif
@@ -557,7 +557,7 @@ int dive_table::init_decompression(struct deco_state *ds, const struct dive *div
 			dump_tissues(ds);
 #endif
 		} else {
-			surface_time = pdive.get_time_local() - last_endtime;
+			surface_time = pdive.get_time_utc() - last_endtime;
 			if (surface_time < 0) {
 #if DECO_CALC_DEBUG & 2
 				printf("Exit because surface intervall is %d\n", surface_time);
@@ -573,8 +573,8 @@ int dive_table::init_decompression(struct deco_state *ds, const struct dive *div
 
 		add_dive_to_deco(ds, pdive, in_planner);
 
-		last_starttime = pdive.get_time_local();
-		last_endtime = pdive.endtime_local();
+		last_starttime = pdive.get_time_utc();
+		last_endtime = pdive.endtime_utc();
 		clear_vpmb_state(ds);
 #if DECO_CALC_DEBUG & 2
 		printf("Tissues after added dive #%d:\n", pdive.number);
@@ -594,7 +594,7 @@ int dive_table::init_decompression(struct deco_state *ds, const struct dive *div
 		dump_tissues(ds);
 #endif
 	} else {
-		surface_time = dive->get_time_local() - last_endtime;
+		surface_time = dive->get_time_utc() - last_endtime;
 		if (surface_time < 0) {
 #if DECO_CALC_DEBUG & 2
 			printf("Exit because surface intervall is %d\n", surface_time);
@@ -662,9 +662,9 @@ int comp_dives(const struct dive &a, const struct dive &b)
 	int cmp;
 	if (&a == &b)
 		return 0;	/* reflexivity */
-	if (a.get_time_local() < b.get_time_local())
+	if (a.get_time_utc() < b.get_time_utc())
 		return -1;
-	if (a.get_time_local() > b.get_time_local())
+	if (a.get_time_utc() > b.get_time_utc())
 		return 1;
 	if (a.divetrip != b.divetrip) {
 		if (!b.divetrip)
@@ -844,27 +844,29 @@ bool dive_or_trip_less_than(struct dive_or_trip a, struct dive_or_trip b)
  *
  * TODO: Here we want to consider global tome
  */
-timestamp_t dive_table::get_surface_interval(timestamp_t when) const
+timestamp_t dive_table::get_surface_interval(datetime_t when) const
 {
+	timestamp_t when_utc = when.in_utc();
+
 	/* find previous dive. might want to use a binary search. */
 	auto it = std::find_if(rbegin(), rend(),
-			       [when] (auto &d) { return d->get_time_local() < when; });
+			       [when_utc] (auto &d) { return d->get_time_utc() < when_utc; });
 	if (it == rend())
 		return -1;
 
-	timestamp_t prev_end = (*it)->endtime_local();
-	if (prev_end > when)
+	timestamp_t prev_end = (*it)->endtime_utc();
+	if (prev_end > when_utc)
 		return 0;
-	return when - prev_end;
+	return when_utc - prev_end;
 }
 
 /* Find visible dive close to given date. First search towards older,
  * then newer dives. */
-struct dive *dive_table::find_next_visible_dive(timestamp_t when)
+struct dive *dive_table::find_next_visible_dive(datetime_t when)
 {
 	/* we might want to use binary search here */
 	auto it = std::find_if(begin(), end(),
-			       [when] (auto &d) { return d->get_time_local() <= when; });
+			       [when] (auto &d) { return d->get_time_utc() <= when.in_utc(); });
 
 	for (auto it2 = it; it2 != begin(); --it2) {
 		if (!(*std::prev(it2))->hidden_by_filter)
@@ -1132,7 +1134,7 @@ static struct dive_trip *get_preferred_trip(const struct dive &a, const struct d
 	 * Ok, so both have location and notes.
 	 * Pick the earlier one.
 	 */
-	if (a.get_time_local() < b.get_time_local())
+	if (a.get_time_utc() < b.get_time_utc())
 		return atrip;
 	return btrip;
 }
@@ -1200,7 +1202,7 @@ merge_result dive_table::merge_dives(const std::vector<dive *> &dives) const
 		return res;
 	}
 
-	auto d = merge_two_dives(*dives[0], *dives[1], dives[1]->get_time_local() - dives[0]->get_time_local(), false);
+	auto d = merge_two_dives(*dives[0], *dives[1], dives[1]->get_time_utc() - dives[0]->get_time_local(), false);
 	d->divetrip = get_preferred_trip(*dives[0], *dives[1]);
 
 	for (size_t i = 2; i < dives.size(); ++i) {

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -36,8 +36,8 @@ struct dive_table : public sorted_owning_table<dive, &comp_dives> {
 	int init_decompression(struct deco_state *ds, const struct dive *dive, bool in_planner) const;
 	void update_cylinder_related_info(struct dive &dive) const;
 	int get_dive_nr_at_idx(int idx) const;
-	timestamp_t get_surface_interval(timestamp_t when) const;
-	struct dive *find_next_visible_dive(timestamp_t when);
+	timestamp_t get_surface_interval(datetime_t when) const;
+	struct dive *find_next_visible_dive(datetime_t when);
 	std::array<std::unique_ptr<dive>, 2> split_divecomputer(const struct dive &src, int num) const;
 	std::array<std::unique_ptr<dive>, 2> split_dive(const struct dive &dive) const;
 	std::array<std::unique_ptr<dive>, 2> split_dive_at_time(const struct dive &dive, duration_t time) const;

--- a/core/divelog.cpp
+++ b/core/divelog.cpp
@@ -107,7 +107,7 @@ static void merge_imported_dives(struct dive_table &table)
 		/* only try to merge overlapping dives - or if one of the dives has
 		 * zero duration (that might be a gps marker from the webservice) */
 		if (prev->duration.seconds && dive->duration.seconds &&
-		    prev->endtime() < dive->when)
+		    prev->endtime_local() < dive->get_time_local())
 			continue;
 
 		auto merged = table.try_to_merge(*prev, *dive, false);
@@ -238,7 +238,7 @@ static bool merge_dive_tables(const std::vector<dive *> &dives_from, struct dive
 		 * by is_same_dive() were already merged, and is_same_dive() should be
 		 * transitive. But let's just go *completely* sure for the odd corner-case. */
 		if (j > 0 && (last_merged_into == std::string::npos || j > last_merged_into + 1) &&
-		    dives_to[j - 1]->endtime() > dive_to_add->when) {
+		    dives_to[j - 1]->endtime_local() > dive_to_add->get_time_local()) {
 			if (try_to_merge_into(*dive_to_add, dives_to[j - 1], prefer_imported,
 					      dives_to_add, dives_to_remove)) {
 				last_merged_into = j - 1;
@@ -250,7 +250,7 @@ static bool merge_dive_tables(const std::vector<dive *> &dives_from, struct dive
 		/* That didn't merge into the previous dive.
 		 * Try to merge into next dive. */
 		if (j < dives_to.size() && (last_merged_into == std::string::npos || j > last_merged_into) &&
-		    dive_to_add->endtime() > dives_to[j]->when) {
+		    dive_to_add->endtime_local() > dives_to[j]->get_time_local()) {
 			if (try_to_merge_into(*dive_to_add, dives_to[j], prefer_imported,
 					      dives_to_add, dives_to_remove)) {
 				last_merged_into = j;

--- a/core/import-cobalt.cpp
+++ b/core/import-cobalt.cpp
@@ -103,7 +103,7 @@ static int cobalt_dive(void *param, int, char **data, char **)
 	dive_start(state);
 	state->cur_dive->number = atoi(data[0]);
 
-	state->cur_dive->when = (time_t)(atol(data[1]));
+	state->cur_dive->set_time_local((time_t)(atol(data[1])));
 
 	if (data[4])
 		utf8_string_std(data[4], &state->cur_dive->notes);

--- a/core/import-csv.cpp
+++ b/core/import-csv.cpp
@@ -510,7 +510,7 @@ int try_to_open_csv(std::string &mem, enum csv_format type, struct divelog *log)
 		return 0;
 
 	auto dive = std::make_unique<struct dive>();
-	dive->when = date;
+	dive->set_time_local(date);
 	dive->number = atoi(header[1]);
 	dc = &dive->dcs[0];
 
@@ -603,7 +603,7 @@ int parse_txt_file(const char *filename, const char *csv, struct divelog *log)
 		cur_tm.tm_sec = ss;
 
 		auto dive = std::make_unique<struct dive>();
-		dive->when = utc_mktime(&cur_tm);;
+		dive->set_time_local(utc_mktime(&cur_tm));
 		dive->dcs[0].model = "Poseidon MkVI Discovery";
 		value = parse_mkvi_value(memtxt.data(), "Rig Serial number");
 		dive->dcs[0].deviceid = atoi(value.c_str());

--- a/core/import-divinglog.cpp
+++ b/core/import-divinglog.cpp
@@ -282,7 +282,7 @@ static int divinglog_dive(void *param, int, char **data, char **)
 	diveid = atoi(data[13]);
 	state->cur_dive->number = atoi(data[0]);
 
-	state->cur_dive->when = (time_t)(atol(data[1]));
+	state->cur_dive->set_time_local((time_t)(atol(data[1])));
 
 	if (data[2])
 		state->log->sites.find_or_create(std::string(data[2]))->add_dive(state->cur_dive.get());

--- a/core/import-seac.cpp
+++ b/core/import-seac.cpp
@@ -125,7 +125,7 @@ static int seac_dive(void *param, int, char **data, char **)
 
 	std::string isodatetime = format_string_std("%4i-%02i-%02iT%02i:%02i:%02i%6s", year, month, day, hour, min, sec, timezoneoffset[tz]);
 	divetime = get_dive_datetime_from_isostring(isodatetime.c_str());
-	state->cur_dive->when = divetime;
+	state->cur_dive->set_time_local(divetime);
 
 	// 6 = dive_type
 	// Dive type 2?

--- a/core/import-shearwater.cpp
+++ b/core/import-shearwater.cpp
@@ -229,7 +229,7 @@ static int shearwater_dive(void *param, int, char **data, char **)
 	dive_start(state);
 	state->cur_dive->number = atoi(data[0]);
 
-	state->cur_dive->when = (time_t)(atol(data[1]));
+	state->cur_dive->set_time_local((time_t)(atol(data[1])));
 
 	long int dive_id = atol(data[11]);
 
@@ -355,7 +355,7 @@ static int shearwater_cloud_dive(void *param, int, char **data, char **)
 	dive_start(state);
 	state->cur_dive->number = atoi(data[0]);
 
-	state->cur_dive->when = (time_t)(atol(data[1]));
+	state->cur_dive->set_time_local((time_t)(atol(data[1])));
 
 	long int dive_id = atol(data[11]);
 	if (data[12])

--- a/core/import-suunto.cpp
+++ b/core/import-suunto.cpp
@@ -177,7 +177,7 @@ static int dm4_dive(void *param, int, char **data, char **)
 	dive_start(state);
 	state->cur_dive->number = atoi(data[0]);
 
-	state->cur_dive->when = (time_t)(atol(data[1]));
+	state->cur_dive->set_time_local((time_t)(atol(data[1])));
 	if (data[2])
 		utf8_string_std(data[2], &state->cur_dive->notes);
 
@@ -366,7 +366,7 @@ static int dm5_dive(void *param, int, char **data, char **)
 	dive_start(state);
 	state->cur_dive->number = atoi(data[0]);
 
-	state->cur_dive->when = (time_t)(atol(data[1]));
+	state->cur_dive->set_time_local((time_t)(atol(data[1])));
 	if (data[2])
 		utf8_string_std(data[2], &state->cur_dive->notes);
 

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -651,11 +651,12 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 		tm.tm_hour = dt.hour;
 		tm.tm_min = dt.minute;
 		tm.tm_sec = dt.second;
-		dive->when = dive->dcs[0].when = utc_mktime(&tm);
+		dive->dcs[0].when = utc_mktime(&tm);
+		dive->set_time_local(dive->dcs[0].when);
 	}
 
 	// Parse the divetime.
-	std::string date_string = get_dive_date_c_string(dive->when);
+	std::string date_string = get_dive_date_c_string(dive->get_time_local());
 	dev_info(translate("gettextFromC", "Dive %d: %s"), import_dive_number, date_string.c_str());
 
 	unsigned int divetime = 0;
@@ -852,7 +853,7 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 
 	/* If we already saw this dive, abort. */
 	if (!devdata->force_download && find_dive(dive->dcs[0])) {
-		std::string date_string = get_dive_date_c_string(dive->when);
+		std::string date_string = get_dive_date_c_string(dive->get_time_local());
 		dev_info(translate("gettextFromC", "Already downloaded dive at %s"), date_string.c_str());
 		return false;
 	}

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -651,8 +651,7 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 		tm.tm_hour = dt.hour;
 		tm.tm_min = dt.minute;
 		tm.tm_sec = dt.second;
-		dive->dcs[0].when = utc_mktime(&tm);
-		dive->set_time_local(dive->dcs[0].when);
+		dive->set_time_local_dc(utc_mktime(&tm));
 	}
 
 	// Parse the divetime.

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -651,7 +651,11 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 		tm.tm_hour = dt.hour;
 		tm.tm_min = dt.minute;
 		tm.tm_sec = dt.second;
-		dive->set_time_local_dc(utc_mktime(&tm));
+		datetime_t t;
+		t.local_time = utc_mktime(&tm);
+		if (dt.timezone != DC_TIMEZONE_NONE)
+			t.offset_to_utc = dt.timezone;
+		dive->set_time_dc(t);
 	}
 
 	// Parse the divetime.

--- a/core/liquivision.cpp
+++ b/core/liquivision.cpp
@@ -217,7 +217,7 @@ static void parse_dives(int log_version, const unsigned char *buf, unsigned int 
 		dive->meandepth.mm = array_uint16_le(buf + ptr) * 10;	// cm->mm
 		ptr += 2;
 
-		dive->when = array_uint32_le(buf + ptr);
+		dive->set_time_local(array_uint32_le(buf + ptr));
 		ptr += 4;
 
 		//unsigned int end_time = array_uint32_le(buf + ptr);

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -1398,7 +1398,7 @@ static void create_new_dive(timestamp_t when, struct git_parser_state *state)
 	state->active_dive = std::make_unique<dive>();
 
 	/* We'll fill in more data from the dive file */
-	state->active_dive->when = when;
+	state->active_dive->set_time_local(when);
 
 	if (state->active_trip)
 		state->active_trip->add_dive(state->active_dive.get());
@@ -1648,7 +1648,7 @@ static struct divecomputer *create_new_dc(struct dive *dive)
 		dive->dcs.emplace_back();
 		dc = &dive->dcs.back();
 	}
-	dc->when = dive->when;
+	dc->when = dive->get_time_local();
 	dc->duration = dive->duration;
 	return dc;
 }

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -148,6 +148,15 @@ static void update_time(timestamp_t *when, const char *line)
 	*when = utc_mktime(&tm);
 }
 
+static void update_offset_to_utc(std::optional<int> *utc_offset, const char *line)
+{
+	unsigned h, m = 0;
+
+	if (sscanf(line, "%02u:%02u", &h, &m) < 2)
+		return;
+	*utc_offset = h * 3600 + m * 60;
+}
+
 static duration_t get_duration(const char *line)
 {
 	int m = 0, s = 0;
@@ -171,6 +180,13 @@ static int get_index(const char *line)
 
 static int get_hex(const char *line)
 { return strtoul(line, NULL, 16); }
+
+static void parse_dive_offset_to_utc(char *line, struct git_parser_state *state)
+{
+	std::optional<int> utc_offset;
+	update_offset_to_utc(&utc_offset, line);
+	state->active_dive->set_offset_to_utc(utc_offset);
+}
 
 static void parse_dive_gps(char *line, struct git_parser_state *state)
 {
@@ -762,6 +778,9 @@ static void parse_dc_surfacetime(char *line, struct git_parser_state *state)
 static void parse_dc_time(char *line, struct git_parser_state *state)
 { update_time(&state->active_dc->when.local_time, line); }
 
+static void parse_dc_offset_to_utc(char *line, struct git_parser_state *state)
+{ update_offset_to_utc(&state->active_dc->when.offset_to_utc, line); }
+
 static void parse_dc_watertemp(char *line, struct git_parser_state *state)
 { state->active_dc->watertemp = get_temperature(line); }
 
@@ -1069,7 +1088,7 @@ static const std::array dc_action {
 #define D(x) keyword_action { #x, parse_dc_ ## x }
 	D(airtemp), D(date), D(dctype), D(deviceid), D(diveid), D(duration),
 	D(event), D(keyvalue), D(lastmanualtime), D(maxdepth), D(meandepth), D(model), D(numberofoxygensensors),
-	D(salinity), D(surfacepressure), D(surfacetime), D(tanksensormapping), D(time), D(watertemp)
+	D(offset_to_utc), D(salinity), D(surfacepressure), D(surfacetime), D(tanksensormapping), D(time), D(watertemp)
 };
 
 /* Sample lines start with a space or a number */
@@ -1088,7 +1107,8 @@ static const std::array dive_action {
 	/* For historical reasons, we accept divemaster and diveguide */
 	D(airpressure), D(airtemp), D(buddy), D(chill), D(current), D(cylinder), D(diveguide),
 	keyword_action { "divemaster", parse_dive_diveguide },
-	D(divesiteid), D(duration), D(gps), D(invalid), D(location), D(notes), D(notrip), D(rating), D(suit), D(surge),
+	D(divesiteid), D(duration), D(gps), D(invalid), D(location), D(offset_to_utc),
+	D(notes), D(notrip), D(rating), D(suit), D(surge),
 	D(tags), D(visibility), D(watersalinity), D(watertemp), D(wavesize), D(weightsystem)
 };
 

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -719,7 +719,7 @@ static void parse_dc_airtemp(char *line, struct git_parser_state *state)
 { state->active_dc->airtemp = get_temperature(line); }
 
 static void parse_dc_date(char *line, struct git_parser_state *state)
-{ update_date(&state->active_dc->when, line); }
+{ update_date(&state->active_dc->when.local_time, line); }
 
 static void parse_dc_deviceid(char *line, struct git_parser_state *state)
 {
@@ -760,7 +760,7 @@ static void parse_dc_surfacetime(char *line, struct git_parser_state *state)
 { state->active_dc->surfacetime = get_duration(line); }
 
 static void parse_dc_time(char *line, struct git_parser_state *state)
-{ update_time(&state->active_dc->when, line); }
+{ update_time(&state->active_dc->when.local_time, line); }
 
 static void parse_dc_watertemp(char *line, struct git_parser_state *state)
 { state->active_dc->watertemp = get_temperature(line); }
@@ -1648,7 +1648,7 @@ static struct divecomputer *create_new_dc(struct dive *dive)
 		dive->dcs.emplace_back();
 		dc = &dive->dcs.back();
 	}
-	dc->when = dive->get_time_local();
+	dc->when = dive->get_time();
 	dc->duration = dive->duration;
 	return dc;
 }

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -850,9 +850,9 @@ static void try_to_fill_dc(struct divecomputer *dc, const char *name, char *buf,
 
 	start_match("divecomputer", name, buf);
 
-	if (MATCH_STATE("date", divedate, &dc->when))
+	if (MATCH_STATE("date", divedate, &dc->when.local_time))
 		return;
-	if (MATCH_STATE("time", divetime, &dc->when))
+	if (MATCH_STATE("time", divetime, &dc->when.local_time))
 		return;
 	if (MATCH("model", utf8_string_std, &dc->model))
 		return;

--- a/core/parse.cpp
+++ b/core/parse.cpp
@@ -104,7 +104,7 @@ void event_end(struct parser_state *state)
 bool is_dive(struct parser_state *state)
 {
 	return state->cur_dive &&
-		(state->cur_dive->dive_site || state->cur_dive->when || !state->cur_dive->dcs[0].samples.empty());
+		(state->cur_dive->dive_site || state->cur_dive->get_time_local() || !state->cur_dive->dcs[0].samples.empty());
 }
 
 void reset_dc_info(struct divecomputer *, struct parser_state *state)
@@ -385,7 +385,7 @@ void divecomputer_start(struct parser_state *state)
 void divecomputer_end(struct parser_state *state)
 {
 	if (!state->cur_dc->when)
-		state->cur_dc->when = state->cur_dive->when;
+		state->cur_dc->when = state->cur_dive->get_time_local();
 	state->cur_dc = NULL;
 }
 

--- a/core/parse.cpp
+++ b/core/parse.cpp
@@ -384,8 +384,8 @@ void divecomputer_start(struct parser_state *state)
 
 void divecomputer_end(struct parser_state *state)
 {
-	if (!state->cur_dc->when)
-		state->cur_dc->when = state->cur_dive->get_time_local();
+	if (!state->cur_dc->when.local_time)
+		state->cur_dc->when = state->cur_dive->get_time();
 	state->cur_dc = NULL;
 }
 

--- a/core/picture.cpp
+++ b/core/picture.cpp
@@ -34,9 +34,9 @@ int get_picture_idx(const picture_table &t, const std::string &filename)
 /* Return distance of timestamp to time of dive. Result is always positive, 0 means during dive. */
 static timestamp_t time_from_dive(const struct dive &d, timestamp_t timestamp)
 {
-	timestamp_t end_time = d.endtime();
-	if (timestamp < d.when)
-		return d.when - timestamp;
+	timestamp_t end_time = d.endtime_local();
+	if (timestamp < d.get_time_local())
+		return d.get_time_local() - timestamp;
 	else if (timestamp > end_time)
 		return timestamp - end_time;
 	else
@@ -99,7 +99,7 @@ std::pair<std::optional<picture>, dive *> create_picture(const std::string &file
 
 	struct picture picture;
 	picture.filename = filename;
-	picture.offset.seconds = metadata.timestamp - dive->when + shift_time;
+	picture.offset.seconds = metadata.timestamp - dive->get_time_local() + shift_time;
 	picture.location = metadata.location;
 	return { picture, dive };
 }

--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -227,7 +227,8 @@ static void create_dive_from_plan(struct diveplan &diveplan, struct dive *dive, 
 	// reset the cylinders and clear out the samples and events of the
 	// dive-to-be-planned so we can restart
 	reset_cylinders(dive, track_gas);
-	dc->when = dive->when = diveplan.when;
+	dive->set_time_local(diveplan.when);
+	dc->when = diveplan.when;
 	dc->surface_pressure = diveplan.surface_pressure;
 	dc->salinity = diveplan.salinity;
 	dc->samples.clear();

--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -53,7 +53,7 @@ static std::vector<depth_t> decostoplevels_imperial = { 0_ft, 10_ft, 20_ft, 30_f
 void dump_plan(const struct diveplan &diveplan)
 {
 	struct tm tm;
-	utc_mkdate(diveplan.when, &tm);
+	utc_mkdate(diveplan.when.local_time, &tm);
 
 	printf("\nDiveplan @ %04d-%02d-%02d %02d:%02d:%02d (surfpres %dmbar):\n",
 	       tm.tm_year, tm.tm_mon + 1, tm.tm_mday,
@@ -227,7 +227,7 @@ static void create_dive_from_plan(struct diveplan &diveplan, struct dive *dive, 
 	// reset the cylinders and clear out the samples and events of the
 	// dive-to-be-planned so we can restart
 	reset_cylinders(dive, track_gas);
-	dive->set_time_local(diveplan.when);
+	dive->set_time(diveplan.when);
 	dc->when = diveplan.when;
 	dc->surface_pressure = diveplan.surface_pressure;
 	dc->salinity = diveplan.salinity;

--- a/core/planner.h
+++ b/core/planner.h
@@ -39,7 +39,7 @@ struct diveplan {
 	diveplan &operator=(const diveplan &) = default;
 	diveplan &operator=(diveplan &&) = default;
 
-	timestamp_t when = 0;
+	datetime_t when;
 	pressure_t surface_pressure;
 	int bottomsac = 0;	/* ml/min */
 	int decosac = 0;	  /* ml/min */

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -675,13 +675,13 @@ static QString get_dive_only_date_string(timestamp_t when)
 QString get_first_dive_date_string()
 {
 	const dive_table &dives = divelog.dives;
-	return !dives.empty() ? get_dive_only_date_string(dives[0]->when) : gettextFromC::tr("no dives");
+	return !dives.empty() ? get_dive_only_date_string(dives[0]->get_time_local()) : gettextFromC::tr("no dives");
 }
 
 QString get_last_dive_date_string()
 {
 	const dive_table &dives = divelog.dives;
-	return !dives.empty() ? get_dive_only_date_string(dives.back()->when) : gettextFromC::tr("no dives");
+	return !dives.empty() ? get_dive_only_date_string(dives.back()->get_time_local()) : gettextFromC::tr("no dives");
 }
 
 std::string get_current_date()

--- a/core/range.h
+++ b/core/range.h
@@ -206,4 +206,35 @@ void range_remove(Range &v, const Element &item)
 		v.erase(it);
 }
 
+// Sort a range by order of other range. Unoptimized.
+// The items must possess quick operator<() and operator==() for binary lookup.
+template<typename Range1, typename Range2>
+void sort_by_reference(Range1 &v, const Range2 &reference)
+{
+	// Sort range for binary lookup.
+	std::sort(std::begin(v), std::end(v));
+
+	// Collect indexes
+	std::vector<size_t> indexes(v.size(), std::string::npos);
+	for (const auto &item: reference) {
+		auto it = std::lower_bound(std::begin(v), std::end(v), item);
+		if (it == std::end(v) || *it != item)
+			continue;
+		indexes[it - std::begin(v)] = &item - reference.data();
+	}
+
+	// Generate permutation table
+	std::vector<size_t> permutation(v.size());
+	std::iota(permutation.begin(), permutation.end(), 0);
+	std::sort(permutation.begin(), permutation.end(),
+		  [&indexes](size_t i1, size_t i2) { return indexes[i1] < indexes[i2]; });
+
+	// Generate result
+	Range1 res;
+	res.reserve(v.size());
+	for (size_t i: permutation)
+		res.push_back(std::move(v[i]));
+	v = std::move(res);
+}
+
 #endif

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -216,11 +216,11 @@ static void save_salinity(struct membuffer *b, const struct divecomputer &dc)
 	put_salinity(b, dc.salinity, "salinity ", "g/l\n");
 }
 
-static void show_date(struct membuffer *b, timestamp_t when)
+static void show_date(struct membuffer *b, datetime_t when)
 {
 	struct tm tm;
 
-	utc_mkdate(when, &tm);
+	utc_mkdate(when.local_time, &tm);
 
 	put_format(b, "date %04u-%02u-%02u\n",
 		   tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
@@ -391,7 +391,7 @@ static void save_dc(struct membuffer *b, const struct dive &dive, const struct d
 		put_format(b, "deviceid %08x\n", dc.deviceid);
 	if (dc.diveid)
 		put_format(b, "diveid %08x\n", dc.diveid);
-	if (dc.when && dc.when != dive.get_time_local())
+	if (dc.when && dc.when != dive.get_time())
 		show_date(b, dc.when);
 	if (dc.duration.seconds && dc.duration.seconds != dive.dcs[0].duration.seconds)
 		put_duration(b, dc.duration, "duration ", "min\n");

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -391,7 +391,7 @@ static void save_dc(struct membuffer *b, const struct dive &dive, const struct d
 		put_format(b, "deviceid %08x\n", dc.deviceid);
 	if (dc.diveid)
 		put_format(b, "diveid %08x\n", dc.diveid);
-	if (dc.when && dc.when != dive.when)
+	if (dc.when && dc.when != dive.get_time_local())
 		show_date(b, dc.when);
 	if (dc.duration.seconds && dc.duration.seconds != dive.dcs[0].duration.seconds)
 		put_duration(b, dc.duration, "duration ", "min\n");
@@ -555,7 +555,7 @@ static void create_dive_name(struct dive &dive, struct membuffer *name, struct t
 	struct tm tm;
 	static const char weekday[7][4] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
 
-	utc_mkdate(dive.when, &tm);
+	utc_mkdate(dive.get_time_local(), &tm);
 	if (tm.tm_year != dirtm->tm_year)
 		put_format(name, "%04u-", tm.tm_year);
 	if (tm.tm_mon != dirtm->tm_mon)
@@ -785,10 +785,10 @@ static int save_one_trip(git_repository *repo, struct dir *tree, dive_trip *trip
 	for (auto &dive: divelog.dives) {
 		if (dive->divetrip != trip)
 			continue;
-		if (dive->when < first)
-			first = dive->when;
-		if (dive->when > last)
-			last = dive->when;
+		if (dive->get_time_local() < first)
+			first = dive->get_time_local();
+		if (dive->get_time_local() > last)
+			last = dive->get_time_local();
 	}
 	verify_shared_date(first, tm);
 	verify_shared_date(last, tm);
@@ -987,7 +987,7 @@ static int create_git_tree(git_repository *repo, struct dir *root, bool select_o
 		}
 
 		/* Create the date-based hierarchy */
-		utc_mkdate(trip ? trip->date() : dive->when, &tm);
+		utc_mkdate(trip ? trip->date() : dive->get_time_local(), &tm);
 		tree = mktree(repo, root, "%04d", tm.tm_year);
 		tree = mktree(repo, tree, "%02d", tm.tm_mon + 1);
 

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -226,6 +226,9 @@ static void show_date(struct membuffer *b, datetime_t when)
 		   tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
 	put_format(b, "time %02u:%02u:%02u\n",
 		   tm.tm_hour, tm.tm_min, tm.tm_sec);
+	if (when.offset_to_utc)
+		put_format(b, "offset_to_utc %+d:%02d\n", *when.offset_to_utc / 3600,
+							  (std::abs(*when.offset_to_utc) / 60) % 60);
 }
 
 static void show_integer(struct membuffer *b, int value, const char *pre, const char *post)

--- a/core/save-html.cpp
+++ b/core/save-html.cpp
@@ -211,7 +211,7 @@ static void put_HTML_coordinates(struct membuffer *b, const struct dive &dive)
 void put_HTML_date(struct membuffer *b, const struct dive &dive, const char *pre, const char *post)
 {
 	struct tm tm;
-	utc_mkdate(dive.when, &tm);
+	utc_mkdate(dive.get_time_local(), &tm);
 	put_format(b, "%s%04u-%02u-%02u%s", pre, tm.tm_year, tm.tm_mon + 1, tm.tm_mday, post);
 }
 
@@ -268,7 +268,7 @@ void put_HTML_weight_units(struct membuffer *b, unsigned int grams, const char *
 void put_HTML_time(struct membuffer *b, const struct dive &dive, const char *pre, const char *post)
 {
 	struct tm tm;
-	utc_mkdate(dive.when, &tm);
+	utc_mkdate(dive.get_time_local(), &tm);
 	put_format(b, "%s%02u:%02u:%02u%s", pre, tm.tm_hour, tm.tm_min, tm.tm_sec, post);
 }
 

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -396,11 +396,11 @@ static void save_tank_sensor_mappings(struct membuffer *b, const struct dive &di
 	}
 }
 
-static void show_date(struct membuffer *b, timestamp_t when)
+static void show_date(struct membuffer *b, datetime_t when)
 {
 	struct tm tm;
 
-	utc_mkdate(when, &tm);
+	utc_mkdate(when.local_time, &tm);
 
 	put_format(b, " date='%04u-%02u-%02u'",
 		   tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
@@ -426,7 +426,7 @@ static void save_dc(struct membuffer *b, const struct dive &dive, const struct d
 		put_format(b, " deviceid='%08x'", dc.deviceid);
 	if (dc.diveid)
 		put_format(b, " diveid='%08x'", dc.diveid);
-	if (dc.when && dc.when != dive.get_time_local())
+	if (dc.when && dc.when != dive.get_time())
 		show_date(b, dc.when);
 	if (dc.duration.seconds && dc.duration.seconds != dive.dcs[0].duration.seconds)
 		put_duration(b, dc.duration, " duration='", " min'");
@@ -508,7 +508,7 @@ void save_one_dive_to_mb(struct membuffer *b, const struct dive &dive, bool anon
 		put_format(b, " divesiteid='%8x'", dive.dive_site->uuid);
 	if (dive.user_salinity)
 		put_salinity(b, dive.user_salinity, " watersalinity='", " g/l'");
-	show_date(b, dive.get_time_local());
+	show_date(b, dive.get_time());
 	if (surface_pressure.mbar)
 		put_pressure(b, surface_pressure, " airpressure='", " bar'");
 	if (dive.dcs[0].duration.seconds > 0)

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -426,7 +426,7 @@ static void save_dc(struct membuffer *b, const struct dive &dive, const struct d
 		put_format(b, " deviceid='%08x'", dc.deviceid);
 	if (dc.diveid)
 		put_format(b, " diveid='%08x'", dc.diveid);
-	if (dc.when && dc.when != dive.when)
+	if (dc.when && dc.when != dive.get_time_local())
 		show_date(b, dc.when);
 	if (dc.duration.seconds && dc.duration.seconds != dive.dcs[0].duration.seconds)
 		put_duration(b, dc.duration, " duration='", " min'");
@@ -508,7 +508,7 @@ void save_one_dive_to_mb(struct membuffer *b, const struct dive &dive, bool anon
 		put_format(b, " divesiteid='%8x'", dive.dive_site->uuid);
 	if (dive.user_salinity)
 		put_salinity(b, dive.user_salinity, " watersalinity='", " g/l'");
-	show_date(b, dive.when);
+	show_date(b, dive.get_time_local());
 	if (surface_pressure.mbar)
 		put_pressure(b, surface_pressure, " airpressure='", " bar'");
 	if (dive.dcs[0].duration.seconds > 0)

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -407,6 +407,9 @@ static void show_date(struct membuffer *b, datetime_t when)
 	if (tm.tm_hour || tm.tm_min || tm.tm_sec)
 		put_format(b, " time='%02u:%02u:%02u'",
 			   tm.tm_hour, tm.tm_min, tm.tm_sec);
+	if (when.offset_to_utc)
+		put_format(b, " offset_to_utc='%+d:%02d'", *when.offset_to_utc / 3600,
+							   (std::abs(*when.offset_to_utc) / 60) % 60);
 }
 
 static void save_samples(struct membuffer *b, const struct divecomputer &dc)

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -70,7 +70,7 @@ static dive *closestInSelection(timestamp_t when, const std::vector<dive *> &sel
 	// the supposed-to-be selected dive. (Note: this mimics the
 	// old behavior when the current dive changed).
 	for (auto it = selection.rbegin(); it < selection.rend(); ++it) {
-		if ((*it)->when > when && !(*it)->hidden_by_filter)
+		if ((*it)->get_time_local() > when && !(*it)->hidden_by_filter)
 			return *it;
 	}
 
@@ -147,7 +147,7 @@ QVector<dive *> setSelectionCore(const std::vector<dive *> &selection, dive *cur
 	current_dive = currentDive;
 	if (current_dive && !currentDive->selected) {
 		// Current not visible -> find a different dive.
-		setClosestCurrentDive(currentDive->when, selection, divesToSelect);
+		setClosestCurrentDive(currentDive->get_time_local(), selection, divesToSelect);
 	}
 
 	return divesToSelect;
@@ -188,7 +188,7 @@ bool setSelectionKeepCurrent(const std::vector<dive *> &selection)
 
 	dive *newCurrent = current_dive;
 	if (current_dive && std::find(selection.begin(), selection.end(), current_dive) == selection.end())
-		newCurrent = closestInSelection(current_dive->when, selection);
+		newCurrent = closestInSelection(current_dive->get_time_local(), selection);
 	setSelectionCore(selection, newCurrent);
 
 	return current_dive != oldCurrent;

--- a/core/selection.cpp
+++ b/core/selection.cpp
@@ -64,13 +64,13 @@ void dump_selection()
 
 // Get closest dive in selection, if possible a newer dive.
 // Supposes that selection is sorted
-static dive *closestInSelection(timestamp_t when, const std::vector<dive *> &selection)
+static dive *closestInSelection(datetime_t when, const std::vector<dive *> &selection)
 {
 	// Start from back until we get the first dive that is before
 	// the supposed-to-be selected dive. (Note: this mimics the
 	// old behavior when the current dive changed).
 	for (auto it = selection.rbegin(); it < selection.rend(); ++it) {
-		if ((*it)->get_time_local() > when && !(*it)->hidden_by_filter)
+		if ((*it)->get_time_utc() > when.in_utc() && !(*it)->hidden_by_filter)
 			return *it;
 	}
 
@@ -91,7 +91,7 @@ static dive *closestInSelection(timestamp_t when, const std::vector<dive *> &sel
 // If a current dive outside of the selection was set, add
 // it to the list of selected dives, so that we never end up
 // in a situation where we display a non-selected dive.
-static void setClosestCurrentDive(timestamp_t when, const std::vector<dive *> &selection, QVector<dive *> &divesToSelect)
+static void setClosestCurrentDive(datetime_t when, const std::vector<dive *> &selection, QVector<dive *> &divesToSelect)
 {
 	if (dive *d = closestInSelection(when, selection)) {
 		current_dive = d;
@@ -147,7 +147,7 @@ QVector<dive *> setSelectionCore(const std::vector<dive *> &selection, dive *cur
 	current_dive = currentDive;
 	if (current_dive && !currentDive->selected) {
 		// Current not visible -> find a different dive.
-		setClosestCurrentDive(currentDive->get_time_local(), selection, divesToSelect);
+		setClosestCurrentDive(currentDive->get_time(), selection, divesToSelect);
 	}
 
 	return divesToSelect;
@@ -188,7 +188,7 @@ bool setSelectionKeepCurrent(const std::vector<dive *> &selection)
 
 	dive *newCurrent = current_dive;
 	if (current_dive && std::find(selection.begin(), selection.end(), current_dive) == selection.end())
-		newCurrent = closestInSelection(current_dive->get_time_local(), selection);
+		newCurrent = closestInSelection(current_dive->get_time(), selection);
 	setSelectionCore(selection, newCurrent);
 
 	return current_dive != oldCurrent;

--- a/core/statistics.cpp
+++ b/core/statistics.cpp
@@ -134,7 +134,7 @@ stats_summary calculate_stats_summary(bool selected_only)
 		//process_dive(dp, &stats);
 
 		/* yearly statistics */
-		utc_mkdate(dp->when, &tm);
+		utc_mkdate(dp->get_time_local(), &tm);
 
 		if (current_year != tm.tm_year || out.stats_yearly.empty()) {
 			current_year = tm.tm_year;

--- a/core/string-format.cpp
+++ b/core/string-format.cpp
@@ -561,6 +561,14 @@ std::string get_dive_date_c_string(timestamp_t when)
 	return get_short_dive_date_string(when).toStdString();
 }
 
+QString get_dive_datetime_string(datetime_t when)
+{
+	QString s = get_dive_date_string(when.local_time);
+	if (!when.offset_to_utc)
+		return s;
+	return QStringLiteral("%1 (%2)").arg(s, get_utc_offset_string(when.offset_to_utc));
+}
+
 QString distance_string(int distanceInMeters)
 {
 	QString str;

--- a/core/string-format.cpp
+++ b/core/string-format.cpp
@@ -242,19 +242,19 @@ QString formatDiveGPS(const dive *d)
 
 QString formatDiveDate(const dive *d)
 {
-	QDateTime localTime = timestampToDateTime(d->when);
+	QDateTime localTime = timestampToDateTime(d->get_time_local());
 	return localTime.date().toString(QString::fromStdString(prefs.date_format_short));
 }
 
 QString formatDiveTime(const dive *d)
 {
-	QDateTime localTime = timestampToDateTime(d->when);
+	QDateTime localTime = timestampToDateTime(d->get_time_local());
 	return localTime.time().toString(QString::fromStdString(prefs.time_format));
 }
 
 QString formatDiveDateTime(const dive *d)
 {
-	QDateTime localTime = timestampToDateTime(d->when);
+	QDateTime localTime = timestampToDateTime(d->get_time_local());
 	return QStringLiteral("%1 %2").arg(localTime.date().toString(QString::fromStdString(prefs.date_format_short)),
 					   localTime.time().toString(QString::fromStdString(prefs.time_format)));
 }

--- a/core/string-format.cpp
+++ b/core/string-format.cpp
@@ -321,6 +321,15 @@ QString formatTripTitleWithDives(const dive_trip &trip)
 	       gettextFromC::tr("(%n dive(s))", "", nr);
 }
 
+QString get_utc_offset_string(std::optional<int> offset)
+{
+	if (!offset)
+		return QString();
+	if (*offset == 0)
+		return QStringLiteral("0:00");
+	return qasprintf_loc("%+d:%02d", *offset / 3600, std::abs(*offset / 60) % 60);
+}
+
 QString get_depth_string(int mm, bool showunit, bool showdecimal)
 {
 	if (prefs.units.length == units::METERS) {

--- a/core/string-format.h
+++ b/core/string-format.h
@@ -37,6 +37,7 @@ QString formatTripTitle(const dive_trip &trip);
 QString formatTripTitleWithDives(const dive_trip &trip);
 
 // Functions that format arbitrary data
+QString get_utc_offset_string(std::optional<int> offset);
 QString get_depth_string(depth_t depth, bool showunit = false, bool showdecimal = true);
 QString get_depth_string(int mm, bool showunit = false, bool showdecimal = true);
 QString get_depth_unit(bool metric);

--- a/core/string-format.h
+++ b/core/string-format.h
@@ -61,6 +61,7 @@ QString get_dive_duration_string(timestamp_t when, QString hoursText, QString mi
 QString get_dive_surfint_string(timestamp_t when, QString daysText, QString hoursText, QString minutesText, QString separator = " ", int maxdays = 4);
 QString get_dive_date_string(timestamp_t when);
 std::string get_dive_date_c_string(timestamp_t when);
+QString get_dive_datetime_string(datetime_t when);
 QString distance_string(int distanceInMeters);
 QString printGPSCoords(const location_t *loc);
 std::string printGPSCoordsC(const location_t *loc);

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -92,7 +92,7 @@ signals:
 	void divesDeleted(dive_trip *trip, bool deleteTrip, const QVector<dive *> &dives);
 	void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
-	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
+	void divesTimeChanged(const QVector<dive *> &dives);
 	void divesImported(); // A general signal when multiple dives have been imported.
 
 	void diveComputerEdited(dive &dive, divecomputer &dc);

--- a/core/trip.cpp
+++ b/core/trip.cpp
@@ -15,11 +15,11 @@ dive_trip::dive_trip() : id(dive_getUniqID())
 
 dive_trip::~dive_trip() = default;
 
-timestamp_t dive_trip::date() const
+datetime_t dive_trip::date() const
 {
 	if (dives.empty())
-		return 0;
-	return dives[0]->get_time_local();
+		return datetime_t();
+	return dives[0]->get_time();
 }
 
 static timestamp_t trip_enddate(const struct dive_trip &trip)

--- a/core/trip.h
+++ b/core/trip.h
@@ -22,7 +22,7 @@ struct dive_trip
 
 	void sort_dives();
 	void add_dive(struct dive *);
-	timestamp_t date() const;
+	datetime_t date() const;
 	bool is_single_day() const;
 	int shown_dives() const;
 };

--- a/core/uemis-downloader.cpp
+++ b/core/uemis-downloader.cpp
@@ -733,7 +733,7 @@ static void parse_tag(struct dive *dive, std::string_view tag, std::string_view 
 		report_info("Adding to dive %d : %s = %s\n", dive->dcs[0].diveid, std::string(tag).c_str(), std::string(val).c_str());
 #endif
 	if (tag == "date") {
-		dive->when = uemis_ts(val);
+		dive->set_time_local(uemis_ts(val));
 	} else if (tag == "duration") {
 		uemis_duration(val, dive->dcs[0].duration);
 	} else if (tag == "depth") {
@@ -1156,7 +1156,7 @@ static bool get_matching_dive(size_t idx, int &newmax, uemis_mem_status &mem_sta
 						 * have the same or higher logfile number.
 						 * UEMIS unfortunately deletes dives by deleting the dive details and not the logs. */
 #if UEMIS_DEBUG & 2
-						d_time = get_dive_date_c_string(dive->when);
+						d_time = get_dive_date_c_string(dive->get_time_local());
 						report_info("Matching dive log id %d from %s with dive details %d\n", dive->dcs[0].diveid, d_time.c_str(), dive_to_read);
 #endif
 						int divespot_id = uemis_obj.get_divespot_id_by_diveid(dive->dcs[0].diveid);
@@ -1166,7 +1166,7 @@ static bool get_matching_dive(size_t idx, int &newmax, uemis_mem_status &mem_sta
 					} else {
 						/* in this case we found a deleted file, so let's increment */
 #if UEMIS_DEBUG & 2
-						d_time = get_dive_date_c_string(dive->when);
+						d_time = get_dive_date_c_string(dive->get_time_local());
 						report_info("TRY matching dive log id %d from %s with dive details %d but details are deleted\n", dive->dcs[0].diveid, d_time.c_str(), dive_to_read);
 #endif
 						deleted_files++;

--- a/core/units.cpp
+++ b/core/units.cpp
@@ -209,3 +209,16 @@ depth_t pressure_to_altitude(pressure_t pressure)
 {						// returns altitude in mm above sea level
 	return depth_t::from_base(static_cast<int32_t>(log(1013.0 / pressure.mbar) * 7800000));
 }
+
+/* Accessing the dive time relative to UTC is tricky, because we might
+ * not know the time-offset. For now, return local time as UTC, but
+ * using the current local time might be preferred.
+ */
+timestamp_t datetime_t::in_utc() const
+{
+	// If local time is undefined, return an undefined timestamp
+	if (!local_time)
+		return 0;
+	return offset_to_utc ? local_time + *offset_to_utc
+			     : local_time /* TODO: + local_offset_to_utc */ ;
+}

--- a/core/units.cpp
+++ b/core/units.cpp
@@ -222,3 +222,23 @@ timestamp_t datetime_t::in_utc() const
 	return offset_to_utc ? local_time + *offset_to_utc
 			     : local_time /* TODO: + local_offset_to_utc */ ;
 }
+
+datetime_t::operator bool() const
+{
+	return !!local_time;
+}
+
+bool datetime_t::operator!() const
+{
+	return !local_time;
+}
+
+bool datetime_t::operator==(const datetime_t &d) const
+{
+	return local_time == d.local_time && offset_to_utc == d.offset_to_utc;
+}
+
+bool datetime_t::operator!=(const datetime_t &d) const
+{
+	return !(*this == d);
+}

--- a/core/units.h
+++ b/core/units.h
@@ -3,6 +3,7 @@
 #define UNITS_H
 
 #include "interpolate.h"
+#include <optional>
 
 #include <math.h>
 #ifndef M_PI
@@ -104,6 +105,16 @@
  * I made a number of types as guidelines.
  */
 using timestamp_t = int64_t;
+
+/*
+ * Often we don't have timezone information, but sometimes we do.
+ * Therefore, store offset-to-utc as an optional.
+ */
+struct datetime_t {
+	timestamp_t		local_time = 0;
+	std::optional<int32_t>	offset_to_utc;
+	timestamp_t		in_utc() const;
+};
 
 /*
  * There is a semi-common pattern where lrint() is used to round

--- a/core/units.h
+++ b/core/units.h
@@ -114,6 +114,11 @@ struct datetime_t {
 	timestamp_t		local_time = 0;
 	std::optional<int32_t>	offset_to_utc;
 	timestamp_t		in_utc() const;
+	operator bool() const;
+	bool operator!() const;
+	// TODO: replace by C++20 operator<=>() = default;
+	bool operator==(const datetime_t &) const;
+	bool operator!=(const datetime_t &) const;
 };
 
 /*

--- a/desktop-widgets/divecomponentselection.cpp
+++ b/desktop-widgets/divecomponentselection.cpp
@@ -3,7 +3,6 @@
 #include "core/dive.h"
 #include "core/divesite.h"
 #include "core/format.h"
-#include "core/qthelper.h" // for get_dive_date_string()
 #include "core/selection.h"
 #include "core/string-format.h"
 
@@ -98,7 +97,7 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 		if (data.number)
 			text += tr("Dive number: ").toStdString() + casprintf_loc("%d", current_dive->number) + '\n';
 		if (data.when)
-			text += tr("Date / time: ").toStdString() + get_dive_date_string(current_dive->get_time_local()).toStdString() + '\n';
+			text += tr("Date / time: ").toStdString() + get_dive_datetime_string(current_dive->get_time()).toStdString() + '\n';
 		QApplication::clipboard()->setText(QString::fromStdString(text));
 	}
 }

--- a/desktop-widgets/divecomponentselection.cpp
+++ b/desktop-widgets/divecomponentselection.cpp
@@ -64,7 +64,7 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 		assign_paste_data(*ui.cylinders, current_dive->cylinders, data.cylinders);
 		assign_paste_data(*ui.weights, current_dive->weightsystems, data.weights);
 		assign_paste_data(*ui.number, current_dive->number, data.number);
-		assign_paste_data(*ui.when, current_dive->when, data.when);
+		assign_paste_data(*ui.when, current_dive->get_time_local(), data.when);
 
 		std::string text;
 		if (data.divesite && current_dive->dive_site)
@@ -98,7 +98,7 @@ void DiveComponentSelection::buttonClicked(QAbstractButton *button)
 		if (data.number)
 			text += tr("Dive number: ").toStdString() + casprintf_loc("%d", current_dive->number) + '\n';
 		if (data.when)
-			text += tr("Date / time: ").toStdString() + get_dive_date_string(current_dive->when).toStdString() + '\n';
+			text += tr("Date / time: ").toStdString() + get_dive_date_string(current_dive->get_time_local()).toStdString() + '\n';
 		QApplication::clipboard()->setText(QString::fromStdString(text));
 	}
 }

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -568,15 +568,15 @@ static bool can_merge(const struct dive *a, const struct dive *b, enum asked_use
 {
 	if (!a || !b)
 		return false;
-	if (a->when > b->when)
+	if (a->get_time_local() > b->get_time_local())
 		return false;
 	/* Don't merge dives if there's more than half an hour between them */
-	if (a->endtime() + 30 * 60 < b->when) {
+	if (a->endtime_local() + 30 * 60 < b->get_time_local()) {
 		if (*have_asked == NOTYET) {
 			if (QMessageBox::warning(MainWindow::instance(),
 						 MainWindow::tr("Warning"),
 						 MainWindow::tr("Trying to merge dives with %1min interval in between").arg(
-							 (b->when - a->endtime()) / 60),
+							 (b->get_time_local() - a->endtime_local()) / 60),
 					     QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Cancel) {
 				*have_asked = DONTMERGE;
 				return false;

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -590,7 +590,7 @@ void PlannerWidgets::planDive()
 
 	plannerWidget.setReplanButton(false);
 
-	plannerWidget.setupStartTime(timestampToDateTime(planned_dive->when));	// This will reload the profile!
+	plannerWidget.setupStartTime(timestampToDateTime(planned_dive->get_time_local()));	// This will reload the profile!
 }
 
 void PlannerWidgets::prepareReplanDive(const dive *currentDive, int currentDcNr)
@@ -607,7 +607,7 @@ void PlannerWidgets::replanDive()
 	DivePlannerPointsModel::instance()->loadFromDive(planned_dive.get(), dcNr);
 
 	plannerWidget.setReplanButton(true);
-	plannerWidget.setupStartTime(timestampToDateTime(planned_dive->when));
+	plannerWidget.setupStartTime(timestampToDateTime(planned_dive->get_time_local()));
 	if (planned_dive->surface_pressure.mbar)
 		plannerWidget.setSurfacePressure(planned_dive->surface_pressure.mbar);
 	if (planned_dive->salinity)

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -282,8 +282,8 @@ void LocationInformationWidget::on_GPSbutton_clicked()
 		return;
 
 	ImportGPS GPSDialog(this, fileName, &ui); // Create a GPS import QDialog
-	GPSDialog.coords.start_dive = current_dive->when; // initialise
-	GPSDialog.coords.end_dive = current_dive->endtime();
+	GPSDialog.coords.start_dive = current_dive->get_time_local(); // initialise
+	GPSDialog.coords.end_dive = current_dive->endtime_local();
 	if (getCoordsFromGPXFile(&GPSDialog.coords, fileName) == 0) { // Get coordinates from GPS file
 		GPSDialog.updateUI();         // If successful, put results in Dialog
 		if (!GPSDialog.exec())        // and show QDialog

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -118,7 +118,7 @@ ShiftTimesDialog::ShiftTimesDialog(std::vector<dive *> dives_in, QWidget *parent
 	connect(close, SIGNAL(activated()), this, SLOT(close()));
 	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this);
 	connect(quit, SIGNAL(activated()), parent, SLOT(close()));
-	when = dives[0]->when;
+	when = dives[0]->get_time_local();
 	ui.currentTime->setText(get_dive_date_string(when));
 	ui.shiftedTime->setText(get_dive_date_string(when));
 }
@@ -223,11 +223,11 @@ void ShiftImageTimesDialog::updateInvalid()
 	ui.warningLabel->hide();
 	ui.invalidFilesText->hide();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-	QDateTime time_first = QDateTime::fromSecsSinceEpoch(first_selected_dive()->when, QTimeZone::utc());
-	QDateTime time_last = QDateTime::fromSecsSinceEpoch(last_selected_dive()->when, QTimeZone::utc());
+	QDateTime time_first = QDateTime::fromSecsSinceEpoch(first_selected_dive()->get_time_local(), QTimeZone::utc());
+	QDateTime time_last = QDateTime::fromSecsSinceEpoch(last_selected_dive()->get_time_local(), QTimeZone::utc());
 #else
-	QDateTime time_first = QDateTime::fromSecsSinceEpoch(first_selected_dive()->when, Qt::UTC);
-	QDateTime time_last = QDateTime::fromSecsSinceEpoch(last_selected_dive()->when, Qt::UTC);
+	QDateTime time_first = QDateTime::fromSecsSinceEpoch(first_selected_dive()->get_time_local(), Qt::UTC);
+	QDateTime time_last = QDateTime::fromSecsSinceEpoch(last_selected_dive()->get_time_local(), Qt::UTC);
 #endif
 	if (first_selected_dive() == last_selected_dive()) {
 		ui.invalidFilesText->setPlainText(tr("Selected dive date/time") + ": " + time_first.toString());

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -167,7 +167,7 @@ void TabDiveInformation::updateProfile()
 // Update fields that depend on start of dive
 void TabDiveInformation::updateWhen()
 {
-	timestamp_t surface_interval = divelog.dives.get_surface_interval(parent.currentDive->when);
+	timestamp_t surface_interval = divelog.dives.get_surface_interval(parent.currentDive->get_time_local());
 	if (surface_interval >= 0)
 		ui->surfaceIntervalText->setText(get_dive_surfint_string(surface_interval, tr("d"), tr("h"), tr("min")));
 	else

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -167,7 +167,7 @@ void TabDiveInformation::updateProfile()
 // Update fields that depend on start of dive
 void TabDiveInformation::updateWhen()
 {
-	timestamp_t surface_interval = divelog.dives.get_surface_interval(parent.currentDive->get_time_local());
+	timestamp_t surface_interval = divelog.dives.get_surface_interval(parent.currentDive->get_time());
 	if (surface_interval >= 0)
 		ui->surfaceIntervalText->setText(get_dive_surfint_string(surface_interval, tr("d"), tr("h"), tr("min")));
 	else

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -122,7 +122,7 @@ void TabDiveNotes::divesChanged(const QVector<dive *> &dives, DiveField field)
 		updateNotes(currentDive);
 	if (field.datetime) {
 		updateDateTime(currentDive);
-		DivePlannerPointsModel::instance()->getDiveplan().when = currentDive->when;
+		DivePlannerPointsModel::instance()->getDiveplan().when = currentDive->get_time_local();
 	}
 	if (field.divesite)
 		updateDiveSite(currentDive);
@@ -171,7 +171,7 @@ void TabDiveNotes::updateNotes(const struct dive *d)
 
 void TabDiveNotes::updateDateTime(const struct dive *d)
 {
-	QDateTime localTime = timestampToDateTime(d->when);
+	QDateTime localTime = timestampToDateTime(d->get_time_local());
 	ui.dateEdit->setDate(localTime.date());
 	ui.timeEdit->setTime(localTime.time());
 }
@@ -352,8 +352,8 @@ void TabDiveNotes::on_depth_editingFinished()
 static void shiftTime(QDateTime &dateTime, dive *currentDive)
 {
 	timestamp_t when = dateTimeToTimestamp(dateTime);
-	if (currentDive->when != when) {
-		timestamp_t offset = when - currentDive->when;
+	if (currentDive->get_time_local() != when) {
+		timestamp_t offset = when - currentDive->get_time_local();
 		Command::shiftTime(getDiveSelection(), (int)offset);
 	}
 }
@@ -362,7 +362,7 @@ void TabDiveNotes::on_dateEdit_editingFinished()
 {
 	if (ignoreInput || !parent.currentDive)
 		return;
-	QDateTime dateTime = timestampToDateTime(parent.currentDive->when);
+	QDateTime dateTime = timestampToDateTime(parent.currentDive->get_time_local());
 	dateTime.setDate(ui.dateEdit->date());
 	shiftTime(dateTime, parent.currentDive);
 }
@@ -371,7 +371,7 @@ void TabDiveNotes::on_timeEdit_editingFinished()
 {
 	if (ignoreInput || !parent.currentDive)
 		return;
-	QDateTime dateTime = timestampToDateTime(parent.currentDive->when);
+	QDateTime dateTime = timestampToDateTime(parent.currentDive->get_time_local());
 	dateTime.setTime(ui.timeEdit->time());
 	shiftTime(dateTime, parent.currentDive);
 }

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -122,7 +122,7 @@ void TabDiveNotes::divesChanged(const QVector<dive *> &dives, DiveField field)
 		updateNotes(currentDive);
 	if (field.datetime) {
 		updateDateTime(currentDive);
-		DivePlannerPointsModel::instance()->getDiveplan().when = currentDive->get_time_local();
+		DivePlannerPointsModel::instance()->getDiveplan().when = currentDive->get_time();
 	}
 	if (field.divesite)
 		updateDiveSite(currentDive);

--- a/desktop-widgets/tab-widgets/TabDiveNotes.h
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.h
@@ -40,6 +40,7 @@ slots:
 	void on_depth_editingFinished();
 	void on_dateEdit_editingFinished();
 	void on_timeEdit_editingFinished();
+	void on_utcOffsetEdit_editingFinished();
 	void on_rating_valueChanged(int value);
 	void on_tagWidget_editingFinished();
 	void updateDateTimeFields();

--- a/desktop-widgets/tab-widgets/TabDiveNotes.ui
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.ui
@@ -95,7 +95,26 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2" colspan="2">
+         <item row="0" column="2">
+          <widget class="QLabel" name="utcOffsetLabel">
+           <property name="text">
+            <string>GMT offset (±h:mm)</string>
+           </property>
+          <property name="isHeader" stdset="0">
+           <bool>true</bool>
+          </property>
+           <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+           </property>
+           <property name="alignment">
+             <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3" colspan="2">
           <widget class="QLabel" name="depthLabely">
            <property name="text">
             <string> </string>
@@ -108,7 +127,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
+         <item row="0" column="3">
           <widget class="QLabel" name="depthLabel">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -124,7 +143,7 @@
           </property>
           </widget>
          </item>
-         <item row="0" column="3">
+         <item row="0" column="4">
           <widget class="QLabel" name="durationLabel">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -163,7 +182,17 @@
            </property>
            </widget>
          </item>
-         <item row="1" column="2" colspan="2">
+         <item row="1" column="2">
+          <widget class="QLineEdit" name="utcOffsetEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3" colspan="2">
           <widget class="QLabel" name="depthLabelx">
            <property name="text">
             <string> </string>
@@ -176,7 +205,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="2">
+         <item row="1" column="3">
           <widget class="QLineEdit" name="depth">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -186,7 +215,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="3">
+         <item row="1" column="4">
           <widget class="QLineEdit" name="duration">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -525,7 +525,7 @@ QVariant TemplateLayout::getValue(QString list, QString property, const State &s
 		} else if (property == "time") {
 			return formatDiveTime(d);
 		} else if (property == "timestamp") {
-			return QVariant::fromValue(d->when);
+			return QVariant::fromValue(d->get_time_local());
 		} else if (property == "location") {
 			return QString::fromStdString(d->get_location());
 		} else if (property == "gps") {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1061,8 +1061,7 @@ parsed:
 			// add a hundred years.
 			if (newDate.addYears(100) < QDateTime::currentDateTime().addYears(1))
 				newDate = newDate.addYears(100);
-			d->dcs[0].when = dateTimeToTimestamp(newDate);
-			d->set_time_local(d->dcs[0].when);
+			d->set_time_local_dc(dateTimeToTimestamp(newDate));
 			return true;
 		}
 		appendTextToLog("none of our parsing attempts worked for the date string");

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -944,7 +944,7 @@ bool QMLManager::checkDate(struct dive *d, QString date)
 			QString dateFormatToDrop = format.contains(QLatin1String("ddd")) ? QStringLiteral("ddd") : QStringLiteral("dddd");
 			QDateTime ts;
 			QLocale loc = getLocale();
-			ts.setMSecsSinceEpoch(d->when * 1000L);
+			ts.setMSecsSinceEpoch(d->get_time_local() * 1000L);
 			QString drop = loc.toString(ts.toUTC(), dateFormatToDrop);
 			format.replace(dateFormatToDrop, "");
 			date.replace(drop, "");
@@ -1061,7 +1061,8 @@ parsed:
 			// add a hundred years.
 			if (newDate.addYears(100) < QDateTime::currentDateTime().addYears(1))
 				newDate = newDate.addYears(100);
-			d->dcs[0].when = d->when = dateTimeToTimestamp(newDate);
+			d->dcs[0].when = dateTimeToTimestamp(newDate);
+			d->set_time_local(d->dcs[0].when);
 			return true;
 		}
 		appendTextToLog("none of our parsing attempts worked for the date string");
@@ -1475,7 +1476,8 @@ bool QMLManager::canMerge(int diveId, int mergeIntoDiveId)
 		return false;
 
 	/* Don't merge dives if there's more than half an hour between them */
-	if ((dive->when <= mergeIntoDive->when && dive->endtime() + 30 * 60 >= mergeIntoDive->when) || (mergeIntoDive->when <= dive->when && mergeIntoDive->endtime() + 30 * 60 >= dive->when))
+	if ((dive->get_time_local() <= mergeIntoDive->get_time_local() && dive->endtime_local() + 30 * 60 >= mergeIntoDive->get_time_local()) ||
+	    (mergeIntoDive->get_time_local() <= dive->get_time_local() && mergeIntoDive->endtime_local() + 30 * 60 >= dive->get_time_local()))
 		return true;
 
 	return false;
@@ -1494,7 +1496,7 @@ void QMLManager::mergeDives(int diveId, int mergeIntoDiveId)
 		return;
 	}
 
-	if (dive->when > mergeIntoDive->when)
+	if (dive->get_time_local() > mergeIntoDive->get_time_local())
 		std::swap(dive, mergeIntoDive);
 
 	QVector<struct dive *> batch = { dive, mergeIntoDive };
@@ -1779,7 +1781,7 @@ QString QMLManager::getDate(const QString& diveId)
 	struct dive *d = divelog.dives.get_by_uniq_id(dive_id);
 	QString datestring;
 	if (d)
-		datestring = get_short_dive_date_string(d->when);
+		datestring = get_short_dive_date_string(d->get_time_local());
 	return datestring;
 }
 

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -62,7 +62,7 @@ QVariant DiveImportedModel::data(const QModelIndex &index, int role) const
 	if (role == Qt::DisplayRole) {
 		switch (column) {
 		case 0:
-			return QVariant(get_short_dive_date_string(d.when));
+			return QVariant(get_short_dive_date_string(d.get_time_local()));
 		case 1:
 			return QVariant(get_dive_duration_string(d.duration.seconds, tr("h"), tr("min")));
 		case 2:

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -81,8 +81,8 @@ void DivePlannerPointsModel::createSimpleDive(struct dive *dIn)
 	setupStartTime();
 
 	// initialize the start time in the plan
-	diveplan.when = dateTimeToTimestamp(startTime);
-	d->set_time_local(diveplan.when);
+	diveplan.when.local_time = dateTimeToTimestamp(startTime);
+	d->set_time(diveplan.when);
 
 	// Use gas from the first cylinder
 	int cylinderid = 0;
@@ -131,7 +131,7 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn, int dcNrIn)
 	removeDeco();
 	diveplan.dp.clear();
 
-	diveplan.when = d->get_time_local();
+	diveplan.when = d->get_time();
 	// is this a "new" dive where we marked manually entered samples?
 	// if yes then the first sample should be marked
 	// if it is we only add the manually entered samples as waypoints to the diveplan
@@ -792,16 +792,16 @@ void DivePlannerPointsModel::setSurfaceSegment(int duration)
 void DivePlannerPointsModel::setStartDate(const QDate &date)
 {
 	startTime.setDate(date);
-	diveplan.when = dateTimeToTimestamp(startTime);
-	d->set_time_local(diveplan.when);
+	diveplan.when.local_time = dateTimeToTimestamp(startTime);
+	d->set_time(diveplan.when);
 	emitDataChanged();
 }
 
 void DivePlannerPointsModel::setStartTime(const QTime &t)
 {
 	startTime.setTime(t);
-	diveplan.when = dateTimeToTimestamp(startTime);
-	d->set_time_local(diveplan.when);
+	diveplan.when.local_time = dateTimeToTimestamp(startTime);
+	d->set_time(diveplan.when);
 	emitDataChanged();
 }
 
@@ -1436,7 +1436,7 @@ QVariantMap DivePlannerPointsModel::calculatePlan(const QVariantList &cylindersD
 	plannedDateTime = QDateTime(plannedDateTime.date(), plannedDateTime.time(), Qt::UTC);
 #endif
 	d->set_time_local(static_cast<time_t>(plannedDateTime.toSecsSinceEpoch()));
-	diveplan.when = d->get_time_local();
+	diveplan.when = d->get_time();
 
 	d->dcs[dcNr].divemode = static_cast<enum divemode_t>(diveMode);
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -72,7 +72,7 @@ void DivePlannerPointsModel::createSimpleDive(struct dive *dIn)
 	dcNr = 0;
 	d->clear();
 	d->id = dive_getUniqID();
-	d->when = QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600;
+	d->set_time_local(QDateTime::currentMSecsSinceEpoch() / 1000L + gettimezoneoffset() + 3600);
 	make_planner_dc(&d->dcs[0]);
 
 	clear();
@@ -82,7 +82,7 @@ void DivePlannerPointsModel::createSimpleDive(struct dive *dIn)
 
 	// initialize the start time in the plan
 	diveplan.when = dateTimeToTimestamp(startTime);
-	d->when = diveplan.when;
+	d->set_time_local(diveplan.when);
 
 	// Use gas from the first cylinder
 	int cylinderid = 0;
@@ -106,7 +106,7 @@ void DivePlannerPointsModel::setupStartTime()
 	// otherwise start an hour from now
 	startTime = QDateTime::currentDateTimeUtc().addSecs(3600 + gettimezoneoffset());
 	if (!divelog.dives.empty()) {
-		time_t ends = divelog.dives.back()->endtime();
+		time_t ends = divelog.dives.back()->endtime_local();
 		time_t diff = ends - dateTimeToTimestamp(startTime);
 		if (diff > 0)
 			startTime = startTime.addSecs(diff + 3600);
@@ -131,7 +131,7 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn, int dcNrIn)
 	removeDeco();
 	diveplan.dp.clear();
 
-	diveplan.when = d->when;
+	diveplan.when = d->get_time_local();
 	// is this a "new" dive where we marked manually entered samples?
 	// if yes then the first sample should be marked
 	// if it is we only add the manually entered samples as waypoints to the diveplan
@@ -793,7 +793,7 @@ void DivePlannerPointsModel::setStartDate(const QDate &date)
 {
 	startTime.setDate(date);
 	diveplan.when = dateTimeToTimestamp(startTime);
-	d->when = diveplan.when;
+	d->set_time_local(diveplan.when);
 	emitDataChanged();
 }
 
@@ -801,7 +801,7 @@ void DivePlannerPointsModel::setStartTime(const QTime &t)
 {
 	startTime.setTime(t);
 	diveplan.when = dateTimeToTimestamp(startTime);
-	d->when = diveplan.when;
+	d->set_time_local(diveplan.when);
 	emitDataChanged();
 }
 
@@ -1435,8 +1435,8 @@ QVariantMap DivePlannerPointsModel::calculatePlan(const QVariantList &cylindersD
 #else
 	plannedDateTime = QDateTime(plannedDateTime.date(), plannedDateTime.time(), Qt::UTC);
 #endif
-	d->when = static_cast<time_t>(plannedDateTime.toSecsSinceEpoch());
-	diveplan.when = d->when;
+	d->set_time_local(static_cast<time_t>(plannedDateTime.toSecsSinceEpoch()));
+	diveplan.when = d->get_time_local();
 
 	d->dcs[dcNr].divemode = static_cast<enum divemode_t>(diveMode);
 

--- a/qt-models/divesummarymodel.cpp
+++ b/qt-models/divesummarymodel.cpp
@@ -165,7 +165,7 @@ static Stats loopDives(timestamp_t start)
 	Stats stats;
 	for (auto &dive: divelog.dives) {
 		// check if dive is newer than primaryStart (add to first column)
-		if (dive->when > start)
+		if (dive->get_time_local() > start)
 			calculateDive(dive.get(), stats);
 	}
 	return stats;

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -1376,13 +1376,13 @@ void DiveTripModelTree::divesMovedBetweenTrips(dive_trip *from, dive_trip *to, b
 	divesAdded(to, createTo, dives);
 }
 
-void DiveTripModelTree::divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives)
+void DiveTripModelTree::divesTimeChanged(const QVector<dive *> &dives)
 {
-	processByTrip(dives, [this, delta] (dive_trip *trip, const QVector<dive *> &divesInTrip)
-		      { divesTimeChangedTrip(trip, delta, divesInTrip); });
+	processByTrip(dives, [this] (dive_trip *trip, const QVector<dive *> &divesInTrip)
+		      { divesTimeChangedTrip(trip, divesInTrip); });
 }
 
-void DiveTripModelTree::divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &divesIn)
+void DiveTripModelTree::divesTimeChangedTrip(dive_trip *trip, const QVector<dive *> &divesIn)
 {
 	QVector <dive *> dives = visibleDives(divesIn);
 	if (dives.empty())
@@ -1703,7 +1703,7 @@ void DiveTripModelList::diveChanged(dive *d)
 	divesChanged(QVector<dive *> { d });
 }
 
-void DiveTripModelList::divesTimeChanged(timestamp_t delta, const QVector<dive *> &divesIn)
+void DiveTripModelList::divesTimeChanged(const QVector<dive *> &divesIn)
 {
 	QVector<dive *> dives = visibleDives(divesIn);
 	if (dives.empty())

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -324,7 +324,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 		case NR:
 			return d->number;
 		case DATE:
-			return get_dive_date_string(d->get_time_local());
+			return get_dive_datetime_string(d->get_time());
 		case DEPTH:
 			return get_depth_string(d->maxdepth, prefs.units.show_units_table);
 		case DURATION:

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -88,7 +88,7 @@ QString DiveTripModelBase::tripTitle(const dive_trip *trip)
 		QDateTime firstTime = timestampToDateTime(trip->date());
 		QString firstMonth = firstTime.toString("MMM");
 		QString firstYear = firstTime.toString("yyyy");
-		QDateTime lastTime = timestampToDateTime(trip->dives[0]->when);
+		QDateTime lastTime = timestampToDateTime(trip->dives[0]->get_time_local());
 		QString lastMonth = lastTime.toString("MMM");
 		QString lastYear = lastTime.toString("yyyy");
 		if (lastMonth == firstMonth && lastYear == firstYear)
@@ -273,7 +273,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 #ifdef SUBSURFACE_MOBILE
 	// Special roles for mobile
 	switch (role) {
-	case MobileListModel::DiveDateRole: return (qlonglong)d->when;
+	case MobileListModel::DiveDateRole: return (qlonglong)d->get_time_local();
 	// We have to return a QString as trip-id, because that will be used as section
 	// variable in the QtQuick list view. That has to be a string because it will try
 	// to do locale-aware sorting. And amazingly this can't be changed.
@@ -324,7 +324,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 		case NR:
 			return d->number;
 		case DATE:
-			return get_dive_date_string(d->when);
+			return get_dive_date_string(d->get_time_local());
 		case DEPTH:
 			return get_depth_string(d->maxdepth, prefs.units.show_units_table);
 		case DURATION:
@@ -814,7 +814,7 @@ dive *DiveTripModelTree::Item::getDive() const
 
 timestamp_t DiveTripModelTree::Item::when() const
 {
-	return d_or_t.trip ? d_or_t.trip->date() : d_or_t.dive->when;
+	return d_or_t.trip ? d_or_t.trip->date() : d_or_t.dive->get_time_local();
 }
 
 dive_or_trip DiveTripModelTree::tripOrDive(const QModelIndex &index) const

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -116,7 +116,7 @@ public slots:
 	void diveSiteChanged(dive_site *ds, int field);
 	void divesChanged(const QVector<dive *> &dives);
 	void diveChanged(dive *d);
-	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
+	void divesTimeChanged(const QVector<dive *> &dives);
 	void divesSelectedSlot(const QVector<dive *> &dives, dive *currentDive, int currentDC);
 	void tripSelected(dive_trip *trip, dive *currentDive);
 	void tripChanged(dive_trip *trip, TripField);
@@ -137,7 +137,7 @@ private:
 	void divesChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
 	void divesShown(dive_trip *trip, const QVector<dive *> &dives);
 	void divesHidden(dive_trip *trip, const QVector<dive *> &dives);
-	void divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
+	void divesTimeChangedTrip(dive_trip *trip, const QVector<dive *> &dives);
 	void divesDeletedInternal(dive_trip *trip, bool deleteTrip, const QVector<dive *> &dives);
 	void divesDeletedUnsorted(dive_trip *trip, QVector<dive *> dives);
 
@@ -195,7 +195,7 @@ public slots:
 	void diveSiteChanged(dive_site *ds, int field);
 	void divesChanged(const QVector<dive *> &dives);
 	void diveChanged(dive *d);
-	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
+	void divesTimeChanged(const QVector<dive *> &dives);
 	// Does nothing in list view.
 	//void divesMovedBetweenTrips(dive_trip *from, dive_trip *to, bool deleteFrom, bool createTo, const QVector<dive *> &dives);
 	void divesSelectedSlot(const QVector<dive *> &dives, dive *currentDive, int currentDC);

--- a/qt-models/divetripmodel.h
+++ b/qt-models/divetripmodel.h
@@ -139,6 +139,7 @@ private:
 	void divesHidden(dive_trip *trip, const QVector<dive *> &dives);
 	void divesTimeChangedTrip(dive_trip *trip, timestamp_t delta, const QVector<dive *> &dives);
 	void divesDeletedInternal(dive_trip *trip, bool deleteTrip, const QVector<dive *> &dives);
+	void divesDeletedUnsorted(dive_trip *trip, QVector<dive *> dives);
 
 	// The tree model has two levels. At the top level, we have either trips or dives
 	// that do not belong to trips. Such a top-level item is represented by the "Item"
@@ -213,9 +214,10 @@ private:
 	bool lessThan(const QModelIndex &i1, const QModelIndex &i2) const override;
 	dive *diveOrNull(const QModelIndex &index) const override;
 	void addDives(QVector<dive *> &dives);
-	void removeDives(QVector<dive *> dives);
+	void removeDives(QVector<dive *> dives, bool unsorted = false);
 	QModelIndex diveToIdx(const dive *d) const;
 	void divesDeletedInternal(const QVector<dive *> &dives);
+	void divesDeletedUnsorted(const QVector<dive *> &dives);
 
 	std::vector<dive *> items;				// TODO: access core data directly
 };

--- a/smtk-import/smartrak.cpp
+++ b/smtk-import/smartrak.cpp
@@ -989,8 +989,7 @@ void smartrak_import(const char *file, struct divelog *log)
 		/* Date issues with libdc parser - Take date time from mdb */
 		smtk_date_to_tm((char *)col[coln(_DATE)]->bind_ptr, &tm_date);
 		smtk_time_to_tm((char *)col[coln(INTIME)]->bind_ptr, &tm_date);
-		smtkdive->dcs[0].when = smtk_timegm(&tm_date);
-		smtkdive->set_time_local(smtkdive->dcs[0].when);
+		smtkdive->set_time_local_dc(smtk_timegm(&tm_date));
 		smtkdive->dcs[0].surfacetime.seconds = smtk_time_to_secs((char *)col[coln(INTVAL)]->bind_ptr);
 
 		/* Data that user may have registered manually if not supported by DC, or not parsed */

--- a/smtk-import/smartrak.cpp
+++ b/smtk-import/smartrak.cpp
@@ -989,7 +989,8 @@ void smartrak_import(const char *file, struct divelog *log)
 		/* Date issues with libdc parser - Take date time from mdb */
 		smtk_date_to_tm((char *)col[coln(_DATE)]->bind_ptr, &tm_date);
 		smtk_time_to_tm((char *)col[coln(INTIME)]->bind_ptr, &tm_date);
-		smtkdive->dcs[0].when = smtkdive->when = smtk_timegm(&tm_date);
+		smtkdive->dcs[0].when = smtk_timegm(&tm_date);
+		smtkdive->set_time_local(smtkdive->dcs[0].when);
 		smtkdive->dcs[0].surfacetime.seconds = smtk_time_to_secs((char *)col[coln(INTVAL)]->bind_ptr);
 
 		/* Data that user may have registered manually if not supported by DC, or not parsed */

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -194,7 +194,7 @@ bool ScatterSeries::hover(QPointF pos)
 			if (!text.empty())
 				text.push_back(QString(" ")); // Argh. Empty strings are filtered away.
 			text.push_back(StatsTranslations::tr("Dive #%1").arg(d->number));
-			text.push_back(get_dive_date_string(d->when));
+			text.push_back(get_dive_date_string(d->get_time_local()));
 			text.push_back(dataInfo(varX, d));
 			text.push_back(dataInfo(varY, d));
 			if (++shown >= show && shown < (int)highlighted.size()) {

--- a/stats/scatterseries.cpp
+++ b/stats/scatterseries.cpp
@@ -194,7 +194,7 @@ bool ScatterSeries::hover(QPointF pos)
 			if (!text.empty())
 				text.push_back(QString(" ")); // Argh. Empty strings are filtered away.
 			text.push_back(StatsTranslations::tr("Dive #%1").arg(d->number));
-			text.push_back(get_dive_date_string(d->get_time_local()));
+			text.push_back(get_dive_datetime_string(d->get_time()));
 			text.push_back(dataInfo(varX, d));
 			text.push_back(dataInfo(varY, d));
 			if (++shown >= show && shown < (int)highlighted.size()) {

--- a/stats/statsvariables.cpp
+++ b/stats/statsvariables.cpp
@@ -862,7 +862,7 @@ struct DateYearBinner : public IntBinner<DateYearBinner, IntBin> {
 		return QString::number(derived_bin(bin).value);
 	}
 	int to_bin_value(const dive *d) const {
-		return utc_year(d->when);
+		return utc_year(d->get_time_local());
 	}
 	double lowerBoundToFloatBase(int year) const {
 		return date_to_double(year, 0, 0);
@@ -897,7 +897,7 @@ struct DateQuarterBinner : public SimpleContinuousBinner<DateQuarterBinner, Date
 	}
 	year_quarter to_bin_value(const dive *d) const {
 		struct tm tm;
-		utc_mkdate(d->when, &tm);
+		utc_mkdate(d->get_time_local(), &tm);
 
 		int year = tm.tm_year;
 		switch (tm.tm_mon) {
@@ -941,7 +941,7 @@ struct DateMonthBinner : public SimpleContinuousBinner<DateMonthBinner, DateMont
 	}
 	year_month to_bin_value(const dive *d) const {
 		struct tm tm;
-		utc_mkdate(d->when, &tm);
+		utc_mkdate(d->get_time_local(), &tm);
 		return { tm.tm_year, tm.tm_mon };
 	}
 	void inc(DateMonthBin &bin) const {
@@ -960,7 +960,7 @@ struct DateVariable : public StatsVariableTemplate<StatsVariable::Type::Continuo
 		return StatsTranslations::tr("Date");
 	}
 	double toFloat(const dive *d) const override {
-		return d->when / 86400.0;
+		return d->get_time_local() / 86400.0;
 	}
 	std::vector<const StatsBinner *> binners() const override {
 		return { &date_year_binner, &date_quarter_binner, &date_month_binner };
@@ -1882,7 +1882,7 @@ struct DayOfWeekBinner : public SimpleBinner<DayOfWeekBinner, IntBin> {
 		return formatDayOfWeek(derived_bin(bin).value);
 	}
 	int to_bin_value(const dive *d) const {
-		return utc_weekday(d->when);
+		return utc_weekday(d->get_time_local());
 	}
 };
 
@@ -1892,7 +1892,7 @@ struct DayOfWeekVariable : public StatsVariableTemplate<StatsVariable::Type::Dis
 		return StatsTranslations::tr("Day of week");
 	}
 	QString diveCategories(const dive *d) const override {
-		return formatDayOfWeek(utc_weekday(d->when));
+		return formatDayOfWeek(utc_weekday(d->get_time_local()));
 	}
 	std::vector<const StatsBinner *> binners() const override {
 		return { &day_of_week_binner };
@@ -1905,7 +1905,7 @@ struct MonthOfYearBinner : public SimpleBinner<MonthOfYearBinner, IntBin> {
 		return QString(monthname(derived_bin(bin).value));
 	}
 	int to_bin_value(const dive *d) const {
-		return utc_month(d->when);
+		return utc_month(d->get_time_local());
 	}
 };
 
@@ -1915,7 +1915,7 @@ struct MonthOfYearVariable : public StatsVariableTemplate<StatsVariable::Type::D
 		return StatsTranslations::tr("Month of year");
 	}
 	QString diveCategories(const dive *d) const override {
-		return QString(monthname(utc_month(d->when)));
+		return QString(monthname(utc_month(d->get_time_local())));
 	}
 	std::vector<const StatsBinner *> binners() const override {
 		return { &month_of_year_binner };

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -221,11 +221,8 @@ void TestParse::testParseHUDC()
 	 * CSV import uses time and date stamps relative to current
 	 * time, thus we need to use a static (random) timestamp
 	 */
-	if (!divelog.dives.empty()) {
-		struct dive &dive = *divelog.dives.back();
-		dive.set_time_local(1255152761);
-		dive.dcs[0].when = 1255152761;
-	}
+	if (!divelog.dives.empty())
+		divelog.dives.back()->set_time_local_dc(1255152761);
 
 	QCOMPARE(save_dives("./testhudcout.ssrf"), 0);
 	FILE_COMPARE("./testhudcout.ssrf",

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -223,7 +223,7 @@ void TestParse::testParseHUDC()
 	 */
 	if (!divelog.dives.empty()) {
 		struct dive &dive = *divelog.dives.back();
-		dive.when = 1255152761;
+		dive.set_time_local(1255152761);
 		dive.dcs[0].when = 1255152761;
 	}
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

The goal here is to make it clear that time-accesses are with respect to local time. Once we support "offset to utc" it should be always made explicit, whether we're treating local time (as in local, where/when the dive took place) or time relative to UTC (for example when sorting dives or calculating N2 loading between consecutive dives).

Therefore, all time accesses should be via accessor function. This PR does that for `struct dive`.  Timestamps are also stored in `struct diveplan` and `struct divecomputer`. However, these are mostly accessed by local code and therefore I suggest tacking those, when introducing a `timeoffset` field.

Completely untested (apart from starting and loading a log)!