### PR TITLE
core: fix integer sign in localized sprintf functions

### DIFF
--- a/core/format.cpp
+++ b/core/format.cpp
@@ -77,12 +77,13 @@ static QString fmt_int(T i, vasprintf_flags flags, int field_width, int precisio
 		return fmt_string(res, flags, field_width, -1);
 	}
 
-	// If we have to prepend a '+' or a space character, remove that from the field width
 	char sign = 0;
-	if (i >= 0 && (flags.space || flags.sign) && field_width > 0) {
+	if (i >= 0 && (flags.space || flags.sign))
 		sign = flags.sign ? '+' : ' ';
+
+	// If we have to prepend a '+' or a space character, remove that from the field width
+	if (sign && field_width > 0)
 		--field_width;
-	}
 	if (flags.left)
 		field_width = -field_width;
 	QChar fillChar = flags.zero && !flags.left ? '0' : ' ';


### PR DESCRIPTION
The '+' or ' ' argument to integer format specifiers was ignored if no field length was given.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

See commit description: our localized sprintf functions were not working properly.

I think this is one for the C experts. :) Please check.