### PR TITLE
fix(plan): Show 'Sea water' on plan mode init to match defaults

### DIFF
--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -73,6 +73,7 @@ DivePlannerWidget::DivePlannerWidget(const dive &planned_dive, int &dcNr, Planne
 	ui.waterType->setItemData(0, FRESHWATER_SALINITY);
 	ui.waterType->setItemData(1, SEAWATER_SALINITY);
 	ui.waterType->setItemData(2, EN13319_SALINITY);
+	ui.waterType->setCurrentIndex(1);
 	waterTypeUpdateTexts();
 
 	disableDecoElements(static_cast<int>(prefs.planner_deco_mode), OC);


### PR DESCRIPTION
This is one way to address the mismatch between the desktop UI showing 'Fresh water' but calculating using seawater salinity when initially opening plan mode.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
@empl0 pointed out that the water type dropdown can default to fresh water, but the underlying calculation uses sea water until the dropdown is updated away from and back to fresh water. I used the example profile in the issue to recreate the scenario. After some digging, it looks like dive.cpp defaults to sea water if there is no provided salinity. However, diveplanner.cpp creates the list of options and doesn't explicitly set an initial value, so I believe the QComboBox chooses the first value in the array, fresh water, and doesn't sync because the change listener hasn't received any change events since dive.cpp isn't emitting the default choice.

The change in this PR just naively sets the QComboBox index to sea water initially, so that it aligns with the eventual decision made in the deco calculation. There are certainly other ways to tackle the issue, and I'm happy to make changes if there is a preferred alternative.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) diveplanner.cpp waterType index initialized to sea water

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4829

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Tested on Debian 13 using Qt5

Before: UI shows fresh, but results are based on salt
<img width="2107" height="1455" alt="before" src="https://github.com/user-attachments/assets/2aeedd81-f6a7-45ee-9551-ce98eb7a8abe" />

After: UI shows fresh, results match
<img width="2308" height="1031" alt="freshAfter" src="https://github.com/user-attachments/assets/eaafd872-e4ec-45c1-8849-ace951baa2ce" />

UI shows sea water, results match the before state
<img width="2308" height="1031" alt="seaAfter" src="https://github.com/user-attachments/assets/bfa64f29-b9d3-41bc-aa8f-80239962a606" />

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
