### PR TITLE
fix(divelist): Prevent 'Collapse others' from collapsing all

### DIFF
--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -812,10 +812,11 @@ void DiveListView::contextMenuEvent(QContextMenuEvent *event)
 	}
 
 	// "collapse all" really closes all trips,
-	// "collapse" keeps the trip with the selected dive open
+	// "collapse others" keeps the trip with the selected dive open
 	QAction *actionTaken = popup.exec(event->globalPos());
 	if (actionTaken == collapseAction && collapseAction) {
 		this->setAnimated(false);
+		expand(selectedIndexes().first());
 		scrollTo(selectedIndexes().first());
 		this->setAnimated(true);
 	}


### PR DESCRIPTION
Ensures that the desktop "Collapse others" menu action on a trip keeps the selected trip open. Previously, it was collapsing all of them.

Reported-by: Kim Delmar

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
With multiple dive trips expanded in the desktop list, right clicking to open the menu shows "Collapse others" to collapse all trips besides the currently highlighted trip. It was previously collapsing all trips, including the selected one, so these changes expand the selected trip, since the QTreeView doesn't have a collapseOthers method built in.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) divelistview.cpp DiveListView::contextMenuEvent include an expand on the selected trip explicitly

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4828 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Tested on Debian 13 using  Qt5

Selected trip remains expanded after selecting "Collapse others"
<img width="1481" height="309" alt="collapseOthers" src="https://github.com/user-attachments/assets/1f68ac7f-c756-4824-add9-fcc702bfe141" />

The issue details seem to indicate it has been a problem for a while. I looked through the history a bit to see how this may have been working before, as the block I made the change in seems to indicate that was it's original purpose, but I couldn't easily find what was there before.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
