### PR TITLE
[TRIVIAL] cleanup: remove unused define of PATH_MAX

### DIFF
--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -34,10 +34,6 @@
 
 #include <QUrlQuery>
 
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
-
 WebServices::WebServices(QWidget *parent) : QDialog(parent, QFlag(0)), reply(0)
 {
 	ui.setupUi(this);


### PR DESCRIPTION
As far as I can see, the last user was removed in
4ee7cb7d1d71b268fdd28554970b5dc79b3633c1

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This is a trivial cleanup: remove unused define.

If the tests run through, I will commit.