### PR TITLE
Desktop: Allow Dive Computer Selection in the Info Tab.

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -176,6 +176,7 @@ MainWindow::MainWindow() :
 		QIcon::setThemeName("subsurface");
 	}
 	connect(diveList.get(), &DiveListView::divesSelected, this, &MainWindow::divesSelected);
+	connect(mainTab.get(), &MainTab::dcChangeRequested, this, &MainWindow::selectDC);
 	connect(&diveListNotifier, &DiveListNotifier::settingsChanged, this, &MainWindow::readSettings);
 	for (int i = 0; i < NUM_RECENT_FILES; i++) {
 		actionsRecent[i] = new QAction(this);
@@ -836,6 +837,13 @@ void MainWindow::on_actionNextDC_triggered()
 {
 	profile->nextDC();
 	// TODO: remove
+	mainTab->updateDiveInfo(getDiveSelection(), profile->d, profile->dc);
+}
+
+void MainWindow::selectDC(int dc)
+{
+	if (profile->d)
+		profile->plotDive(profile->d, dc);
 	mainTab->updateDiveInfo(getDiveSelection(), profile->d, profile->dc);
 }
 

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -120,6 +120,7 @@ slots:
 	void on_actionViewAll_triggered();
 	void on_actionPreviousDC_triggered();
 	void on_actionNextDC_triggered();
+	void selectDC(int dc);
 	void on_actionFullScreen_triggered(bool checked);
 
 	/* other menu actions */

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.cpp
@@ -2,10 +2,28 @@
 #include "TabDiveExtraInfo.h"
 #include "ui_TabDiveExtraInfo.h"
 #include "core/dive.h"
+#include "core/divemode.h"
 #include "core/gettextfromc.h"
 #include "core/selection.h"
 #include "core/string-format.h"
 #include "qt-models/divecomputerextradatamodel.h"
+
+#include <QHash>
+#include <QList>
+#include <QSet>
+#include <QSignalBlocker>
+
+// Override the disabled-text colour so the combo remains readable in both
+// light and dark themes when it is disabled (only one option available).
+// Platform defaults often render disabled text as near-invisible grey.
+static void setReadableWhenDisabled(QComboBox *combo)
+{
+	QPalette p = combo->palette();
+	QColor activeText = p.color(QPalette::Active, QPalette::WindowText);
+	p.setColor(QPalette::Disabled, QPalette::Text,       activeText);
+	p.setColor(QPalette::Disabled, QPalette::ButtonText, activeText);
+	combo->setPalette(p);
+}
 
 TabDiveExtraInfo::TabDiveExtraInfo(MainTab *parent) :
 	TabBase(parent),
@@ -14,8 +32,15 @@ TabDiveExtraInfo::TabDiveExtraInfo(MainTab *parent) :
 {
 	ui->setupUi(this);
 	ui->extraData->setModel(extraDataModel);
-
 	ui->extraData->horizontalHeader()->setStretchLastSection(true);
+
+	setReadableWhenDisabled(ui->modelCombo);
+	setReadableWhenDisabled(ui->serialCombo);
+
+	connect(ui->modelCombo, QOverload<int>::of(&QComboBox::activated),
+		this, &TabDiveExtraInfo::onModelComboActivated);
+	connect(ui->serialCombo, QOverload<int>::of(&QComboBox::activated),
+		this, &TabDiveExtraInfo::onSerialComboActivated);
 }
 
 TabDiveExtraInfo::~TabDiveExtraInfo()
@@ -23,38 +48,184 @@ TabDiveExtraInfo::~TabDiveExtraInfo()
 	delete ui;
 }
 
+// --- Private helpers --------------------------------------------------------
+
+// Walks currentDivePtr once and returns a snapshot of every dive computer's
+// index, trimmed model name, and trimmed serial.  All other helpers consume
+// this list so that model/serial canonicalization lives in a single place.
+QList<TabDiveExtraInfo::DCEntry> TabDiveExtraInfo::allDCs() const
+{
+	QList<DCEntry> entries;
+	if (!currentDivePtr)
+		return entries;
+	const int numDCs = currentDivePtr->number_of_computers();
+	entries.reserve(numDCs);
+	for (int i = 0; i < numDCs; ++i) {
+		const divecomputer *idc = currentDivePtr->get_dc(i);
+		entries.append({ i,
+			QString::fromStdString(idc->model).trimmed(),
+			QString::fromStdString(idc->serial).trimmed() });
+	}
+	return entries;
+}
+
+// Returns all unique DC model names in dive order (O(n) via QSet lookup).
+QStringList TabDiveExtraInfo::uniqueModelNames() const
+{
+	QStringList ordered;
+	QSet<QString> seen;
+	for (const DCEntry &e : allDCs()) {
+		if (!seen.contains(e.model)) {
+			seen.insert(e.model);
+			ordered.append(e.model);
+		}
+	}
+	return ordered;
+}
+
+// Returns the DC index (0-based) of the first dive computer with the given
+// model name, or -1 if none matches.
+int TabDiveExtraInfo::firstDCIndexForModel(const QString &model) const
+{
+	for (const DCEntry &e : allDCs()) {
+		if (e.model == model)
+			return e.index;
+	}
+	return -1;
+}
+
+// ----------------------------------------------------------------------------
+
+void TabDiveExtraInfo::populateSerialCombo(const QString &modelName, int selectedDCIdx)
+{
+	QSignalBlocker block(ui->serialCombo);
+	ui->serialCombo->clear();
+
+	if (!currentDivePtr)
+		return;
+
+	// Collect only the DCs that belong to the requested model.
+	QList<DCEntry> group;
+	for (const DCEntry &e : allDCs()) {
+		if (e.model == modelName)
+			group.append(e);
+	}
+
+	// Count how many times each serial appears in the group so we can
+	// detect duplicates (including the empty-string case).
+	QHash<QString, int> serialCount;
+	for (const DCEntry &e : group)
+		++serialCount[e.serial];
+
+	int comboIndexToSelect = 0;
+	for (int n = 0; n < group.size(); ++n) {
+		const DCEntry &e = group[n];
+		QString label;
+		if (e.serial.isEmpty())
+			label = tr("(no serial) #%1").arg(n + 1);
+		else if (serialCount.value(e.serial) > 1)
+			label = tr("%1 (#%2)").arg(e.serial).arg(n + 1);
+		else
+			label = e.serial;
+		ui->serialCombo->addItem(label, e.index); // item data = DC index
+		if (e.index == selectedDCIdx)
+			comboIndexToSelect = ui->serialCombo->count() - 1;
+	}
+
+	ui->serialCombo->setCurrentIndex(comboIndexToSelect);
+	// Only enable the serial combo when there are multiple DCs with the same model
+	ui->serialCombo->setEnabled(ui->serialCombo->count() > 1);
+}
+
 void TabDiveExtraInfo::updateData(const std::vector<dive *> &, dive *currentDive, int currentDC)
 {
-	if (currentDive) {
-		const divecomputer *dc = currentDive->get_dc(currentDC);
-
-		ui->model->setText(QString::fromStdString(dc->model).trimmed());
-		ui->serial->setText(QString::fromStdString(dc->serial).trimmed());
-		ui->firmware->setText(QString::fromStdString(dc->fw_version).trimmed());
-		ui->date->setText(get_dive_date_string(dc->when));
-		ui->duration->setText(get_dive_duration_string(dc->duration.seconds, tr("h"), tr("min"), tr("sec"),
-				" ", dc->divemode == FREEDIVE));
-		if (dc->divemode >= 0 && dc->divemode < NUM_DIVEMODE)
-			ui->diveMode->setText(gettextFromC::tr(divemode_text_ui[dc->divemode]));
-		else
-			ui->diveMode->clear();
-
-		extraDataModel->updateDiveComputer(dc);
-		ui->extraData->setVisible(false); // This will cause the resize to include rows outside the current viewport
-		ui->extraData->resizeColumnsToContents();
-		ui->extraData->setVisible(true);
-	} else {
+	if (!currentDive) {
 		clear();
+		return;
 	}
+
+	currentDivePtr = currentDive;
+
+	const divecomputer *dc = currentDive->get_dc(currentDC);
+
+	// --- Populate model combo ---
+	{
+		QSignalBlocker block(ui->modelCombo);
+		ui->modelCombo->clear();
+
+		const QStringList models = uniqueModelNames();
+		for (const QString &model : models)
+			ui->modelCombo->addItem(model);
+
+		const QString currentModel = QString::fromStdString(dc->model).trimmed();
+		const int modelIdx = ui->modelCombo->findText(currentModel);
+		if (modelIdx >= 0)
+			ui->modelCombo->setCurrentIndex(modelIdx);
+
+		// Only enable the model combo when there are multiple distinct model names
+		ui->modelCombo->setEnabled(models.size() > 1);
+	}
+
+	// --- Populate serial combo for the current model ---
+	populateSerialCombo(QString::fromStdString(dc->model).trimmed(), currentDC);
+
+	// --- Remaining read-only fields ---
+	ui->firmware->setText(QString::fromStdString(dc->fw_version).trimmed());
+	ui->date->setText(get_dive_date_string(dc->when));
+	ui->duration->setText(get_dive_duration_string(dc->duration.seconds, tr("h"), tr("min"), tr("sec"),
+			" ", dc->divemode == FREEDIVE));
+	if (dc->divemode >= 0 && dc->divemode < NUM_DIVEMODE)
+		ui->diveMode->setText(gettextFromC::tr(divemode_text_ui[dc->divemode]));
+	else
+		ui->diveMode->clear();
+
+	extraDataModel->updateDiveComputer(dc);
+	ui->extraData->setVisible(false); // This causes the resize to include rows outside the current viewport
+	ui->extraData->resizeColumnsToContents();
+	ui->extraData->setVisible(true);
 }
 
 void TabDiveExtraInfo::clear()
 {
-	ui->model->clear();
-	ui->serial->clear();
+	currentDivePtr = nullptr;
+
+	QSignalBlocker blockModel(ui->modelCombo);
+	QSignalBlocker blockSerial(ui->serialCombo);
+
+	ui->modelCombo->clear();
+	ui->modelCombo->setEnabled(false);
+	ui->serialCombo->clear();
+	ui->serialCombo->setEnabled(false);
 	ui->firmware->clear();
 	ui->date->clear();
 	ui->duration->clear();
 	ui->diveMode->clear();
 	extraDataModel->clear();
+}
+
+void TabDiveExtraInfo::onModelComboActivated(int index)
+{
+	if (!currentDivePtr)
+		return;
+
+	const QString modelName = ui->modelCombo->itemText(index);
+	const int firstDC = firstDCIndexForModel(modelName);
+	if (firstDC < 0)
+		return;
+
+	// Repopulate the serial combo for the newly selected model
+	populateSerialCombo(modelName, firstDC);
+
+	// The serial combo now shows the first DC for that model; emit its DC index
+	const int selectedDC = ui->serialCombo->currentData().toInt();
+	emit dcChangeRequested(selectedDC);
+}
+
+void TabDiveExtraInfo::onSerialComboActivated(int index)
+{
+	if (!currentDivePtr)
+		return;
+
+	const int dcIndex = ui->serialCombo->itemData(index).toInt();
+	emit dcChangeRequested(dcIndex);
 }

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.h
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.h
@@ -9,6 +9,7 @@ namespace Ui {
 };
 
 class ExtraDataModel;
+struct dive;
 
 class TabDiveExtraInfo : public TabBase {
 	Q_OBJECT
@@ -17,9 +18,27 @@ public:
 	~TabDiveExtraInfo();
 	void updateData(const std::vector<dive *> &selection, dive *currentDive, int currentDC) override;
 	void clear() override;
+signals:
+	void dcChangeRequested(int dcIndex);
+private slots:
+	void onModelComboActivated(int index);
+	void onSerialComboActivated(int index);
 private:
+	// Snapshot of every dive computer in currentDivePtr (built once per call).
+	struct DCEntry {
+		int     index;
+		QString model;
+		QString serial;
+	};
+
 	Ui::TabDiveExtraInfo *ui;
 	ExtraDataModel *extraDataModel;
+	dive *currentDivePtr = nullptr;
+	QList<DCEntry> allDCs() const;                                  // single walk over number_of_computers()
+	void populateSerialCombo(const QString &modelName, int selectedDCIdx);
+	// Helpers for iterating dive computers by model name
+	QStringList uniqueModelNames() const;
+	int firstDCIndexForModel(const QString &model) const;
 };
 
 #endif

--- a/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
+++ b/desktop-widgets/tab-widgets/TabDiveExtraInfo.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>700</width>
     <height>300</height>
    </rect>
   </property>
@@ -27,11 +27,27 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetMinimumSize</enum>
       </property>
-      <property name="alignment">
-       <set>Qt::AlignHCenter</set>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
       </property>
       <item>
-       <widget class="QLabel" name="model" />
+       <widget class="QComboBox" name="modelCombo">
+        <property name="minimumContentsLength">
+         <number>10</number>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -52,11 +68,27 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetMinimumSize</enum>
       </property>
-      <property name="alignment">
-       <set>Qt::AlignHCenter</set>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
       </property>
       <item>
-       <widget class="QLabel" name="serial" native="true"/>
+       <widget class="QComboBox" name="serialCombo">
+        <property name="minimumContentsLength">
+         <number>10</number>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -77,16 +109,28 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetMinimumSize</enum>
       </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
+      </property>
       <property name="alignment">
        <set>Qt::AlignHCenter</set>
       </property>
       <item>
-       <widget class="QLabel" name="firmware" native="true"/>
+       <widget class="QLabel" name="firmware"/>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="0" column="3">
     <widget class="QGroupBox">
      <property name="title">
       <string>Date</string>
@@ -102,16 +146,28 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetMinimumSize</enum>
       </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
+      </property>
       <property name="alignment">
        <set>Qt::AlignHCenter</set>
       </property>
       <item>
-       <widget class="QLabel" name="date" />
+       <widget class="QLabel" name="date"/>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="0" column="4">
     <widget class="QGroupBox">
      <property name="title">
       <string>Duration</string>
@@ -127,16 +183,28 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetMinimumSize</enum>
       </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
+      </property>
       <property name="alignment">
        <set>Qt::AlignHCenter</set>
       </property>
       <item>
-       <widget class="QLabel" name="duration" native="true"/>
+       <widget class="QLabel" name="duration"/>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="0" column="5">
     <widget class="QGroupBox">
      <property name="title">
       <string>Dive Mode</string>
@@ -152,16 +220,28 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetMinimumSize</enum>
       </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
+      </property>
       <property name="alignment">
        <set>Qt::AlignHCenter</set>
       </property>
       <item>
-       <widget class="QLabel" name="diveMode" native="true"/>
+       <widget class="QLabel" name="diveMode"/>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
+   <item row="1" column="0" colspan="6">
     <widget class="QGroupBox">
      <property name="title">
       <string>Extra Data</string>

--- a/desktop-widgets/tab-widgets/maintab.cpp
+++ b/desktop-widgets/tab-widgets/maintab.cpp
@@ -41,8 +41,11 @@ MainTab::MainTab(QWidget *parent) : QTabWidget(parent),
 	addTab(extraWidgets.last(), tr("Summary"));
 	extraWidgets << new TabDivePhotos(this);
 	addTab(extraWidgets.last(), tr("Media"));
-	extraWidgets << new TabDiveExtraInfo(this);
-	addTab(extraWidgets.last(), tr("Dive Computer Info"));
+	auto *extraInfoTab = new TabDiveExtraInfo(this);
+	extraWidgets << extraInfoTab;
+	addTab(extraInfoTab, tr("Dive Computer Info"));
+	connect(extraInfoTab, &TabDiveExtraInfo::dcChangeRequested,
+		this, &MainTab::dcChangeRequested);
 
 	// make sure we know if this is a light or dark mode
 	isDark = paletteIsDark(palette());

--- a/desktop-widgets/tab-widgets/maintab.h
+++ b/desktop-widgets/tab-widgets/maintab.h
@@ -33,6 +33,9 @@ slots:
 	void settingsChanged();
 	void escDetected();
 	void colorsChanged();
+signals:
+	// Emitted when the user selects a different dive computer in the Dive Computer Info tab.
+	void dcChangeRequested(int dcIndex);
 private:
 	bool lastSelectedDive;
 	int lastTabSelectedDive;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
If multiple dive computers were used in a dive, allow the user to select
the dive computer (and possibly serial number
if multiple identical dive computers were used) in the 'Dive Computer
Info' tab. This will change the dive computer in an identical way to how
it can be changed by using 'left arrow' and 'right arrow' in the dive
profile.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
<img width="1024" height="179" alt="image" src="https://github.com/user-attachments/assets/e7fae059-553d-4cff-b77d-ad72903bcd89" />

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
