### PR TITLE
cleanup: move print_qt_version() into subsurfacestartup.cpp

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1546,11 +1546,6 @@ void parse_seabear_header(const char *filename, struct xml_params *params)
 	f.close();
 }
 
-void print_qt_versions()
-{
-	printf("%s\n", qPrintable(QStringLiteral("built with Qt Version %1, runtime from Qt Version %2").arg(QT_VERSION_STR).arg(qVersion())));
-}
-
 QMutex planLock;
 
 void lock_planner()

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -112,7 +112,6 @@ std::string hashfile_name();
 enum deco_mode decoMode(bool in_planner);
 void parse_seabear_header(const char *filename, struct xml_params *params);
 time_t get_dive_datetime_from_isostring(const char *when);
-void print_qt_versions();
 void lock_planner();
 void unlock_planner();
 xsltStylesheetPtr get_stylesheet(const char *name);

--- a/core/subsurfacestartup.cpp
+++ b/core/subsurfacestartup.cpp
@@ -43,7 +43,7 @@ void print_version()
 	printf("Subsurface v%s,\n", subsurface_canonical_version());
 #endif
 	printf("built with libdivecomputer v%s\n", dc_version(NULL));
-	print_qt_versions();
+	printf("built with Qt Version %s, runtime from Qt Version %s\n", QT_VERSION_STR, qVersion());
 	int git_maj, git_min, git_rev;
 	git_libgit2_version(&git_maj, &git_min, &git_rev);
 	printf("built with libgit2 %d.%d.%d\n", git_maj, git_min, git_rev);


### PR DESCRIPTION
This function was in qthelper.cpp from a time when the startup code was pure C.

Just fold it into the only caller. Also, there seems to be no reason to use convoluted Qt constructs, since the version information comes as C-style strings.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another trivial "make qthelper.cpp smaller" commit. Since the startup code is now C++, there is no reason to access the version information in an external file.