### PR TITLE
Remove leading/trailing whitespace from extra_data values

### DIFF
--- a/core/device.cpp
+++ b/core/device.cpp
@@ -73,7 +73,7 @@ int create_device_node(device_table &dcs, const std::string &m, const std::strin
 		it->nickName = n;
 		return it - dcs.begin();
 	} else {
-		dev.deviceId = calculate_string_hash(s.c_str());
+		dev.deviceId = calculate_string_hash(s);
 		it = dcs.insert(it, dev);
 		return it - dcs.begin();
 	}

--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -369,7 +369,7 @@ struct event *get_event(struct divecomputer *dc, int idx)
 void add_extra_data(struct divecomputer *dc, const std::string &key, const std::string &value)
 {
 	if (key == "Serial") {
-		dc->deviceid = calculate_string_hash(value.c_str());
+		dc->deviceid = calculate_string_hash(value);
 		dc->serial = value;
 	}
 	if (key == "FW Version")

--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -366,16 +366,20 @@ struct event *get_event(struct divecomputer *dc, int idx)
 	return &dc->events[idx];
 }
 
-void add_extra_data(struct divecomputer *dc, const std::string &key, const std::string &value)
+void add_extra_data(struct divecomputer *dc, const std::string &key, std::string_view value)
 {
 	if (key == "Serial") {
 		dc->deviceid = calculate_string_hash(value);
 		dc->serial = value;
 	}
-	if (key == "FW Version")
-		dc->fw_version = value;
 
-	dc->extra_data.push_back(extra_data { key, value });
+	// Some libdivecomputer backends add a spurious '\n' character at the
+	// end of FW Version. Remove this for now. Note that, for now,
+	// the sanitized string will not be written to the log.
+	if (key == "FW Version")
+		dc->fw_version = trimmed(value);
+
+	dc->extra_data.push_back(extra_data { key, std::string(value) });
 }
 
 /*

--- a/core/divecomputer.h
+++ b/core/divecomputer.h
@@ -67,7 +67,7 @@ extern int add_event_to_dc(struct divecomputer *dc, struct event ev); // event s
 extern struct event *add_event(struct divecomputer *dc, unsigned int time, int type, int flags, int value, const std::string &name);
 extern struct event remove_event_from_dc(struct divecomputer *dc, int idx);
 struct event *get_event(struct divecomputer *dc, int idx);
-extern void add_extra_data(struct divecomputer *dc, const std::string &key, const std::string &value);
+extern void add_extra_data(struct divecomputer *dc, const std::string &key, std::string_view value);
 extern uint32_t calculate_string_hash(std::string_view sv);
 extern bool is_dc_planner(const struct divecomputer *dc);
 extern void make_planner_dc(struct divecomputer *dc);

--- a/core/divecomputer.h
+++ b/core/divecomputer.h
@@ -6,6 +6,7 @@
 #include "units.h"
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 struct extra_data;
@@ -67,7 +68,7 @@ extern struct event *add_event(struct divecomputer *dc, unsigned int time, int t
 extern struct event remove_event_from_dc(struct divecomputer *dc, int idx);
 struct event *get_event(struct divecomputer *dc, int idx);
 extern void add_extra_data(struct divecomputer *dc, const std::string &key, const std::string &value);
-extern uint32_t calculate_string_hash(const char *str);
+extern uint32_t calculate_string_hash(std::string_view sv);
 extern bool is_dc_planner(const struct divecomputer *dc);
 extern void make_planner_dc(struct divecomputer *dc);
 extern const char *manual_dc_name;

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -589,9 +589,9 @@ static uint32_t calculate_diveid(const unsigned char *fingerprint, unsigned int 
 	return SHA1_uint32(fingerprint, fsize);
 }
 
-uint32_t calculate_string_hash(const char *str)
+uint32_t calculate_string_hash(std::string_view sv)
 {
-	return calculate_diveid((const unsigned char *)str, strlen(str));
+	return calculate_diveid((const unsigned char *)sv.data(), sv.size());
 }
 
 static void parse_string_field(device_data_t *devdata, struct dive *dive, dc_field_string_t *str)
@@ -943,7 +943,7 @@ static std::string fingerprint_file(device_data_t *devdata)
 	uint32_t model, serial;
 
 	// Model hash and libdivecomputer 32-bit 'serial number' for the file name
-	model = calculate_string_hash(devdata->model.c_str());
+	model = calculate_string_hash(devdata->model);
 	serial = devdata->devinfo.serial;
 
 	return format_string_std("%s/fingerprints/%04x.%u",
@@ -1040,7 +1040,7 @@ static void lookup_fingerprint(dc_device_t *device, device_data_t *devdata)
 		return;
 
 	/* first try our in memory data - raw_data is owned by the table, the dc_device_set_fingerprint function copies the data */
-	auto [fsize, raw_data] = get_fingerprint_data(fingerprints, calculate_string_hash(devdata->model.c_str()), devdata->devinfo.serial);
+	auto [fsize, raw_data] = get_fingerprint_data(fingerprints, calculate_string_hash(devdata->model), devdata->devinfo.serial);
 	if (fsize) {
 		if (verbose)
 			dev_info("... found fingerprint in dive table");
@@ -1582,7 +1582,7 @@ std::string do_libdivecomputer_import(device_data_t *data)
 	 */
 	save_fingerprint(data);
 	if (data->fingerprint && data->fdiveid)
-		create_fingerprint_node(fingerprints, calculate_string_hash(data->model.c_str()), data->devinfo.serial,
+		create_fingerprint_node(fingerprints, calculate_string_hash(data->model), data->devinfo.serial,
 					data->fingerprint, data->fsize, data->fdeviceid, data->fdiveid);
 	free(data->fingerprint);
 	data->fingerprint = NULL;

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -958,7 +958,7 @@ static void parse_divecomputerid_keyvalue(void *_cid, const char *key, const std
 	// Serial number and nickname matter
 	if (!strcmp(key, "serial")) {
 		cid->serial = value;
-		cid->deviceid = calculate_string_hash(value.c_str());
+		cid->deviceid = calculate_string_hash(value);
 		return;
 	}
 	if (!strcmp(key, "nickname")) {

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -825,7 +825,7 @@ static void save_one_device(struct membuffer *b, const struct device &d)
 		return;
 
 	show_utf8(b, "divecomputerid ", d.model.c_str(), "");
-	put_format(b, " deviceid=%08x", calculate_string_hash(d.serialNumber.c_str()));
+	put_format(b, " deviceid=%08x", calculate_string_hash(d.serialNumber));
 	show_utf8(b, " serial=", d.serialNumber.c_str(), "");
 	show_utf8(b, " nickname=", d.nickName.c_str(), "");
 	put_string(b, "\n");

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -568,7 +568,7 @@ static void save_one_device(struct membuffer *b, const struct device &d)
 
 	put_format(b, "<divecomputerid");
 	show_utf8(b, d.model.c_str(), " model='", "'", 1);
-	put_format(b, " deviceid='%08x'", calculate_string_hash(d.serialNumber.c_str()));
+	put_format(b, " deviceid='%08x'", calculate_string_hash(d.serialNumber));
 	show_utf8(b, d.serialNumber.c_str(), " serial='", "'", 1);
 	show_utf8(b, d.nickName.c_str(), " nickname='", "'", 1);
 	put_format(b, "/>\n");

--- a/core/subsurface-string.cpp
+++ b/core/subsurface-string.cpp
@@ -15,3 +15,18 @@ std::string join(const std::vector<std::string> &l, const std::string &separator
 	}
 	return res;
 }
+
+// Poor man's trim function for std::string_view
+void trim(std::string_view &sv)
+{
+	while (!sv.empty() && isspace(sv.front()))
+		sv.remove_prefix(1);
+	while (!sv.empty() && isspace(sv.back()))
+		sv.remove_suffix(1);
+}
+
+std::string trimmed(std::string_view sv)
+{
+	trim(sv);
+	return std::string(sv);
+}

--- a/core/subsurface-string.h
+++ b/core/subsurface-string.h
@@ -54,4 +54,7 @@ inline bool contains(std::string_view haystack, const std::string &needle)
 
 std::string join(const std::vector<std::string> &l, const std::string &separator, bool skip_empty = false);
 
+void trim(std::string_view &sv);
+std::string trimmed(std::string_view sv);
+
 #endif // SUBSURFACE_STRING_H


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Since some libdivecomputer devices seem to add spurious whitespace to the firmware version, remove it.

See discussion in #4699.

@mikeller: What do you think of this "brutal" solution to the whitespace problem? Does one ever want to keep the whitespece at the beginning or end of the extra data value?