### PR TITLE
Core: increase MAX_SENSORS from 2 to 10

### DIFF
--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -672,11 +672,13 @@ static struct sample *new_sample(struct git_parser_state *state)
 	size_t num_samples = state->active_dc->samples.size();
 	if (num_samples >= 2) {
 		*sample = state->active_dc->samples[num_samples - 2];
-		sample->pressure[0] = 0_bar;
-		sample->pressure[1] = 0_bar;
+		for (int i = 0; i < MAX_SENSORS; i++)
+			sample->pressure[i] = 0_bar;
 	} else {
 		sample->sensor[0] = sanitize_sensor_id(state->active_dive.get(), !state->o2pressure_sensor);
 		sample->sensor[1] = sanitize_sensor_id(state->active_dive.get(), state->o2pressure_sensor);
+		for (int i = 2; i < MAX_SENSORS; i++)
+			sample->sensor[i] = NO_SENSOR;
 	}
 	return sample;
 }

--- a/core/sample.h
+++ b/core/sample.h
@@ -4,7 +4,7 @@
 
 #include "units.h"
 
-#define MAX_SENSORS 2
+#define MAX_SENSORS 4
 #define MAX_O2_SENSORS 6
 #define DC_REPORTED_PPO2 MAX_O2_SENSORS
 #define NO_SENSOR -1
@@ -19,11 +19,11 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	depth_t depth;                    // int32_t    4    mm     (0-2000 km)            dive depth of this sample
 	depth_t stopdepth;                // int32_t    4    mm     (0-2000 km)            depth of next deco stop
 	temperature_t temperature;        // uint32_t   4    mK     (0-4 MK)               ambient temperature
-	pressure_t pressure[MAX_SENSORS]; // int32_t  2x4    mbar   (0-2 Mbar)             cylinder pressures (main and CCR o2)
+	pressure_t pressure[MAX_SENSORS]; // int32_t  4x4    mbar   (0-2 Mbar)             cylinder pressures (up to 4 wireless transmitters)
 	o2pressure_t setpoint;            // uint16_t   2    mbar   (0-65 bar)             O2 partial pressure (will be setpoint)
 	o2pressure_t o2sensor[MAX_O2_SENSORS + 1]; // uint16_t 6x2    mbar   (0-65 bar)             Up to 6 PO2 sensor values (rebreather)
 	bearing_t bearing = { .degrees = -1 };// int16_t    2  degrees  (-1 no val, 0-360 deg) compass bearing
-	int16_t sensor[MAX_SENSORS] = {}; // int16_t  2x2  sensorID (0-16k)                ID of cylinder pressure sensor
+	int16_t sensor[MAX_SENSORS] = {}; // int16_t  4x2  sensorID (0-16k)                ID of cylinder pressure sensor
 	uint16_t cns = 0;                 // uint16_t   2     %     (0-64k %)              cns% accumulated
 	uint8_t heartbeat = 0;            // uint8_t    1  beats/m  (0-255)                heart rate measurement
 	volume_t sac;                     //            4  ml/min                          predefined SAC
@@ -31,7 +31,7 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	bool manually_entered = false;    // bool       1    y/n      y/n                  this sample was entered by the user,
 					  //                                               not calculated when planning a dive
 	sample();			  // Default constructor
-};	                                  // Total size of structure: 63 bytes, excluding padding at end
+};	                                  // Total size of structure: 75 bytes, excluding padding at end
 
 extern void add_sample_pressure(struct sample *sample, int sensor, int mbar);
 

--- a/core/sample.h
+++ b/core/sample.h
@@ -4,7 +4,7 @@
 
 #include "units.h"
 
-#define MAX_SENSORS 4
+#define MAX_SENSORS 10
 #define MAX_O2_SENSORS 6
 #define DC_REPORTED_PPO2 MAX_O2_SENSORS
 #define NO_SENSOR -1
@@ -19,11 +19,11 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	depth_t depth;                    // int32_t    4    mm     (0-2000 km)            dive depth of this sample
 	depth_t stopdepth;                // int32_t    4    mm     (0-2000 km)            depth of next deco stop
 	temperature_t temperature;        // uint32_t   4    mK     (0-4 MK)               ambient temperature
-	pressure_t pressure[MAX_SENSORS]; // int32_t  4x4    mbar   (0-2 Mbar)             cylinder pressures (up to 4 wireless transmitters)
+	pressure_t pressure[MAX_SENSORS]; // int32_t 10x4    mbar   (0-2 Mbar)             cylinder pressures (up to 10 wireless transmitters)
 	o2pressure_t setpoint;            // uint16_t   2    mbar   (0-65 bar)             O2 partial pressure (will be setpoint)
 	o2pressure_t o2sensor[MAX_O2_SENSORS + 1]; // uint16_t 6x2    mbar   (0-65 bar)             Up to 6 PO2 sensor values (rebreather)
 	bearing_t bearing = { .degrees = -1 };// int16_t    2  degrees  (-1 no val, 0-360 deg) compass bearing
-	int16_t sensor[MAX_SENSORS] = {}; // int16_t  4x2  sensorID (0-16k)                ID of cylinder pressure sensor
+	int16_t sensor[MAX_SENSORS] = {}; // int16_t 10x2  sensorID (0-16k)                ID of cylinder pressure sensor
 	uint16_t cns = 0;                 // uint16_t   2     %     (0-64k %)              cns% accumulated
 	uint8_t heartbeat = 0;            // uint8_t    1  beats/m  (0-255)                heart rate measurement
 	volume_t sac;                     //            4  ml/min                          predefined SAC
@@ -31,7 +31,7 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	bool manually_entered = false;    // bool       1    y/n      y/n                  this sample was entered by the user,
 					  //                                               not calculated when planning a dive
 	sample();			  // Default constructor
-};	                                  // Total size of structure: 75 bytes, excluding padding at end
+};	                                  // Total size of structure: 111 bytes, excluding padding at end
 
 extern void add_sample_pressure(struct sample *sample, int sensor, int mbar);
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ x] New feature - depending on how you see it
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The struct sample supports two tank pressure sensor slots, originally designed for a main gas sensor and a CCR O2 supply sensor. This is documented in the comment on the pressure array in core/sample.h. The limit is enforced in add_sample_pressure() in core/sample.cpp, which silently discards data when both slots are occupied:

  /* We do not have enough slots for the pressure samples. */
  /* Should we warn the user about dropping pressure data? */

Modern Shearwater computers (e.g. Perdix 2) support up to four wireless Swift transmitters simultaneously. When libdivecomputer delivers DC_SAMPLE_PRESSURE events for sensors beyond index 1, they are silently discarded.

Evidence from a saved log: sensor 2 appears exactly once, at a sample where sensor 1 happened not to transmit, leaving slot 1 free. At every subsequent sample where both sensors 0 and 1 are present, sensor 2's data is absent. This confirms the data is being received from the dive computer but dropped by Subsurface.

Increase MAX_SENSORS to 4. Most code already uses MAX_SENSORS in loops and requires no further change. The one exception is new_sample() in core/load-git.cpp, which cleared pressure values with hardcoded indices [0] and [1] -- changed to a loop. Also initialise sensor slots 2 and 3 to NO_SENSOR in the first-sample path of new_sample().

The new MAX_SENSORS is 4, but the new [Garmin computers can take up to 8](https://www.garmin.com/en-AU/p/985238/pn/010-02853-00/#:~:text=Exchange%20preset%20diver%2Dto%2Ddiver%20messages%20up%20to%2030%20metres%20as%20well%20as%20monitor%20tank%20pressure%2C%20depth%20and%20distance%20for%20up%20to%208%20divers%20within%20a%20range%20of%2010%20metres) and I think the Halcyon Symbios can take 9, so 4 might be too small in the long run.

The on-disk format is unaffected: save-xml.cpp and save-git.cpp already write pressure data keyed by sensor ID dynamically, and parse-xml.cpp already handles pressure0 through pressure4. Files saved with up to four sensors degrade gracefully when opened by older builds, which will silently discard slots beyond index 1.

Fixes #4856

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
