### PR TITLE
mobile: invalidate both models in MobileModels

### DIFF
--- a/qt-models/mobilelistmodel.cpp
+++ b/qt-models/mobilelistmodel.cpp
@@ -967,6 +967,6 @@ MobileSwipeModel *MobileModels::swipeModel()
 // This is called when the settings changed. Instead of rebuilding the model, send a changed signal on all entries.
 void MobileModels::invalidate()
 {
-	sm.invalidate();
+	lm.invalidate();
 	sm.invalidate();
 }


### PR DESCRIPTION
Fix typü in MobileModels::invalidate(): swipe model was indvalidated twice, list model never.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Obvious typo fix, which was there for >5 years.