### PR TITLE
Android: close app via back button

### DIFF
--- a/mobile-widgets/3rdparty/0011-PageRow-emit-backRequested-at-root-page-for-app-exit.patch
+++ b/mobile-widgets/3rdparty/0011-PageRow-emit-backRequested-at-root-page-for-app-exit.patch
@@ -1,0 +1,55 @@
+From 940f4f59483ea823ed4555e7286c807eec0e54c4 Mon Sep 17 00:00:00 2001
+From: Dirk Hohndel <dirk@hohndel.org>
+Date: Sun, 12 Apr 2026 13:43:39 -0700
+Subject: [PATCH] PageRow: emit backRequested at root page for app exit
+
+This used to work with Kirigami for Qt 5, but now goBack is skipped if
+currentIndex == 0 which prevents us from handling that behavior in an
+app.
+
+If the app doesn't handle the event, un-accept it so it can propagate
+to the window's onClosing handler.
+
+Signed-off-by: Dirk Hohndel <dirk@hohndel.org>
+---
+ src/controls/PageRow.qml | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/src/controls/PageRow.qml b/src/controls/PageRow.qml
+index b1befa81..7268cfc7 100644
+--- a/src/controls/PageRow.qml
++++ b/src/controls/PageRow.qml
+@@ -584,6 +586,22 @@ QT.Control {
+                 }
+             }
+         }
++
++        // Root page handling: emit backRequested so the application can
++        // handle "back at root" (e.g. exit the app on Android).  Without
++        // this, the back key is silently consumed when currentIndex is 0.
++        if (currentIndex === 0 && !backEvent.accepted) {
++            try {
++                currentItem.backRequested(backEvent)
++            } catch (error) {}
++
++            if (backEvent.accepted) {
++                if (event) {
++                    event.accepted = true
++                }
++                return
++            }
++        }
+     }
+ 
+     /*!
+@@ -631,6 +649,7 @@ QT.Control {
+ 
+     Keys.onReleased: event => {
+         if (event.key === Qt.Key_Back) {
++            event.accepted = false
+             this.goBack(event)
+         }
+     }
+-- 
+2.43.0
+

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -1024,14 +1024,15 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		}
 	}
 	onClosing: function(close) {
-		// this duplicates the check that is already in the onBackRequested signal handler of the DiveList
 		if (globalDrawer.visible) {
 			globalDrawer.close()
 			close.accepted = false
-		}
-		if (contextDrawer.visible) {
+		} else if (contextDrawer.visible) {
 			contextDrawer.close()
 			close.accepted = false
+		} else {
+			manager.appendTextToLog("DEBUG: onClosing calling manager.quit()")
+			manager.quit()
 		}
 	}
 }


### PR DESCRIPTION
This worked in the Qt 5 version, but the current Kirigami handles back events slightly differently and we stayed on the dive list. This should fix that problem.

Fixes #4760

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another Kirigami behavioral change that makes no sense to me.
Which likely means that I just don't understand how Kirigami is supposed to work.
But it seemed easiest to just patch the problem.
