### PR TITLE
cleanup: use std::string's sorting function in divepicturemodel.cpp

### DIFF
--- a/core/picture.cpp
+++ b/core/picture.cpp
@@ -25,7 +25,6 @@ void add_picture(picture_table &t, struct picture newpic)
 
 int get_picture_idx(const picture_table &t, const std::string &filename)
 {
-
 	return index_of_if(t, [&filename] (const picture &p)
 			   { return p.filename == filename; });
 }

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -20,15 +20,12 @@ PictureEntry::PictureEntry(dive *dIn, const picture &p) : d(dIn),
 }
 
 // Note: it is crucial that this uses the same sorting as the core.
-// Therefore, we use the C strcmp functions [std::string::operator<()
-// should give the same result].
 bool PictureEntry::operator<(const PictureEntry &p2) const
 {
 	if (int cmp = comp_dives_ptr(d, p2.d))
 		return cmp < 0;
-	if (offsetSeconds != p2.offsetSeconds)
-		return offsetSeconds < p2.offsetSeconds;
-	return strcmp(filename.c_str(), p2.filename.c_str()) < 0;
+	return std::tie(offsetSeconds, filename) <
+	       std::tie(p2.offsetSeconds, p2.filename);
 }
 
 DivePictureModel *DivePictureModel::instance()


### PR DESCRIPTION
This one is ironic: In the code of DivePictureModel, strcmp() was used to compare two std::strings with a comment that this is due to using the same sorting as in core. However, core has long been changed to use the std::string's sorting function.

Use the idiomatic version also in the model.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Trivial (hopefully) cleanup. See commit description.