### PR TITLE
launchpad: don't give up on first error

### DIFF
--- a/packaging/ubuntu/make-package.sh
+++ b/packaging/ubuntu/make-package.sh
@@ -146,10 +146,15 @@ else
 fi
 
 # Upload each distro variant separately so that orig.tar.xz is included in
-# every batch. A single dput call with multiple .changes files causes dput to
-# skip orig.tar.xz for all distros after the first, and Launchpad returns a
-# 550 error because the file isn't yet in the PPA pool.
+# every batch.
+# Launchpad appears to be randomly failing, even in this scenario, so try
+# all of them and then error at the end if one or more didn't succeed.
+failed=""
 for f in "${FOLDER}-${rev}"~*.changes; do
 	rm -f ~/.dput.log
-	dput "$PPA" "$f"
+	dput "$PPA" "$f" || { echo "WARNING: dput failed for $f"; failed="$failed $f"; }
 done
+if [ -n "$failed" ]; then
+	echo "The following uploads failed:$failed"
+	exit 1
+fi


### PR DESCRIPTION
We seem to be getting mostly random errors when uploading to Launchpad. At least try all of them instead of just giving up on the first failure.

### Pull request long description:
<!-- Describe your pull request in detail. -->
Honestly this all is very strange - maybe it's still an after effect of the CloudFlare hosted DDOS on Launchpad / Ubuntu.

This should at a minimum prevent a random failure from stopping 'later' distros to try and upload as well. Which is especially important since most users will be on those later distros.