### PR TITLE
Desktop: show depth and time for non-manual dives

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -235,8 +235,10 @@ void TabDiveNotes::updateData(const std::vector<dive *> &, dive *currentDive, in
 		ui.NotesLabel->setText(tr("Trip notes"));
 		ui.notes->setText(QString::fromStdString(currentTrip->notes));
 		ui.depth->setVisible(false);
+		ui.depthFixed->setVisible(false);
 		ui.depthLabel->setVisible(false);
 		ui.duration->setVisible(false);
+		ui.durationFixed->setVisible(false);
 		ui.durationLabel->setVisible(false);
 	} else {
 		// make all the fields visible writeable
@@ -255,6 +257,8 @@ void TabDiveNotes::updateData(const std::vector<dive *> &, dive *currentDive, in
 		ui.dateEdit->setReadOnly(false);
 		ui.timeLabel->setVisible(true);
 		ui.timeEdit->setVisible(true);
+		ui.depthLabel->setVisible(true);
+		ui.durationLabel->setVisible(true);
 		/* and fill them from the dive */
 		ui.rating->setCurrentStars(currentDive->rating);
 		// reset labels in case we last displayed trip notes
@@ -263,18 +267,26 @@ void TabDiveNotes::updateData(const std::vector<dive *> &, dive *currentDive, in
 		ui.tagWidget->setText(QString::fromStdString(taglist_get_tagstring(currentDive->tags)));
 		bool isManual = is_dc_manually_added_dive(&currentDive->dcs[0]);
 		ui.depth->setVisible(isManual);
-		ui.depthLabel->setVisible(isManual);
 		ui.duration->setVisible(isManual);
-		ui.durationLabel->setVisible(isManual);
+		ui.depthFixed->setVisible(!isManual);
+		ui.durationFixed->setVisible(!isManual);
 
 		updateNotes(currentDive);
 		updateDiveSite(currentDive);
 		updateDateTime(currentDive);
 		ui.diveguide->setText(QString::fromStdString(currentDive->diveguide));
 		ui.buddy->setText(QString::fromStdString(currentDive->buddy));
+
+		QString durationString = render_seconds_to_string(currentDive->duration.seconds);
+		QString depthString = get_depth_string(currentDive->maxdepth, true);
+		if (isManual) {
+			ui.duration->setText(durationString);
+			ui.depth->setText(depthString);
+		} else {
+			ui.durationFixed->setText(durationString);
+			ui.depthFixed->setText(depthString);
+		}
 	}
-	ui.duration->setText(render_seconds_to_string(currentDive->duration.seconds));
-	ui.depth->setText(get_depth_string(currentDive->maxdepth, true));
 
 	ui.editDiveSiteButton->setEnabled(!ui.location->text().isEmpty());
 	/* unset the special value text for date and time, just in case someone dove at midnight */

--- a/desktop-widgets/tab-widgets/TabDiveNotes.ui
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.ui
@@ -95,19 +95,6 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2" colspan="2">
-          <widget class="QLabel" name="depthLabely">
-           <property name="text">
-            <string> </string>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-             <horstretch>2</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="2">
           <widget class="QLabel" name="depthLabel">
            <property name="sizePolicy">
@@ -163,21 +150,18 @@
            </property>
            </widget>
          </item>
-         <item row="1" column="2" colspan="2">
-          <widget class="QLabel" name="depthLabelx">
-           <property name="text">
-            <string> </string>
-           </property>
+         <item row="1" column="2">
+          <widget class="QLineEdit" name="depth">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-             <horstretch>2</horstretch>
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>1</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="QLineEdit" name="depth">
+          <widget class="QLabel" name="depthFixed">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
              <horstretch>1</horstretch>
@@ -195,7 +179,17 @@
             </sizepolicy>
            </property>
           </widget>
-          </item>
+         </item>
+         <item row="1" column="3">
+          <widget class="QLabel" name="durationFixed">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
          </layout>
        </item>
        <item>


### PR DESCRIPTION
In the UI-definition of the notes-tab there was code suggesting that we wanted to show the depth and time of the dive even in non-manual dives.

Either we lost this, or it was never properly implemented.

Implement it, by showing QLabels with the information for non-manually added dives.what the intention was.

I tried reusing the QLineEdit and setting it to read-only for non-manual dives. However, the UI doesn't grey out the QLineEdit, making the UI confusing. Bad Qt.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
See commit description: show depth and time even for non-manual dives in a read-only QLabel.

If we do not want this, we should at least remove the spurious UI elements.

I lack time to dig in the history to find out whether we list this feature at one point or whether it was never implemented.