### PR TITLE
Add support for the Seac BLE dive computers

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -310,9 +310,17 @@ static bool is_write_characteristic(const QLowEnergyCharacteristic &c)
 		  QLowEnergyCharacteristic::WriteNoResponse);
 }
 
+static bool is_read_characteristic(const QLowEnergyCharacteristic &c)
+{
+	if (match_uuid_list(c.uuid(), skip_characteristics, ACCESS_READ))
+		return false;
+	return c.properties() &
+		 (QLowEnergyCharacteristic::Read);
+}
+
 // We need a Notify or Indicate for the reading side, and
 // a descriptor to enable it
-static bool is_read_characteristic(const QLowEnergyCharacteristic &c)
+static bool is_notify_characteristic(const QLowEnergyCharacteristic &c)
 {
 	if (match_uuid_list(c.uuid(), skip_characteristics, ACCESS_READ))
 		return false;
@@ -379,6 +387,25 @@ dc_status_t BLEObject::read(void *data, size_t size, size_t *actual)
 
 	if (actual)
 		*actual = 0;
+
+	if (!notify) {
+		bool found = false;
+		auto service = preferredService();
+		for (const QLowEnergyCharacteristic &ch: service->characteristics()) {
+			if (!is_read_characteristic(ch))
+				continue;
+
+			report_info("Reading BLE characteristic %s", to_str(ch.uuid()).c_str());
+			service->readCharacteristic(ch);
+			found = true;
+			break;
+		}
+
+		if (!found) {
+			report_error("No read characteristic found.");
+			return DC_STATUS_IO;
+		}
+	}
 
 	// Wait for a packet
 	rc = poll(timeout);
@@ -477,17 +504,19 @@ dc_status_t BLEObject::select_preferred_service()
 #endif
 			continue;
 
+		bool hasnotify = false;
 		bool hasread = false;
 		bool haswrite = false;
 		QBluetoothUuid uuid = s->serviceUuid();
 
 		for (const QLowEnergyCharacteristic &c: s->characteristics()) {
+			hasnotify |= is_notify_characteristic(c);
 			hasread |= is_read_characteristic(c);
 			haswrite |= is_write_characteristic(c);
 		}
 
-		if (!hasread) {
-			report_info(" .. ignoring service without read characteristic %s", to_str(uuid).c_str());
+		if (!hasnotify && !hasread) {
+			report_info(" .. ignoring service without read/notify characteristic %s", to_str(uuid).c_str());
 			continue;
 		}
 
@@ -498,6 +527,7 @@ dc_status_t BLEObject::select_preferred_service()
 
 		// We now know that the service has both read and write characteristics
 		preferred = s;
+		notify = hasnotify;
 		report_info("Using service %s as preferred service", to_str(s->serviceUuid()).c_str());
 		break;
 	}
@@ -509,6 +539,7 @@ dc_status_t BLEObject::select_preferred_service()
 	}
 
 	connect(preferred, &QLowEnergyService::stateChanged, this, &BLEObject::serviceStateChanged);
+	connect(preferred, &QLowEnergyService::characteristicRead, this, &BLEObject::characteristcStateChanged);
 	connect(preferred, &QLowEnergyService::characteristicChanged, this, &BLEObject::characteristcStateChanged);
 	connect(preferred, &QLowEnergyService::characteristicWritten, this, &BLEObject::characteristicWritten);
 	connect(preferred, &QLowEnergyService::descriptorWritten, this, &BLEObject::writeCompleted);
@@ -702,7 +733,7 @@ dc_status_t qt_ble_open(void **io, dc_context_t *, const char *devaddr, device_d
 		}
 	} else {
 		for (const QLowEnergyCharacteristic &c: list) {
-			if (!is_read_characteristic(c))
+			if (!is_notify_characteristic(c))
 				continue;
 
 			report_info("Using read characteristic %s", to_str(c.uuid()).c_str());

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -172,6 +172,7 @@ static const struct uuid_match serial_service_uuids[] = {
         { "6e400001-b5a3-f393-e0a9-e50e24dc10b8", "Cressi"}, // Must have higher priority than Nordic UART
         { "6e400001-b5a3-f393-e0a9-e50e24dcca9e", "Nordic Semi UART" },
 	{ "00000001-8c3b-4f2c-a59e-8c08224f3253", "Halcyon Symbios" },
+	{ "84968ffe-d26d-478a-b953-5010bcf58bca", "Seac" },
 	{ NULL, }
 };
 

--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -50,6 +50,7 @@ private:
 	QLowEnergyController *controller;
 	QLowEnergyService *preferred = nullptr;
 	QList<QByteArray> receivedPackets;
+	bool notify = false;
 	bool isCharacteristicWritten;
 	device_data_t &device;
 	unsigned int hw_credit = 0;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

The Seac dive computers use a BLE service with a characteristic which does not support notifications or indications and must be read instead.

This will also need the corresponding changes in libdivecomputer
(commits https://github.com/libdivecomputer/libdivecomputer/commit/415778c314c052bcfbfac8be89f46cae416230a3 and https://github.com/libdivecomputer/libdivecomputer/commit/15d6f6c975eadab25fe27810fd3e52a04c6a49e0).

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
