### PR TITLE
Android: only exit on back key from top level

### DIFF
--- a/mobile-widgets/3rdparty/0011-PageRow-emit-backRequested-at-root-page-for-app-exit.patch
+++ b/mobile-widgets/3rdparty/0011-PageRow-emit-backRequested-at-root-page-for-app-exit.patch
@@ -1,55 +1,45 @@
 From 940f4f59483ea823ed4555e7286c807eec0e54c4 Mon Sep 17 00:00:00 2001
 From: Dirk Hohndel <dirk@hohndel.org>
 Date: Sun, 12 Apr 2026 13:43:39 -0700
-Subject: [PATCH] PageRow: emit backRequested at root page for app exit
+Subject: [PATCH] PageRow: close window when back has nowhere to navigate
 
-This used to work with Kirigami for Qt 5, but now goBack is skipped if
-currentIndex == 0 which prevents us from handling that behavior in an
-app.
+On Android 13+, the system back gesture is intercepted by Qt's
+OnBackInvokedCallback, which converts it to a Key_Back event. If no
+QML handler accepts the event, it is simply dropped -- it does NOT
+trigger the window's onClosing handler or Activity.finish(), because
+the callback already consumed the gesture at the OS level.
 
-If the app doesn't handle the event, un-accept it so it can propagate
-to the window's onClosing handler.
+Previously, Keys.onReleased always auto-accepted Key_Back, so goBack()
+silently swallowed the event even when it had nowhere to navigate
+(currentIndex already 0, no layers to pop). This made it impossible to
+exit the app via the back button.
+
+Fix by un-accepting the event before calling goBack(). If goBack()
+navigates, it sets event.accepted = true. If it doesn't (root page,
+nothing to do), explicitly close the window so the application's
+onClosing handler can decide whether to quit.
 
 Signed-off-by: Dirk Hohndel <dirk@hohndel.org>
 ---
- src/controls/PageRow.qml | 19 +++++++++++++++++++
- 1 file changed, 19 insertions(+)
+ src/controls/PageRow.qml | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/src/controls/PageRow.qml b/src/controls/PageRow.qml
 index b1befa81..7268cfc7 100644
 --- a/src/controls/PageRow.qml
 +++ b/src/controls/PageRow.qml
-@@ -584,6 +586,22 @@ QT.Control {
-                 }
-             }
-         }
-+
-+        // Root page handling: emit backRequested so the application can
-+        // handle "back at root" (e.g. exit the app on Android).  Without
-+        // this, the back key is silently consumed when currentIndex is 0.
-+        if (currentIndex === 0 && !backEvent.accepted) {
-+            try {
-+                currentItem.backRequested(backEvent)
-+            } catch (error) {}
-+
-+            if (backEvent.accepted) {
-+                if (event) {
-+                    event.accepted = true
-+                }
-+                return
-+            }
-+        }
-     }
- 
-     /*!
-@@ -631,6 +649,7 @@ QT.Control {
- 
+@@ -631,7 +631,11 @@ QT.Control {
+
      Keys.onReleased: event => {
          if (event.key === Qt.Key_Back) {
 +            event.accepted = false
              this.goBack(event)
++            if (!event.accepted) {
++                this.Window.window?.close()
++            }
          }
      }
--- 
+
+--
 2.43.0
 

--- a/mobile-widgets/qml/main.qml
+++ b/mobile-widgets/qml/main.qml
@@ -1023,6 +1023,20 @@ if you have network connectivity and want to sync your data to cloud storage."),
 			showDownloadForPluggedInDevice()
 		}
 	}
+	// Android 13+ predictive back navigates the page stack (changing
+	// currentIndex) BEFORE delivering the Key_Back / close event to QML.
+	// This means onClosing cannot distinguish "user was at root and wants
+	// to exit" from "user was deeper and just navigated back" by looking
+	// at currentIndex alone. Track the timestamp of the last navigation
+	// so onClosing can tell the two apart.
+	property real lastPageNavigationTime: 0
+	Connections {
+		target: pageStack
+		function onCurrentIndexChanged() {
+			lastPageNavigationTime = Date.now()
+		}
+	}
+
 	onClosing: function(close) {
 		if (globalDrawer.visible) {
 			globalDrawer.close()
@@ -1030,8 +1044,13 @@ if you have network connectivity and want to sync your data to cloud storage."),
 		} else if (contextDrawer.visible) {
 			contextDrawer.close()
 			close.accepted = false
+		} else if (Date.now() - lastPageNavigationTime < 500) {
+			// The page stack just changed — this close event is a
+			// side-effect of Android's predictive back animation
+			// navigating away from a deeper page, not a "quit from
+			// root" gesture. Reject it.
+			close.accepted = false
 		} else {
-			manager.appendTextToLog("DEBUG: onClosing calling manager.quit()")
 			manager.quit()
 		}
 	}


### PR DESCRIPTION
This is far more annoying than I want it to be.

The predictive back event in Android 13 and later turns the simple act of sending a back event (either via gesture or back navigation button) into two phases. One where QML executes the navigation, and then (typically about 50ms later, but that can take as much as 300ms) the actual back event fires. Therefore, by time the app sees the back key, the navigation up one level has already happened and currentIndex == 0 both when we go back from DiveDetails to DiveList and when we execute another back event on the DiveList. In other words, there isn't a reasonably obvious logic to detect if this is a back key on the DiveList or one level deeper down in the page stack.

The hack to work around this problem is to look at how long it has been since the last time we navigated to a different page. If it's less than 500ms assume that this is just the situation described above. If it's longer than that, actually exit.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
