### PR TITLE
Turn "extra info" tab into "dive computer info" tab

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
@@ -28,9 +28,9 @@ void TabDiveExtraInfo::updateData(const std::vector<dive *> &, dive *currentDive
 	if (currentDive) {
 		const divecomputer *dc = currentDive->get_dc(currentDC);
 
-		ui->model->setText(QString::fromStdString(dc->model));
-		ui->serial->setText(QString::fromStdString(dc->serial));
-		ui->firmware->setText(QString::fromStdString(dc->fw_version));
+		ui->model->setText(QString::fromStdString(dc->model).trimmed());
+		ui->serial->setText(QString::fromStdString(dc->serial).trimmed());
+		ui->firmware->setText(QString::fromStdString(dc->fw_version).trimmed());
 		ui->date->setText(get_dive_date_string(dc->when));
 		ui->duration->setText(get_dive_duration_string(dc->duration.seconds, tr("h"), tr("min"), tr("sec"),
 				" ", dc->divemode == FREEDIVE));

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
@@ -2,7 +2,9 @@
 #include "TabDiveExtraInfo.h"
 #include "ui_TabDiveExtraInfo.h"
 #include "core/dive.h"
+#include "core/gettextfromc.h"
 #include "core/selection.h"
+#include "core/string-format.h"
 #include "qt-models/divecomputerextradatamodel.h"
 
 TabDiveExtraInfo::TabDiveExtraInfo(MainTab *parent) :
@@ -23,15 +25,36 @@ TabDiveExtraInfo::~TabDiveExtraInfo()
 
 void TabDiveExtraInfo::updateData(const std::vector<dive *> &, dive *currentDive, int currentDC)
 {
-	if (currentDive)
-		extraDataModel->updateDiveComputer(currentDive->get_dc(currentDC));
+	if (currentDive) {
+		const divecomputer *dc = currentDive->get_dc(currentDC);
 
-	ui->extraData->setVisible(false); // This will cause the resize to include rows outside the current viewport
-	ui->extraData->resizeColumnsToContents();
-	ui->extraData->setVisible(true);
+		ui->model->setText(QString::fromStdString(dc->model));
+		ui->serial->setText(QString::fromStdString(dc->serial));
+		ui->firmware->setText(QString::fromStdString(dc->fw_version));
+		ui->date->setText(get_dive_date_string(dc->when));
+		ui->duration->setText(get_dive_duration_string(dc->duration.seconds, tr("h"), tr("min"), tr("sec"),
+				" ", dc->divemode == FREEDIVE));
+		if (dc->divemode >= 0 && dc->divemode < NUM_DIVEMODE)
+			ui->diveMode->setText(gettextFromC::tr(divemode_text_ui[dc->divemode]));
+		else
+			ui->diveMode->clear();
+
+		extraDataModel->updateDiveComputer(dc);
+		ui->extraData->setVisible(false); // This will cause the resize to include rows outside the current viewport
+		ui->extraData->resizeColumnsToContents();
+		ui->extraData->setVisible(true);
+	} else {
+		clear();
+	}
 }
 
 void TabDiveExtraInfo::clear()
 {
+	ui->model->clear();
+	ui->serial->clear();
+	ui->firmware->clear();
+	ui->date->clear();
+	ui->duration->clear();
+	ui->diveMode->clear();
 	extraDataModel->clear();
 }

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
@@ -10,9 +10,181 @@
     <height>300</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QTableView" name="extraData"/>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QGroupBox">
+     <property name="title">
+      <string>Model</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      </sizepolicy>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignHCenter</set>
+      </property>
+      <item>
+       <widget class="QLabel" name="model" />
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QGroupBox">
+     <property name="title">
+      <string>Serial</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      </sizepolicy>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignHCenter</set>
+      </property>
+      <item>
+       <widget class="QLabel" name="serial" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QGroupBox">
+     <property name="title">
+      <string>Firmware</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      </sizepolicy>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignHCenter</set>
+      </property>
+      <item>
+       <widget class="QLabel" name="firmware" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox">
+     <property name="title">
+      <string>Date</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      </sizepolicy>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignHCenter</set>
+      </property>
+      <item>
+       <widget class="QLabel" name="date" />
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QGroupBox">
+     <property name="title">
+      <string>Duration</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      </sizepolicy>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignHCenter</set>
+      </property>
+      <item>
+       <widget class="QLabel" name="duration" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QGroupBox">
+     <property name="title">
+      <string>Dive Mode</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      </sizepolicy>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignHCenter</set>
+      </property>
+      <item>
+       <widget class="QLabel" name="diveMode" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QGroupBox">
+     <property name="title">
+      <string>Extra Data</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      </sizepolicy>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMaximumSize</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignHCenter</set>
+      </property>
+      <item>
+       <widget class="QTableView" name="extraData"/>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
@@ -10,9 +10,6 @@
     <height>300</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Dive Computer Info</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTableView" name="extraData"/>

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Extra Info</string>
+   <string>Dive Computer Info</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/desktop-widgets/tab-widgets/TabDiveInformation.ui
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.ui
@@ -10,9 +10,6 @@
     <height>421</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Information</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="KMessageWidget" name="multiDiveWarningMessage"/>

--- a/desktop-widgets/tab-widgets/TabDivePhotos.ui
+++ b/desktop-widgets/tab-widgets/TabDivePhotos.ui
@@ -10,9 +10,6 @@
     <height>300</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Photos</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="DivePictureWidget" name="photosView">

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.ui
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.ui
@@ -64,7 +64,6 @@
          <property name="verticalSpacing">
           <number>0</number>
          </property>
-
          <item row="0" column="0">
           <widget class="QGroupBox" name="groupBoxb">
            <property name="title">

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.ui
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.ui
@@ -10,9 +10,6 @@
     <height>304</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Statistics</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="verticalSpacing">
     <number>0</number>

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -42,7 +42,7 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	extraWidgets << new TabDivePhotos(this);
 	addTab(extraWidgets.last(), tr("Media"));
 	extraWidgets << new TabDiveExtraInfo(this);
-	addTab(extraWidgets.last(), tr("Extra Info"));
+	addTab(extraWidgets.last(), tr("Dive Computer Info"));
 
 	// make sure we know if this is a light or dark mode
 	isDark = paletteIsDark(palette());

--- a/qt-models/divecomputerextradatamodel.cpp
+++ b/qt-models/divecomputerextradatamodel.cpp
@@ -46,10 +46,18 @@ int ExtraDataModel::rowCount(const QModelIndex&) const
 
 void ExtraDataModel::updateDiveComputer(const struct divecomputer *dc)
 {
+	std::vector<extra_data> new_items;
+	if (dc) {
+		new_items.reserve(dc->extra_data.size());
+		for (const extra_data &data: dc->extra_data) {
+			// Filter out serial and firmware version, because these data
+			// have their own field in struct divecomputer.
+			if (data.key != "Serial" && data.key != "FW Version" && data.key != "Firmware")
+				new_items.push_back(data);
+		}
+	}
+
 	beginResetModel();
-	if (dc)
-		items = dc->extra_data;
-	else
-		items.clear();
+	items = std::move(new_items);
 	endResetModel();
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The "Extra Info" tab is about additional info for each dive computer. Make that more clear.

Moreover, show the recorded start-time of each dive computer, which was stored, but to my knowledge not shown anywhere.

The UI is at the proof-of-concept stage. No idea how to do this properly (and little motivation to find out).

In my tests, this seems to work.