### PR TITLE
Add BLE support for the Shearwater Perdix 3

### DIFF
--- a/SupportedDivecomputers.html
+++ b/SupportedDivecomputers.html
@@ -95,7 +95,7 @@
 	    <li>XP5</li></ul>
     </dd>
     <dt>Shearwater</dt><dd><ul>
-	    <li>Nerd, Nerd 2, Perdix, Perdix 2, Perdix AI, Peregrine, Peregrine TX, Petrel, Petrel 2, Petrel 3, Predator, Teric, Tern, Tern TX</li></ul>
+	    <li>Nerd, Nerd 2, Perdix, Perdix 2, Perdix 3, Perdix AI, Peregrine, Peregrine TX, Petrel, Petrel 2, Petrel 3, Predator, Teric, Tern, Tern TX</li></ul>
     </dd>
     <dt>Sherwood</dt><dd><ul>
 	    <li>Amphos, Amphos 2.0, Amphos Air, Amphos Air 2.0, Beacon, Insight, Insight 2, Sage, Vision, Wisdom, Wisdom 2, Wisdom 3, Wisdom 4</li></ul>

--- a/SupportedDivecomputers.txt
+++ b/SupportedDivecomputers.txt
@@ -32,7 +32,7 @@ Scorpena: Alpha
 Scubapro: Aladin A1, Aladin A2, Aladin H Matrix, Aladin Sport Matrix, Aladin Square, Chromis, G2, G2 Console, G2 HUD, G2 TEK, G3, Luna 2.0, Luna 2.0 AI, Mantis, Mantis 2, Meridian, XTender 5
 Seac: Action, Guru, Jack, Screen, Tablet
 Seemann: XP5
-Shearwater: Nerd, Nerd 2, Perdix, Perdix 2, Perdix AI, Peregrine, Peregrine TX, Petrel, Petrel 2, Petrel 3, Predator, Teric, Tern, Tern TX
+Shearwater: Nerd, Nerd 2, Perdix, Perdix 2, Perdix 3, Perdix AI, Peregrine, Peregrine TX, Petrel, Petrel 2, Petrel 3, Predator, Teric, Tern, Tern TX
 Sherwood: Amphos, Amphos 2.0, Amphos Air, Amphos Air 2.0, Beacon, Insight, Insight 2, Sage, Vision, Wisdom, Wisdom 2, Wisdom 3, Wisdom 4
 Sporasub: SP2
 Subgear: XP Air, XP-10, XP-3G, XP-Air

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -70,6 +70,7 @@ struct namePattern {
 static struct namePattern name[] = {
 	// Shearwater dive computers
 	{ "Predator", "Shearwater", "Predator" },
+	{ "Perdix 3", "Shearwater", "Perdix 3"},
 	{ "Perdix 2", "Shearwater", "Perdix 2"},
 	{ "Petrel 3", "Shearwater", "Petrel 3"},
 	// both the Petrel and Petrel 2 identify as "Petrel" as BT/BLE device

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -2,6 +2,7 @@
 #include <errno.h>
 
 #include <QtBluetooth/QBluetoothAddress>
+#include <QtBluetooth/QBluetoothDeviceDiscoveryAgent>
 #include <QLowEnergyController>
 #include <QLowEnergyService>
 #include <QCoreApplication>
@@ -175,6 +176,7 @@ static const struct uuid_match serial_service_uuids[] = {
 	{ "ca7b0001-f785-4c38-b599-c7c5fbadb034", "Pelagic (i330R, DSX)" },
 	{ "fdcdeaaa-295d-470e-bf15-04217b7aa0a0", "ScubaPro (G2, G3)"},
 	{ "fe25c237-0ece-443c-b0aa-e02033e7029d", "Shearwater (Perdix/Teric/Peregrine/Tern)" },
+	{ "1aa44039-1667-4b29-87cc-dfecaaf31d97", "Shearwater (Perdix 3)" },
 	{ "0000fcef-0000-1000-8000-00805f9b34fb", "Divesoft" },
         { "6e400001-b5a3-f393-e0a9-e50e24dc10b8", "Cressi"}, // Must have higher priority than Nordic UART
         { "6e400001-b5a3-f393-e0a9-e50e24dcca9e", "Nordic Semi UART" },
@@ -705,11 +707,48 @@ dc_status_t qt_ble_open(void **io, dc_context_t *, const char *devaddr, device_d
 		controller->setRemoteAddressType(QLowEnergyController::RandomAddress);
 #endif
 
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+	// AI-generated (Claude)
+	// Some dive computers (e.g. the Shearwater Perdix 3) advertise with a
+	// resolvable random address that changes between connections. BlueZ
+	// frequently aborts a cold connect to such a device because the
+	// controller needs a fresh advertising report to know the current
+	// address; connecting works reliably only while an LE scan is active.
+	// Keep a scan running for the duration of the connect attempt.
+	QBluetoothDeviceDiscoveryAgent scanAgent;
+	scanAgent.setLowEnergyDiscoveryTimeout(0); // scan until stop()
+	scanAgent.start(QBluetoothDeviceDiscoveryAgent::LowEnergyMethod);
+#endif
+
 	// Try to connect to the device
 	controller->connectToDevice();
 
 	// Create a timer. If the connection doesn't succeed after five seconds or no error occurs then stop the opening step
 	WAITFOR(controller->state() != QLowEnergyController::ConnectingState, BLE_TIMEOUT);
+
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+	// AI-generated (Claude)
+	// A cold LE connect on BlueZ can fail transiently: the kernel may
+	// abort the first attempt with le-connection-abort-by-local while it
+	// waits for a fresh advertising report, or the connect can complete
+	// just after our timeout while BlueZ is still retrying. Retry a few
+	// times (with the scan still active) before giving up.
+	for (int attempt = 1; attempt <= 2; attempt++) {
+		if (controller->state() == QLowEnergyController::ConnectedState)
+			break;
+		if (controller->state() == QLowEnergyController::UnconnectedState) {
+			report_info("connect attempt %d to %s failed ('%s'), retrying",
+				    attempt, devaddr, qPrintable(controller->errorString()));
+			controller->connectToDevice();
+		} else {
+			report_info("connect attempt %d to %s still pending, waiting longer",
+				    attempt, devaddr);
+		}
+		WAITFOR(controller->state() != QLowEnergyController::ConnectingState, BLE_TIMEOUT);
+	}
+
+	scanAgent.stop();
+#endif
 
 	switch (controller->state()) {
 	case QLowEnergyController::ConnectedState:


### PR DESCRIPTION
Add support for downloading dives from the Shearwater Perdix 3 over BLE.

The Perdix 3 uses a new vendor GATT service and a modified BLE transport
framing (24-bit transfer length, no per-packet frame prefix, wider download
blocks). The protocol itself is implemented in libdivecomputer; this PR is
the Subsurface-side glue plus a Linux BLE connect reliability fix.

### Changes

- **`core/btdiscovery.cpp`** — add a `Perdix 3` name entry to the dive
  computer discovery list, before `Perdix` since matching is by prefix.
- **`core/qt-ble.cpp`** — add the Perdix 3 vendor service UUID to the
  preferred-service table, and make the Linux BLE connect more reliable:
  the Perdix 3 advertises with a resolvable random address, and BlueZ
  regularly aborts a cold connect (`le-connection-abort-by-local`) or
  completes it only after our timeout, because the controller needs a
  fresh advertising report to resolve the current address. Keep an LE scan
  running for the duration of `connectToDevice()` and retry the connect up
  to two more rounds before giving up. This is gated to
  `Q_OS_LINUX && !Q_OS_ANDROID`; Android's stack handles the random-address
  connect itself.
- **`libdivecomputer`** — bump the submodule to the branch carrying the
  Perdix 3 protocol support (see dependency note).

### Testing

Verified end-to-end on Linux (desktop) and Android: the Perdix 3 connects
over BLE and its dive log downloads and imports into the dive list.

### Dependency / merge order (please read)

This PR bumps the `libdivecomputer` submodule to a commit that currently
lives only on my fork branch `splichy/subsurface-libdc @ 27c81c4`. It
**cannot merge as-is** — the companion libdivecomputer PR must be merged
into `Subsurface/libdc` first, then the submodule gitlink here repointed
to the merged upstream commit. I will update the gitlink once the libdc
PR lands.

Companion PR: https://github.com/subsurface/libdc/pull/117

### Notes for reviewers

The two multi-line blocks added to `qt_ble_open()` (scan-during-connect
and the retry loop) were AI-assisted and are marked with an
`AI-generated (Claude)` comment. The one-line table entries are not marked,
per the project's convention of marking only non-trivial blocks.

Generated with Claude Code (https://claude.com/claude-code)
