### PR TITLE
cleanup: move (un)lock_planner() to profile.cpp

### DIFF
--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -3,10 +3,6 @@
 /* creates all the necessary data for drawing the dive profile
  */
 #include "gettext.h"
-#include <limits.h>
-#include <string.h>
-#include <assert.h>
-#include <stdlib.h>
 
 #include "dive.h"
 #include "divelist.h"
@@ -29,6 +25,12 @@
 #include "qthelper.h"
 #include "range.h"
 #include "format.h"
+
+#include <limits.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <QMutex>
 
 //#define DEBUG_GAS 1
 
@@ -841,6 +843,18 @@ static void calculate_ndl_tts(struct deco_state *ds, const struct dive *dive, st
 			next_stop -= deco_stepsize;
 		}
 	}
+}
+
+QMutex planLock;
+
+static void lock_planner()
+{
+	planLock.lock();
+}
+
+static void unlock_planner()
+{
+	planLock.unlock();
 }
 
 /* Let's try to do some deco calculations.

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1546,18 +1546,6 @@ void parse_seabear_header(const char *filename, struct xml_params *params)
 	f.close();
 }
 
-QMutex planLock;
-
-void lock_planner()
-{
-	planLock.lock();
-}
-
-void unlock_planner()
-{
-	planLock.unlock();
-}
-
 // function to call to allow the UI to show updates for longer running activities
 void (*uiNotificationCallback)(QString msg) = nullptr;
 

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -112,8 +112,6 @@ std::string hashfile_name();
 enum deco_mode decoMode(bool in_planner);
 void parse_seabear_header(const char *filename, struct xml_params *params);
 time_t get_dive_datetime_from_isostring(const char *when);
-void lock_planner();
-void unlock_planner();
 xsltStylesheetPtr get_stylesheet(const char *name);
 weight_t string_to_weight(const char *str);
 depth_t string_to_depth(const char *str);


### PR DESCRIPTION
The only callers (un)lock_planner() are in profile.cpp, so we might just move it there and shrink qthelper.cpp.

This helper function was needed, when planner.c was pure C. Not any longer.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
A rather trivial cleanup and part of the long-term project "shrink qthelper.cpp".