### PR TITLE
CICD: Comment "First appeared in release vX." on Pull Requests when Merged.

### DIFF
--- a/.github/workflows/post-releasenotes.yml
+++ b/.github/workflows/post-releasenotes.yml
@@ -17,6 +17,9 @@ jobs:
     outputs:
       release_tag: v${{ steps.version_number.outputs.version }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - name: checkout sources
       uses: actions/checkout@v6
@@ -38,6 +41,34 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         scripts/create-releasenotes.sh $EVENT_HEAD_COMMIT_ID
+
+    - name: comment on merged pull request with release tag
+      if: github.event_name == 'push' && hashFiles('release_pr_number.txt') != ''
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: v${{ steps.version_number.outputs.version }}
+        BUILD_NUMBER: ${{ steps.version_number.outputs.buildnr }}
+      run: |
+        set -eu
+        pr_number=$(< release_pr_number.txt)
+        marker='<!-- subsurface-release-info -->'
+
+        # Idempotency: skip if a previous run already posted the marker.
+        existing=$(gh pr view "$pr_number" \
+          --repo ${{ github.repository }} \
+          --json comments \
+          --jq ".comments[].body" | grep -F "$marker" || true)
+        if [ -n "$existing" ]; then
+          echo "PR #$pr_number already has release-info comment, skipping."
+          exit 0
+        fi
+
+        release_url="https://github.com/${{ github.repository_owner }}/nightly-builds/releases/tag/${RELEASE_TAG}"
+        gh pr comment "$pr_number" \
+          --repo ${{ github.repository }} \
+          --body "${marker}
+        This pull request first appeared in release [${RELEASE_TAG}](${release_url}) (build ${BUILD_NUMBER})."
+        echo "Posted release-info comment on PR #$pr_number."
 
     # add a file containing the release title so it can be picked up and listed on the release page on our web server
     - name: publish release

--- a/scripts/create-releasenotes.sh
+++ b/scripts/create-releasenotes.sh
@@ -9,6 +9,7 @@ json=$(gh pr list -s merged -S "$1" --json title,number,url)
 cp gh_release_notes_top.md gh_release_notes.md
 if [[ $json != "[]" ]]; then
 	echo -n $json | jq -j '.[0]|{title}|join(" ")' > release_content_title.txt
+	echo -n $json | jq -j '.[0]|{number}|join(" ")' > release_pr_number.txt
 
 	(
 		echo -n 'This build was created by [merging pull request '


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
post-releasenotes.yml now posts a one-shot comment on the PR that
triggered the push, linking to the draft release in nightly-builds.
The release URL becomes live once publish-release.yml flips draft to
published.

create-releasenotes.sh: also writes release_pr_number.txt when a PR
matches the merge SHA, so the workflow step can comment without a
second gh pr list call.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
