### PR TITLE
CICD: Retry Launchpad dput Uploads on Transient Failures.

### DIFF
--- a/packaging/ubuntu/make-package.sh
+++ b/packaging/ubuntu/make-package.sh
@@ -147,12 +147,30 @@ fi
 
 # Upload each distro variant separately so that orig.tar.xz is included in
 # every batch.
-# Launchpad appears to be randomly failing, even in this scenario, so try
-# all of them and then error at the end if one or more didn't succeed.
+# Launchpad's FTP upload endpoint randomly returns transient 550 errors
+# ("Requested action not taken: internal server error"), so retry each
+# upload a few times with linear backoff before giving up. After all
+# uploads have been attempted, error out at the end if one or more
+# definitively failed.
 failed=""
+max_attempts=5
 for f in "${FOLDER}-${rev}"~*.changes; do
-	rm -f ~/.dput.log
-	dput "$PPA" "$f" || { echo "WARNING: dput failed for $f"; failed="$failed $f"; }
+	attempt=1
+	while : ; do
+		rm -f ~/.dput.log
+		if dput "$PPA" "$f"; then
+			break
+		fi
+		if [ "$attempt" -ge "$max_attempts" ]; then
+			echo "WARNING: dput failed for $f after $attempt attempts"
+			failed="$failed $f"
+			break
+		fi
+		delay=$((attempt * 30))
+		echo "dput failed for $f (attempt $attempt/$max_attempts), retrying in ${delay}s..."
+		sleep "$delay"
+		attempt=$((attempt + 1))
+	done
 done
 if [ -n "$failed" ]; then
 	echo "The following uploads failed:$failed"


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Wrap each dput invocation in a small retry loop with linear backoff
(up to 5 attempts, 30s/60s/90s/120s between tries) so that transient
Launchpad hiccups no longer turn the workflow red. The end-of-loop
'fail if anything is still broken' behaviour is preserved.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
