### PR TITLE
Make conversion to json more robust against different locales.

### DIFF
--- a/core/uploadDiveLogsDE.cpp
+++ b/core/uploadDiveLogsDE.cpp
@@ -65,6 +65,8 @@ bool uploadDiveLogsDE::prepareDives(bool selected)
 	xsltStylesheetPtr xslt_divelogs = NULL;
 	xsltStylesheetPtr xslt_json = NULL;
 
+	bool ret = true;
+
 	emit uploadStatus(tr("building json to upload"));
 
 	xslt_divelogs = get_stylesheet("divelogs-export.xslt");
@@ -78,8 +80,21 @@ bool uploadDiveLogsDE::prepareDives(bool selected)
 	if (!xslt_json) {
 		report_info("%s missing stylesheet", errPrefix);
 		report_error("%s", qPrintable(tr("Stylesheet to export to json is not found")));
+		xsltFreeStylesheet(xslt_divelogs);
 		return false;
 	}
+
+	/*
+	 * Set locale to "C" to make sure we use '.' as decimal separator in the JSON output,
+	 * regardless of user's locale.
+	 *
+	 * POSIX specifies that the returned pointer,
+	 * not just the contents of the pointed-to string,
+	 * may be invalidated by subsequent calls to setlocale.
+	 */
+	const char* temp_user_locale = setlocale(LC_NUMERIC, NULL);
+	char* user_locale = strdup(temp_user_locale);
+	setlocale(LC_NUMERIC, "C");
 
 	put_string(&mb_json, "[");
 
@@ -138,10 +153,9 @@ bool uploadDiveLogsDE::prepareDives(bool selected)
 		if (!doc) {
 			report_info("%s could not parse back into memory the XML file we've just created!", errPrefix);
 			report_error("%s", qPrintable(tr("internal error")));
-			xsltFreeStylesheet(xslt_divelogs);
-			xsltFreeStylesheet(xslt_json);
 			free_xml_params(params);
-			return false;
+			ret = false;
+			goto cleanup;
 		}
 
 		xml_params_add_int(params, "allcylinders", prefs.include_unused_tanks);
@@ -150,6 +164,7 @@ bool uploadDiveLogsDE::prepareDives(bool selected)
 		if (!transformed) {
 			report_info("%s XSLT transform failed for dive: %d", errPrefix, i);
 			report_error("%s", qPrintable(tr("Conversion of dive %1 to divelogs.de format failed").arg(i)));
+			xmlFreeDoc(doc);
 			continue;
 		}
 		xmlDocDumpMemory(transformed, (xmlChar **)&membuf, &streamsize);
@@ -161,14 +176,14 @@ bool uploadDiveLogsDE::prepareDives(bool selected)
 		if (!doc) {
 			report_info("%s could not parse back into memory the XML file we've just created!", errPrefix);
 			report_error("%s", qPrintable(tr("internal error")));
-			xsltFreeStylesheet(xslt_divelogs);
-			xsltFreeStylesheet(xslt_json);
-			return false;
+			ret = false;
+			goto cleanup;
 		}
 		transformed = xsltApplyStylesheet(xslt_json, doc, NULL);
 		if (!transformed) {
 			report_info("%s XSLT transform failed for dive: %d", errPrefix, i);
 			report_error("%s", qPrintable(tr("Conversion of dive %1 to divelogs.de format failed").arg(i)));
+			xmlFreeDoc(doc);
 			continue;
 		}
 		xsltSaveResultToString((xmlChar **)&membuf, &streamsize, transformed, xslt_json);
@@ -187,9 +202,14 @@ bool uploadDiveLogsDE::prepareDives(bool selected)
 	// Wrap the JSON array
 	put_string(&mb_json, "]");
 
+cleanup:
+	// Restore user's locale
+	setlocale(LC_NUMERIC, user_locale);
+	free(user_locale);
+
 	xsltFreeStylesheet(xslt_divelogs);
 	xsltFreeStylesheet(xslt_json);
-	return true;
+	return ret;
 }
 
 

--- a/xslt/divelogs-export.xslt
+++ b/xslt/divelogs-export.xslt
@@ -135,7 +135,7 @@
               <xsl:value-of select="$double - 1" />
             </dbltank>
             <vol>
-              <xsl:value-of select="format-number(substring-before(@size, ' ') div $double, '#.##')" />
+              <xsl:value-of select="substring-before(@size, ' ') div $double" />
             </vol>
             <start_pressure>
               <xsl:choose>
@@ -387,7 +387,7 @@
     <xsl:param name="until" />
 
     <xsl:variable name="curdepth">
-      <xsl:value-of select="format-number(((($timefirst + 60) - $timefirst) div ($timesecond - $timefirst) * ($depthsecond - $depthfirst) + $depthfirst), '#.##')" />
+      <xsl:value-of select="((($timefirst + 60) - $timefirst) div ($timesecond - $timefirst) * ($depthsecond - $depthfirst) + $depthfirst)" />
     </xsl:variable>
     <xsl:variable name="curtime">
       <xsl:value-of select="$timefirst + 60" />


### PR DESCRIPTION
Instead of using format-number for all numbers that could possibly have decimals to prevent commas when converting to json, we set the user's locale for numbers to "C" for the minimal locale. This makes the conversion more robust against future changes to the format.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Set user locale to "C" instead of explicitly casting values when converting from XML to JSON.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4832 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
