### PR TITLE
Windows: Fix version and vcpkg path bugs in MSVC build scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,10 +183,17 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_CXX_COMPILER_ID STREQUAL "
 	# Use SUBSURFACE_VCPKG_ROOT to avoid conflicts with vcpkg toolchain variables
 	# The vcpkg toolchain sets VCPKG_INSTALLED_DIR based on toolchain file location,
 	# which can point to VS bundled vcpkg instead of the one we installed deps to
+	# AI-generated (Claude)
+	# Normalize to forward slashes: this path gets embedded verbatim into
+	# generated install(CODE ...) script text below, where a native
+	# backslash path (e.g. "C:\vcpkg") would be misparsed as an escape
+	# sequence (e.g. "\v") by the generated cmake_install.cmake.
 	if(DEFINED SUBSURFACE_VCPKG_ROOT)
-		set(_VCPKG_PREFIX "${SUBSURFACE_VCPKG_ROOT}/installed/x64-windows")
+		file(TO_CMAKE_PATH "${SUBSURFACE_VCPKG_ROOT}" _VCPKG_ROOT_NORMALIZED)
+		set(_VCPKG_PREFIX "${_VCPKG_ROOT_NORMALIZED}/installed/x64-windows")
 	elseif(DEFINED ENV{VCPKG_ROOT})
-		set(_VCPKG_PREFIX "$ENV{VCPKG_ROOT}/installed/x64-windows")
+		file(TO_CMAKE_PATH "$ENV{VCPKG_ROOT}" _VCPKG_ROOT_NORMALIZED)
+		set(_VCPKG_PREFIX "${_VCPKG_ROOT_NORMALIZED}/installed/x64-windows")
 	else()
 		set(_VCPKG_PREFIX "C:/vcpkg/installed/x64-windows")
 	endif()

--- a/cmake/Modules/version.cmake
+++ b/cmake/Modules/version.cmake
@@ -4,9 +4,12 @@ if(DEFINED ENV{CANONICALVERSION})
 	set(CANONICAL_VERSION_STRING $ENV{CANONICALVERSION})
 else()
 	if(USING_MSVC)
+		# AI-generated (Claude)
 		# Use PowerShell on Windows with MSVC
+		# -NoProfile avoids the user's PowerShell profile script writing
+		# extra text to stdout, which would corrupt the captured version string.
 		execute_process(
-			COMMAND powershell -ExecutionPolicy Bypass -File ${CMAKE_TOP_SRC_DIR}/scripts/get-version.ps1
+			COMMAND powershell -NoProfile -ExecutionPolicy Bypass -File ${CMAKE_TOP_SRC_DIR}/scripts/get-version.ps1
 			WORKING_DIRECTORY ${CMAKE_TOP_SRC_DIR}
 			OUTPUT_VARIABLE CANONICAL_VERSION_STRING
 			OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -27,7 +30,7 @@ else()
 	if(USING_MSVC)
 		# Use PowerShell on Windows with MSVC
 		execute_process(
-			COMMAND powershell -ExecutionPolicy Bypass -File ${CMAKE_TOP_SRC_DIR}/scripts/get-version.ps1 4
+			COMMAND powershell -NoProfile -ExecutionPolicy Bypass -File ${CMAKE_TOP_SRC_DIR}/scripts/get-version.ps1 4
 			WORKING_DIRECTORY ${CMAKE_TOP_SRC_DIR}
 			OUTPUT_VARIABLE CANONICAL_VERSION_STRING_4
 			OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
## Summary
Two independent build-script bugs on the native Windows/MSVC path, both
found while building and testing an unrelated feature on a real MSVC setup:

- `cmake/Modules/version.cmake` invoked `powershell -File get-version.ps1`
  without `-NoProfile`. If the user's PowerShell `$PROFILE` script writes
  anything to stdout, that text gets captured together with the actual
  version string, corrupting the generated `ssrf-version.h` (unescaped
  newlines in a C string literal - fails to compile).
- `CMakeLists.txt` built `_VCPKG_PREFIX` directly from `$ENV{VCPKG_ROOT}`,
  which on Windows is typically a native backslash path (e.g. `C:\vcpkg`).
  That string is embedded verbatim into generated `install(CODE ...)`
  script text; CMake later misparses `\v` in `C:\vcpkg` as an invalid
  escape sequence, failing `ninja install`.

## Test plan
- [x] Reproduced both failures on a real Windows/MSVC/vcpkg build
- [x] Rebuilt clean after each fix; both errors gone
- [x] `ninja install` completes and produces a working staged app
