### PR TITLE
fix(location): use ds pointer directly in itemActivated to identify synthetic rows

### DIFF
--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -546,11 +546,12 @@ void DiveLocationLineEdit::itemActivated(const QModelIndex &index)
 	if (index.column() == LocationInformationModel::DIVESITE)
 		idx = index.model()->index(index.row(), LocationInformationModel::NAME);
 
+	// Synthetic rows return nullptr for the dive site column; a real site returns its pointer.
+	// A null ds signals that a new site should be created from the entered text.
 	dive_site *ds = index.model()->index(index.row(), LocationInformationModel::DIVESITE)
 			    .data().value<dive_site *>();
-	currDs = index.row() <= 1 ? nullptr : ds;
-	if (index.row() >= 1)
-		setText(idx.data().toString());
+	currDs = ds;
+	setText(idx.data().toString());
 	if (view->isVisible())
 		view->hide();
 	emit diveSiteSelected();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

 itemActivated used index.row() <= 1 to identify synthetic "create new" rows and force currDs = nullptr, which triggers
  creation of a new dive site. However, index.row() refers to the position in the filtered proxy model, not the source
  model.

  The autocomplete row (source row 1) is filtered out when the typed text has no prefix match among existing site names,
  or when it is an exact match. In that case, the first real matching site shifts into proxy position 1 and gets
  misidentified as synthetic, causing a duplicate site to be created instead of reusing the existing one.

  The fix is to use ds directly: the model already returns nullptr for synthetic rows and a real pointer for existing
  sites, so no position check is needed.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

 1. In DiveLocationLineEdit::itemActivated: replace currDs = index.row() <= 1 ? nullptr : ds with currDs = ds and
  always call setText.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes #4843 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

  Reproduction steps: type a site name that either has no autocomplete candidate or matches an existing site name
  exactly, then select the existing site from the dropdown. A duplicate site is created instead of reusing the existing
  one.


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

No user-facing changes.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mikeller 
