### PR TITLE
cleanup: move render_seconds_to_string() to string-format.cpp

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -490,21 +490,6 @@ timestamp_t dateTimeToTimestamp(const QDateTime &t)
 	return t.toSecsSinceEpoch();
 }
 
-QString render_seconds_to_string(int seconds)
-{
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-	if (seconds % 60 == 0)
-		return QDateTime::fromSecsSinceEpoch(seconds, QTimeZone::utc()).toUTC().toString("h:mm");
-	else
-		return QDateTime::fromSecsSinceEpoch(seconds, QTimeZone::utc()).toUTC().toString("h:mm:ss");
-#else
-	if (seconds % 60 == 0)
-		return QDateTime::fromSecsSinceEpoch(seconds, Qt::UTC).toUTC().toString("h:mm");
-	else
-		return QDateTime::fromSecsSinceEpoch(seconds, Qt::UTC).toUTC().toString("h:mm:ss");
-#endif
-}
-
 int parseDurationToSeconds(const QString &text)
 {
 	int secs;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -53,7 +53,6 @@ int parseTemperatureToMkelvin(const QString &text);
 int parsePressureToMbar(const QString &text);
 int parseGasMixO2(const QString &text);
 int parseGasMixHE(const QString &text);
-QString render_seconds_to_string(int seconds);
 QString get_first_dive_date_string();
 QString get_last_dive_date_string();
 QString get_short_dive_date_string(timestamp_t when);

--- a/core/string-format.cpp
+++ b/core/string-format.cpp
@@ -523,6 +523,14 @@ QString get_dive_duration_string(timestamp_t when, QString hoursText, QString mi
 	return get_dive_duration_string(when, hoursText, minutesText, gettextFromC::tr("sec"), QStringLiteral(":"), false);
 }
 
+QString get_duration_string_short(duration_t duration)
+{
+	auto seconds = std::abs(duration.seconds);
+	const char *prefix = duration.seconds < 0 ? "-" : "";
+	return seconds % 60 == 0 ? qasprintf_loc("%s%d:%02d", prefix, seconds / 3600, (seconds / 60) % 60)
+				 : qasprintf_loc("%s%d:%02d:%02d", prefix, seconds / 3600, (seconds / 60) % 60, seconds % 60);
+}
+
 QString get_dive_surfint_string(timestamp_t when, QString daysText, QString hoursText, QString minutesText, QString separator, int maxdays)
 {
 	int days, hrs, mins;

--- a/core/string-format.h
+++ b/core/string-format.h
@@ -59,6 +59,7 @@ QString get_dive_duration_string(timestamp_t when, QString hoursText, QString mi
 QString get_dive_duration_string(timestamp_t when, QString hoursText, QString minutesText); // Default values for seconds, separator and isFreeDive
 QString get_dive_surfint_string(timestamp_t when, QString daysText, QString hoursText, QString minutesText, QString separator = " ", int maxdays = 4);
 QString get_dive_date_string(timestamp_t when);
+QString get_duration_string_short(duration_t duration);
 std::string get_dive_date_c_string(timestamp_t when);
 QString distance_string(int distanceInMeters);
 QString printGPSCoords(const location_t *loc);

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -113,7 +113,7 @@ void TabDiveNotes::divesChanged(const QVector<dive *> &dives, DiveField field)
 
 	dive *currentDive = parent.currentDive;
 	if (field.duration)
-		ui.duration->setText(render_seconds_to_string(currentDive->duration.seconds));
+		ui.duration->setText(get_duration_string_short(currentDive->duration));
 	if (field.depth)
 		ui.depth->setText(get_depth_string(currentDive->maxdepth, true));
 	if (field.rating)
@@ -275,7 +275,7 @@ void TabDiveNotes::updateData(const std::vector<dive *> &, dive *currentDive, in
 		ui.diveguide->setText(QString::fromStdString(currentDive->diveguide));
 		ui.buddy->setText(QString::fromStdString(currentDive->buddy));
 	}
-	ui.duration->setText(render_seconds_to_string(currentDive->duration.seconds));
+	ui.duration->setText(get_duration_string_short(currentDive->duration));
 	ui.depth->setText(get_depth_string(currentDive->maxdepth, true));
 
 	ui.editDiveSiteButton->setEnabled(!ui.location->text().isEmpty());


### PR DESCRIPTION
Part of a long term project to slim qthelper.cpp.

This was a very odd implementation using Qt primitives. Rewrite it and also pass a duration_t as argument, since both callers used this functions to format a duration_t.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
See commit description: move more stuff from qthelper.

This one contains a rewrite, so some discretion is adviced.