### PR TITLE
cleanup: remove unnecessary 'this' capture from lambdas

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -407,9 +407,9 @@ PlannerSettingsWidget::PlannerSettingsWidget(PlannerWidgets *parent)
 	connect(ui.min_switch_duration, QOverload<int>::of(&QSpinBox::valueChanged), &PlannerShared::set_min_switch_duration);
 	connect(ui.surface_segment, QOverload<int>::of(&QSpinBox::valueChanged), &PlannerShared::set_surface_segment);
 
-	connect(ui.recreational_deco, &QAbstractButton::clicked, [this, parent] { parent->disableDecoElements(RECREATIONAL, parent->getDiveMode()); });
-	connect(ui.buehlmann_deco, &QAbstractButton::clicked, [this, parent] { parent->disableDecoElements(BUEHLMANN, parent->getDiveMode()); });
-	connect(ui.vpmb_deco, &QAbstractButton::clicked, [this, parent] { parent->disableDecoElements(VPMB, parent->getDiveMode()); });
+	connect(ui.recreational_deco, &QAbstractButton::clicked, [parent] { parent->disableDecoElements(RECREATIONAL, parent->getDiveMode()); });
+	connect(ui.buehlmann_deco, &QAbstractButton::clicked, [parent] { parent->disableDecoElements(BUEHLMANN, parent->getDiveMode()); });
+	connect(ui.vpmb_deco, &QAbstractButton::clicked, [parent] { parent->disableDecoElements(VPMB, parent->getDiveMode()); });
 
 	connect(ui.sacfactor, QOverload<double>::of(&QDoubleSpinBox::valueChanged), &PlannerShared::set_sacfactor);
 	connect(ui.problemsolvingtime, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setProblemSolvingTime);


### PR DESCRIPTION
Fixes a valid warning.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

Trivial cleanup to test the Mac build.