### PR TITLE
[BugFix] Fixed midnight datetime bug.

### DIFF
--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -397,9 +397,8 @@ static void show_date(struct membuffer *b, timestamp_t when)
 
 	put_format(b, " date='%04u-%02u-%02u'",
 		   tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
-	if (tm.tm_hour || tm.tm_min || tm.tm_sec)
-		put_format(b, " time='%02u:%02u:%02u'",
-			   tm.tm_hour, tm.tm_min, tm.tm_sec);
+	put_format(b, " time='%02u:%02u:%02u'",
+		   tm.tm_hour, tm.tm_min, tm.tm_sec);
 }
 
 static void save_samples(struct membuffer *b, const struct divecomputer &dc)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When a dive occurs exactly at midnight (00:00:00), XML saving logic was omitting the time attribute. This feature causes some issues for UDDF. This PR ensures that the time attribute is always written.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Omitted the check in `core/save-xml.cpp` file, `show_date()` function. If statement was removed and the row in if block has flattened 1 layer.
2) Tests are ensured that the change is working.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4783 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Before this fix, a midnight dive would be saved as:
```
<divelog program='subsurface' version='3'>
<settings>
</settings>
<divesites>
</divesites>
<dives>
<dive number='1' otu='3' cns='4%' date='2026-04-20' duration='40:00 min'>
  <cylinder size='11.1 l' workpressure='207.0 bar' description='unknown' depth='66.0 m' />
  <divecomputer model='manually added dive' last-manual-time='40:00 min'>
  <depth max='15.0 m' mean='13.002 m' />
  <sample time='0:00 min' depth='0.0 m' />
  <sample time='1:40 min' depth='15.0 m' />
  <sample time='32:52 min' depth='15.0 m' />
  <sample time='33:59 min' depth='4.95 m' />
  <sample time='39:27 min' depth='4.95 m' />
  <sample time='40:00 min' depth='0.0 m' />
  </divecomputer>
</dive>
</dives>
</divelog>
```
After this fix, it is saved as:
```
<divelog program='subsurface' version='3'>
<settings>
</settings>
<divesites>
</divesites>
<dives>
<dive number='1' otu='3' cns='4%' date='2026-04-21' time='00:00:00' duration='40:00 min'>
  <cylinder size='11.1 l' workpressure='207.0 bar' description='unknown' depth='66.0 m' />
  <divecomputer model='manually added dive' last-manual-time='40:00 min'>
  <depth max='15.0 m' mean='13.002 m' />
  <sample time='0:00 min' depth='0.0 m' />
  <sample time='1:40 min' depth='15.0 m' />
  <sample time='32:52 min' depth='15.0 m' />
  <sample time='33:59 min' depth='4.95 m' />
  <sample time='39:27 min' depth='4.95 m' />
  <sample time='40:00 min' depth='0.0 m' />
  </divecomputer>
</dive>
</dives>
</divelog>
```

When I tried to add a dive manually, the time was like `00:00:06` because of the system clock. I wanted to try editting XML file directly to `00:00:00`. After reopening this save in Subsurface and saving it again, the time attribute disappeared from XML file. With this, I confirmed that the if statement does its own opportunity and this was cause of the bug. After the fix, I did the exact same test case. There was the time attribute. So the fix tech is working.


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
