### PR TITLE
Re-enable Printing Tests and Re-add Support for Templates Supported in Qt5.

### DIFF
--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -8,12 +8,6 @@
 #include "range.h"
 #include "selection.h"
 #include "subsurface-qt/divelistnotifier.h"
-#if !defined(SUBSURFACE_MOBILE) && !defined(SUBSURFACE_DOWNLOADER)
-#include "desktop-widgets/mapwidget.h"
-#include "desktop-widgets/mainwindow.h"
-#include "desktop-widgets/divelistview.h"
-#include "qt-models/filtermodels.h"
-#endif
 
 // Set filter status of dive and return whether it has been changed
 bool DiveFilter::setFilterStatus(struct dive *d, bool shown, std::vector<dive *> &removeFromSelection) const
@@ -146,11 +140,9 @@ void DiveFilter::startFilterDiveSites(std::vector<dive_site *> ds)
 	} else {
 		std::sort(ds.begin(), ds.end());
 		dive_sites = std::move(ds);
-		// When switching into dive site mode, reload the dive sites.
-		// TODO: why here? why not catch the filterReset signal in the map widget
-#ifdef MAP_SUPPORT
-		MapWidget::instance()->reload();
-#endif
+		// Notify listeners that dive-site filter mode was entered; a
+		// listening map widget will reload to show only filtered sites.
+		emit diveListNotifier.diveSiteFilterModeChanged();
 		emit diveListNotifier.filterReset();
 	}
 }
@@ -161,9 +153,8 @@ void DiveFilter::stopFilterDiveSites()
 		return;
 	dive_sites.clear();
 	emit diveListNotifier.filterReset();
-#ifdef MAP_SUPPORT
-	MapWidget::instance()->reload();
-#endif
+	// Notify listeners that dive-site filter mode was left.
+	emit diveListNotifier.diveSiteFilterModeChanged();
 }
 
 void DiveFilter::setFilterDiveSite(std::vector<dive_site *> ds)
@@ -176,10 +167,10 @@ void DiveFilter::setFilterDiveSite(std::vector<dive_site *> ds)
 	dive_sites = std::move(ds);
 
 	emit diveListNotifier.filterReset();
-#ifdef MAP_SUPPORT
-	MapWidget::instance()->setSelected(dive_sites);
-#endif
-	MainWindow::instance()->diveList->expandAll();
+	// Notify UI listeners (map widget, dive list view) that the set of
+	// filtered dive sites has changed. Keeping this as a signal avoids
+	// pulling desktop-widget headers/symbols into core.
+	emit diveListNotifier.filteredDiveSitesChanged(dive_sites);
 }
 
 const std::vector<dive_site *> &DiveFilter::filteredDiveSites() const

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -125,6 +125,13 @@ signals:
 	// Filter-related signals
 	void numShownChanged();
 	void filterReset();
+	// Emitted when dive-site filter mode is entered or left. Listeners
+	// (e.g. the map widget) can use this to trigger a full reload.
+	void diveSiteFilterModeChanged();
+	// Emitted when the set of dive sites that the dive-site filter restricts
+	// to has changed. Listeners (e.g. the map widget) can update their
+	// selection accordingly without core code having to reach into the UI.
+	void filteredDiveSitesChanged(std::vector<dive_site *> sites);
 
 	// Event-related signals. Currently, we're very blunt: only one signal for any changes to the events.
 	void eventsChanged(dive *d);

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -46,6 +46,10 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent),
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &DiveListView::divesChanged);
 	connect(&diveListNotifier, &DiveListNotifier::cylinderEdited, this, &DiveListView::cylinderEdited);
 	connect(&diveListNotifier, &DiveListNotifier::cylinderRemoved, this, &DiveListView::cylinderEdited);
+	// Previously called directly from DiveFilter::setFilterDiveSite via
+	// MainWindow::instance()->diveList->expandAll().
+	connect(&diveListNotifier, &DiveListNotifier::filteredDiveSitesChanged,
+		this, [this](const std::vector<dive_site *> &) { expandAll(); });
 
 	setSortingEnabled(true);
 	setContextMenuPolicy(Qt::DefaultContextMenu);

--- a/desktop-widgets/mapwidget.cpp
+++ b/desktop-widgets/mapwidget.cpp
@@ -30,6 +30,10 @@ MapWidget::MapWidget(QWidget *parent) : QQuickWidget(parent)
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &MapWidget::divesChanged);
 	connect(&diveListNotifier, &DiveListNotifier::dataReset, this, &MapWidget::reload);
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &MapWidget::reload);
+	// Previously triggered directly from DiveFilter; now driven via the
+	// notifier to keep core code free of desktop-widget dependencies.
+	connect(&diveListNotifier, &DiveListNotifier::diveSiteFilterModeChanged, this, &MapWidget::reload);
+	connect(&diveListNotifier, &DiveListNotifier::filteredDiveSitesChanged, this, &MapWidget::setSelected);
 	setSource(urlMapWidget);
 }
 

--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -599,29 +599,54 @@ void Printer::print()
 void Printer::previewOnePage()
 {
 	if (printMode == PREVIEW) {
+#ifdef USE_QLITEHTML
+		// Render the first page of the document into the supplied
+		// paintDevice (a QImage in the test harness, a widget pixmap
+		// elsewhere) using QLiteHtmlWidget.  generateContent() does
+		// the profile-image injection and litehtml CSS adaptation.
+		pageSize.setHeight(paintDevice->height());
+		pageSize.setWidth(paintDevice->width());
+
+		QString content = generateContent();
+
+		QLiteHtmlWidget widget;
+		widget.setResourceHandler([](const QUrl &url) -> QByteArray {
+			if (url.isLocalFile()) {
+				QFile file(url.toLocalFile());
+				if (file.open(QIODevice::ReadOnly))
+					return file.readAll();
+			}
+			return QByteArray();
+		});
+		widget.setUrl(QUrl("file:///", QUrl::TolerantMode));
+		widget.resize(pageSize);
+		widget.setHtml(content);
+		// Force layout/paint pipeline to run without showing the widget.
+		widget.setAttribute(Qt::WA_DontShowOnScreen, true);
+		widget.show();
+		QCoreApplication::processEvents();
+
+		QPainter painter(paintDevice);
+		static_cast<QWidget &>(widget).render(&painter, QPoint(),
+			QRegion(0, 0, pageSize.width(), pageSize.height()));
+		painter.end();
+
+		widget.hide();
+#else
 		TemplateLayout t(printOptions, templateOptions);
 
 		pageSize.setHeight(paintDevice->height());
 		pageSize.setWidth(paintDevice->width());
-#ifndef USE_QLITEHTML
 		webView->page()->setViewportSize(pageSize);
-#endif
 		// initialize the border settings
 		// templateOptions.border_width = std::max(1, pageSize.width() / 1000);
-#ifndef USE_QLITEHTML
 		if (printOptions.type == print_options::DIVELIST)
 			webView->setHtml(t.generate(getDives()));
 		else if (printOptions.type == print_options::STATISTICS )
 			webView->setHtml(t.generateStatistics());
-#endif
 		bool ok;
 		int divesPerPage;
-#ifndef USE_QLITEHTML
 		divesPerPage = webView->page()->mainFrame()->findFirstElement("body").attribute("data-numberofdives").toInt(&ok);
-#else
-		divesPerPage = 1;   // FIXME
-		ok = true;
-#endif
 		if (!ok) {
 			divesPerPage = 1; // print each dive in a single page if the attribute is missing or malformed
 			//TODO: show warning
@@ -631,6 +656,7 @@ void Printer::previewOnePage()
 		} else {
 			render(1);
 		}
+#endif
 	}
 }
 

--- a/desktop-widgets/printer.cpp
+++ b/desktop-widgets/printer.cpp
@@ -336,10 +336,63 @@ QString Printer::generateContent()
 	// still applies.  Use max-width/max-height to constrain the image
 	// proportionally — the image picks whichever is more restrictive
 	// while maintaining its aspect ratio.
-	QString repl = QString("<div class=\"diveProfile\" id=\"dive_\\1\">"
-			       "<img style=\"max-width:100%%; max-height:%1px;\" src=\"file:///%2/dive_\\1.png\">"
-			       "</div>").arg(profileMaxHeight).arg(printDir.path());
-	html.replace(QRegularExpression("<div\\s+class=\"diveProfile\"\\s+id=\"dive_([^\"]*)\"\\s*>\\s*</div>"), repl);
+	//
+	// We must accept the full range of <div> spellings that the old
+	// WebKit-based printing path used to handle:
+	//   - extra classes alongside "diveProfile" (e.g. "summary diveProfile compact")
+	//   - the diveProfile class/id attributes in any order, with any number
+	//     of additional attributes (style="...", data-*, etc.)
+	//   - self-closing form  <div ... />
+	//   - explicit empty form <div ...></div>
+	// The replacement preserves the original opening tag's attributes so
+	// the template author's styling continues to apply, and replaces the
+	// empty body with the <img> referencing the rendered profile.
+	QRegularExpression diveDivRe(R"(<div\b([^>]*?)\s*(/)?>(\s*</div>)?)",
+				      QRegularExpression::DotMatchesEverythingOption);
+	QRegularExpression classAttrRe(R"RX(\bclass\s*=\s*"([^"]*)")RX");
+	QRegularExpression idAttrRe(R"RX(\bid\s*=\s*"dive_([^"]+)")RX");
+	QRegularExpression wsRe(R"(\s+)");
+
+	QString rewritten;
+	rewritten.reserve(html.size());
+	int last = 0;
+	QRegularExpressionMatchIterator it = diveDivRe.globalMatch(html);
+	while (it.hasNext()) {
+		QRegularExpressionMatch m = it.next();
+		const QString attrs = m.captured(1);
+		const bool selfClosing = m.captured(2) == "/";
+		const bool hasExplicitClose = !m.captured(3).isEmpty();
+
+		// Only rewrite empty divs — either self-closing or immediately
+		// followed by </div>. A div that wraps content is not a profile
+		// placeholder.
+		if (!selfClosing && !hasExplicitClose)
+			continue;
+
+		QRegularExpressionMatch cm = classAttrRe.match(attrs);
+		QRegularExpressionMatch im = idAttrRe.match(attrs);
+		if (!cm.hasMatch() || !im.hasMatch())
+			continue;
+
+		const QStringList classes = cm.captured(1).split(wsRe, SKIP_EMPTY);
+		if (!classes.contains(QStringLiteral("diveProfile")))
+			continue;
+
+		const QString diveId = im.captured(1);
+		const QString replacement =
+			QString("<div%1><img style=\"max-width:100%%; max-height:%2px;\" "
+				"src=\"file:///%3/dive_%4.png\"></div>")
+				.arg(attrs)
+				.arg(profileMaxHeight)
+				.arg(printDir.path())
+				.arg(diveId);
+
+		rewritten.append(html.mid(last, m.capturedStart() - last));
+		rewritten.append(replacement);
+		last = m.capturedEnd();
+	}
+	rewritten.append(html.mid(last));
+	html = rewritten;
 
 	// Adapt the HTML for litehtml compatibility.
 	// pageSize must be set before calling generateContent() —

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -6,7 +6,6 @@
 #include <QTextStream>
 
 #include "templatelayout.h"
-#include "mainwindow.h"
 #include "printoptions.h"
 #include "core/dive.h"
 #include "core/divelist.h"

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -8,6 +8,7 @@
 #include "templatelayout.h"
 #include "mainwindow.h"
 #include "printoptions.h"
+#include "core/dive.h"
 #include "core/divelist.h"
 #include "core/gettextfromc.h"
 #include "core/selection.h"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -509,7 +509,11 @@ for (( i=0 ; i < ${#BUILDS[@]} ; i++ )) ; do
 	BUILDDIR=${BUILDDIRS[$i]}
 	echo "build $SUBSURFACE_EXECUTABLE in $BUILDDIR"
 
-	if [ "$SUBSURFACE_EXECUTABLE" = "DesktopExecutable" ] && [ "$BUILD_WITH_WEBKIT" = "1" ]; then
+	# Printing support requires either QtWebKit (Qt5 only, and only if -build-with-webkit
+	# was passed because WebKit isn't part of a standard Qt5 install) or QLiteHtml
+	# (the Qt6 replacement, which this script builds automatically for Qt6 desktop builds).
+	if [ "$SUBSURFACE_EXECUTABLE" = "DesktopExecutable" ] && \
+	   { [ "$BUILD_WITH_WEBKIT" = "1" ] || [ "$BUILD_WITH_QT6" = "1" ]; }; then
 		EXTRA_OPTS="-DNO_PRINTING=OFF"
 	else
 		EXTRA_OPTS="-DNO_PRINTING=ON"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,21 +134,14 @@ endif()
 TEST(TestMerge testmerge.cpp)
 TEST(TestTagList testtaglist.cpp)
 
-# printer.cpp pulls in subsurface_interface, which transitively
-# depends on the entire desktop UI stack (commands, planner, profile,
-# stats, map widget)
-# divefilter.cpp in subsurface_corelib directly calls
-# MapWidget::instance() and MainWindow::instance()
-# and things go downhill from there
-# I'm not willing to refactor this right now
-# if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "DesktopExecutable" AND NOT NO_PRINTING)
-#	TEST(TestPrinting testprinting.cpp)
-#	target_sources(TestPrinting PRIVATE
-#		../desktop-widgets/printer.cpp
-#		../desktop-widgets/templatelayout.cpp
-#	)
-#	set(TEST_PRINTING TestPrinting)
-# endif()
+if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "DesktopExecutable" AND NOT NO_PRINTING)
+	TEST(TestPrinting testprinting.cpp)
+	target_sources(TestPrinting PRIVATE
+		../desktop-widgets/printer.cpp
+		../desktop-widgets/templatelayout.cpp
+	)
+	set(TEST_PRINTING TestPrinting)
+endif()
 
 #if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "MobileExecutable")
 #TEST(TestPlannerShared testplannershared.cpp)


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Re-enable the printing tests after some fixes to the layering to make this code testable independent of the UI framework. This also includes some fixes to the printing code itself, and a separation of the code paths for QtWebView / QLiteHtml for print previews, and more generic support for legacy / Qt5 template printing in Qt6.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. fix building with printing;
2. re-enable the printing tests;
3. separate code paths for QtWebView / QLiteHtml for print previews;
4. add more generic support for legacy / Qt5 template printing in Qt6.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
