### PR TITLE
Add seconds to duration label on dive notes tab

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveNotes.ui
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.ui
@@ -133,7 +133,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Duration (h:mm)</string>
+            <string>Duration (h:mm(:ss))</string>
            </property>
           <property name="isHeader" stdset="0">
            <bool>true</bool>


### PR DESCRIPTION
The label says "(h:mm)", but factually, one also can enter seconds resulting values such as "1:23:45". Let the label reflect that.

The whole thing is a bit finicky.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
See commit description: The label of the duration field was factually wrong, as it is also possible to enter second values (why not?).

See discussion in #4691.