### PR TITLE
cleanup: fix inherited GitHub Action permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -134,6 +134,8 @@ jobs:
           Subsurface-mobile-${{ steps.version_number.outputs.version }}.apk
 
   notify-release-coordinator:
+    permissions:
+      contents: write
     if: always()
     needs: build
     uses: ./.github/workflows/notify-release-coordinator.yml

--- a/.github/workflows/documentation-publish.yml
+++ b/.github/workflows/documentation-publish.yml
@@ -81,6 +81,8 @@ jobs:
           Subsurface-Documentation-${{ steps.version_number.outputs.version }}.tar.gz
 
   notify-release-coordinator:
+    permissions:
+      contents: write
     if: always()
     needs: publish-documentation
     uses: ./.github/workflows/notify-release-coordinator.yml

--- a/.github/workflows/linux-ubuntu-20.04-qt5-appimage.yml
+++ b/.github/workflows/linux-ubuntu-20.04-qt5-appimage.yml
@@ -158,6 +158,8 @@ jobs:
          ./Subsurface-*.AppImage
 
   notify-release-coordinator:
+    permissions:
+      contents: write
     if: always()
     needs: build
     uses: ./.github/workflows/notify-release-coordinator.yml

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -220,6 +220,8 @@ jobs:
         files: ${{ steps.build.outputs.dmg }}
 
   notify-release-coordinator:
+    permissions:
+      contents: write
     if: always()
     needs: [compute-version, build]
     uses: ./.github/workflows/notify-release-coordinator.yml

--- a/.github/workflows/post-releasenotes.yml
+++ b/.github/workflows/post-releasenotes.yml
@@ -53,6 +53,8 @@ jobs:
         body_path: gh_release_notes.md
 
   notify-release-coordinator:
+    permissions:
+      contents: write
     if: always()
     needs: postRelease
     uses: ./.github/workflows/notify-release-coordinator.yml

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -109,6 +109,8 @@ jobs:
          ./smtk2ssrf*.exe
 
   notify-release-coordinator:
+    permissions:
+      contents: write
     if: always()
     needs: build
     uses: ./.github/workflows/notify-release-coordinator.yml


### PR DESCRIPTION
That became obvious only after the previous commit was merged...

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is so annoying 🤦🏻‍♂️
That's what I get for trying to follow best practices...

