### PR TITLE
Android: move state maintained on host into container

### DIFF
--- a/packaging/android/local-build.sh
+++ b/packaging/android/local-build.sh
@@ -10,8 +10,17 @@
 #       ANDROID_KEYSTORE_PASSWORD=<keystore password>
 #       ANDROID_KEYSTORE_ALIAS=<key alias>
 #
-# The build-android and kirigami-build directories are mounted from the host
-# (as siblings of the source tree) so that incremental rebuilds are fast.
+# A named container ("subsurface-android-build") is kept between runs so
+# that build artifacts inside the container persist and incremental rebuilds
+# are fast. Only the source tree and the output directory are bind-mounted
+# from the host; everything else lives inside the container's writable
+# layer.
+#
+# When the container image changes (e.g. a new Qt or NDK version), the old
+# container is automatically removed and recreated from the new image.
+#
+# To force a full clean rebuild, remove the container:
+#   docker rm -f subsurface-android-build  # or podman
 #
 # Optionally, set ANDROID_APPLICATION_ID in .secrets to override the
 # default applicationId (org.subsurfacedivelog.mobile), e.g. for a
@@ -88,6 +97,7 @@ fi
 echo "Using container runtime: ${CONTAINER_RT}"
 
 CONTAINER_IMAGE="docker.io/subsurface/android-build:6.10.3-2"
+CONTAINER_NAME="subsurface-android-build"
 
 # These must match the values in
 # scripts/docker/android-build-container/Dockerfile
@@ -95,28 +105,19 @@ SDK_VERSION="35.0.0"
 ANDROID_SDK_ROOT="/opt/android-sdk"
 BUILDROOT="/android"
 
-# persistent build directories on the host for incremental rebuilds.
-# Resolve to canonical absolute paths (no '..') -- podman with some storage
-# drivers walks each path component and statfs()es siblings during bind-mount
-# setup, which can fail in confusing ways if ".." appears in the path.
-PARENT_DIR="$(cd "${SUBSURFACE_SOURCE}/.." && pwd)"
-BUILD_ANDROID="${PARENT_DIR}/build-android"
-KIRIGAMI_BUILD="${PARENT_DIR}/kirigami-build-android"
-GOOGLEMAPS_BUILD="${PARENT_DIR}/googlemaps-build-android"
-GOOGLEMAPS_SRC="${PARENT_DIR}/googlemaps-android"
-LIBDC_BUILD="${PARENT_DIR}/libdivecomputer-build-android"
-INSTALL_ROOT="${PARENT_DIR}/install-root-arm64-v8a-android"
 OUTPUT_DIR="${SUBSURFACE_SOURCE}/output/android"
+mkdir -p "${OUTPUT_DIR}"
 
-mkdir -p "${BUILD_ANDROID}" "${KIRIGAMI_BUILD}" "${GOOGLEMAPS_BUILD}" \
-	"${GOOGLEMAPS_SRC}" "${LIBDC_BUILD}" "${INSTALL_ROOT}" "${OUTPUT_DIR}"
-
-# Stamp file recording which container image (by content-addressed ID) the
-# persistent build directories were last populated from. If the image changes
-# we throw all of them away and start clean -- a new image may ship a new Qt
-# or NDK, and stale build trees pinned to the old toolchain paths would fail
-# in confusing ways.
-STAMP="${INSTALL_ROOT}/.image-id"
+# --- Container lifecycle management ---
+#
+# We keep a named container around between runs so that all build state
+# (build-android, kirigami-build, googlemaps, libdivecomputer-build, and
+# the install-root with its pre-compiled native libraries) persists in the
+# container's writable layer. Only the source tree and output directory
+# are bind-mounted from the host.
+#
+# If the container image has changed, we remove the old container and
+# recreate it from the new image.
 
 # Make sure the image is present locally so we can read its ID.
 IMAGE_ID=$(${CONTAINER_RT} image inspect --format '{{.Id}}' "${CONTAINER_IMAGE}" 2>/dev/null || true)
@@ -126,68 +127,38 @@ if [ -z "${IMAGE_ID}" ]; then
 	IMAGE_ID=$(${CONTAINER_RT} image inspect --format '{{.Id}}' "${CONTAINER_IMAGE}")
 fi
 
-if [ ! -f "${STAMP}" ] || [ "$(cat "${STAMP}" 2>/dev/null)" != "${IMAGE_ID}" ]; then
-	if [ -f "${STAMP}" ]; then
-		echo "Container image changed -- discarding stale build trees for a clean rebuild"
-	else
-		echo "First run -- seeding install-root from container image"
-	fi
-	# The wipe runs *inside* a container rather than on the host because the
-	# files in these directories were created by previous container runs and
-	# may be owned by root (under rootful docker on Linux). Removing them as
-	# the host user would fail with EPERM. Inside a container we are root (or,
-	# under rootless podman, the user-namespace mapping makes us effectively
-	# the owner) and can clean up unconditionally. We mount the parent of the
-	# source tree so a single rm -rf can reach all six directories.
-	${CONTAINER_RT} run --rm \
-		-v "${PARENT_DIR}:/parent" \
-		"${CONTAINER_IMAGE}" \
-		bash -c '
-			rm -rf /parent/build-android \
-			       /parent/kirigami-build-android \
-			       /parent/googlemaps-build-android \
-			       /parent/googlemaps-android \
-			       /parent/libdivecomputer-build-android \
-			       /parent/install-root-arm64-v8a-android
-		'
-	mkdir -p "${INSTALL_ROOT}"
-	# Seed install-root and write the stamp from inside the container, so the
-	# stamp file ends up with the same (root-owned, under rootful docker)
-	# ownership as everything else in install-root. Writing the stamp from the
-	# host would fail with EACCES under rootful docker because the host user
-	# can't create files inside a directory whose contents the container just
-	# populated as root.
-	${CONTAINER_RT} run --rm \
-		-e IMAGE_ID="${IMAGE_ID}" \
-		-v "${INSTALL_ROOT}:/host-install-root" \
-		"${CONTAINER_IMAGE}" \
-		bash -c "
-			cp -a /android/src/install-root-arm64-v8a/. /host-install-root/
-			printf '%s\n' \"\${IMAGE_ID}\" > /host-install-root/.image-id
-		"
-	# The wipe container removed every directory we'll bind-mount into the
-	# main build container below. Recreate the empty ones now -- if we don't,
-	# podman fails to start the build container with a "statfs: no such file
-	# or directory" on the first missing bind source.
-	mkdir -p "${BUILD_ANDROID}" "${KIRIGAMI_BUILD}" "${GOOGLEMAPS_BUILD}" \
-		"${GOOGLEMAPS_SRC}" "${LIBDC_BUILD}"
+# Check if the container already exists and whether it was created from
+# the current image. If the image has changed, remove the stale container
+# so it gets recreated below.
+EXISTING_IMAGE=$(${CONTAINER_RT} inspect --format '{{.Image}}' "${CONTAINER_NAME}" 2>/dev/null || true)
+if [ -n "${EXISTING_IMAGE}" ] && [ "${EXISTING_IMAGE}" != "${IMAGE_ID}" ]; then
+	echo "Container image changed -- removing old container for a clean rebuild"
+	${CONTAINER_RT} rm -f "${CONTAINER_NAME}" >/dev/null
+	EXISTING_IMAGE=""
 fi
 
-# build, package, and sign everything in a single container
-#
-# NOTE: this says 'run --rm', but all the state is in the mounted volumes
-#       so this works perfectly for incremental builds and the typical developer
-#       workflows
-${CONTAINER_RT} run --rm \
-	-v "${SUBSURFACE_SOURCE}:${BUILDROOT}/src/subsurface" \
-	-v "${BUILD_ANDROID}:${BUILDROOT}/build-android" \
-	-v "${KIRIGAMI_BUILD}:${BUILDROOT}/src/kirigami-build" \
-	-v "${GOOGLEMAPS_BUILD}:${BUILDROOT}/src/googlemaps-build" \
-	-v "${GOOGLEMAPS_SRC}:${BUILDROOT}/src/googlemaps" \
-	-v "${LIBDC_BUILD}:${BUILDROOT}/libdivecomputer-build" \
-	-v "${INSTALL_ROOT}:${BUILDROOT}/src/install-root-arm64-v8a" \
-	-v "${OUTPUT_DIR}:${BUILDROOT}/output" \
-	-v "${KEYSTORE_FILE}:/tmp/keystore:ro" \
+# Create the container if it doesn't exist. The container runs
+# "sleep infinity" as its main process so we can docker-start / docker-exec
+# it repeatedly. Only the source tree and output directory are
+# bind-mounted from the host; all build state lives inside the container.
+if [ -z "${EXISTING_IMAGE}" ]; then
+	echo "Creating build container ${CONTAINER_NAME}..."
+	${CONTAINER_RT} create \
+		--name "${CONTAINER_NAME}" \
+		-v "${SUBSURFACE_SOURCE}:${BUILDROOT}/src/subsurface" \
+		-v "${OUTPUT_DIR}:${BUILDROOT}/output" \
+		"${CONTAINER_IMAGE}" \
+		sleep infinity >/dev/null
+fi
+
+# Start the container (no-op if already running).
+${CONTAINER_RT} start "${CONTAINER_NAME}" >/dev/null
+
+# Copy the keystore into the running container.
+${CONTAINER_RT} cp "${KEYSTORE_FILE}" "${CONTAINER_NAME}:/tmp/keystore"
+
+# --- Run the build ---
+${CONTAINER_RT} exec \
 	-e BUILDNR="${BUILDNR}" \
 	-e VERSION="${VERSION}" \
 	-e VERSION_4="${VERSION_4}" \
@@ -197,11 +168,11 @@ ${CONTAINER_RT} run --rm \
 	-e KS_ALIAS="${ANDROID_KEYSTORE_ALIAS}" \
 	-e APP_ID="${ANDROID_APPLICATION_ID:-}" \
 	-e BUILD_AAB="${BUILD_AAB}" \
-	"${CONTAINER_IMAGE}" \
+	"${CONTAINER_NAME}" \
 	bash -c "
 		set -e
 		bash -x ${BUILDROOT}/src/subsurface/scripts/docker/android-build-container/android-build-subsurface.sh
-		if [ $BUILD_AAB = 1 ]; then
+		if [ \${BUILD_AAB} = 1 ]; then
 			echo '=== Building AAB ==='
 			cd ${BUILDROOT}/build-android/android-build
 			GRADLE_PROPS=\"\"
@@ -228,7 +199,7 @@ ${CONTAINER_RT} run --rm \
 				--ks-key-alias \"\${KS_ALIAS}\" \
 				--in /tmp/aligned.apk \
 				--out \${APK}
-			if [ $BUILD_AAB = 1 ]; then
+			if [ \${BUILD_AAB} = 1 ]; then
 				jarsigner -sigalg SHA256withRSA -digestalg SHA-256 \
 					-keystore /tmp/keystore \
 					-storepass \"\${KS_PASS}\" \
@@ -238,6 +209,9 @@ ${CONTAINER_RT} run --rm \
 		fi
 		chown \${HOST_UID}:\${HOST_GID} ${BUILDROOT}/output/*
 	"
+
+# Stop the container (keeps it around for the next incremental build).
+${CONTAINER_RT} stop "${CONTAINER_NAME}" >/dev/null
 
 echo "=== Done ==="
 if [ -n "$ANDROID_KEYSTORE_ALIAS" ]; then


### PR DESCRIPTION
Keep the host filesystem less cluttered and use container lifecycle to maintain state instead.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->

Undo all the work that I have done over the last four months to keep state in the host filesystem