### PR TITLE
Import: Add Option to Force Bluetooth Classic.

### DIFF
--- a/cli-downloader.cpp
+++ b/cli-downloader.cpp
@@ -3,6 +3,7 @@
 #include "core/configuredivecomputer.h"
 #include "core/downloadfromdcthread.h"
 #include "core/libdivecomputer.h"
+#include "core/bluetoothaddress.h"
 #include "core/subsurfacestartup.h"
 #include <QCoreApplication>
 #include <QEventLoop>
@@ -18,52 +19,19 @@ static QString expandTilde(const QString &path)
 	return path;
 }
 
-static bool isHexDigit(QChar c)
-{
-	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
-}
-
-static bool looksLikeBluetoothAddress(const QString &device)
-{
-	QString address = device.trimmed();
-	if (address.startsWith("LE:"))
-		address = address.mid(3);
-
-	if (address.size() == 12) {
-		for (QChar c: address) {
-			if (!isHexDigit(c))
-				return false;
-		}
-		return true;
-	}
-
-	if (address.size() == 17) {
-		for (int i = 0; i < address.size(); ++i) {
-			if (i % 3 == 2) {
-				if (address[i] != ':' && address[i] != '-')
-					return false;
-			} else if (!isHexDigit(address[i])) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	return false;
-}
-
 // Perform a firmware update from the command line. Returns 0 on success, non-zero on failure.
 int cliFirmwareUpdate(const std::string &vendor, const std::string &product, const std::string &device, const std::string &filename, bool force)
 {
 	ConfigureDiveComputer config;
 	DCDeviceData localData;
 	QString deviceName = QString::fromStdString(device);
+	QString bluetoothAddress = extractBluetoothAddress(deviceName);
 
 	// prepare device_data
 	localData.setVendor(QString::fromStdString(vendor));
 	localData.setProduct(QString::fromStdString(product));
-	localData.setBluetoothMode(looksLikeBluetoothAddress(deviceName));
-	localData.setDevName(deviceName);
+	localData.setBluetoothMode(!bluetoothAddress.isEmpty());
+	localData.setDevName(bluetoothAddress.isEmpty() ? deviceName : bluetoothAddress);
 	localData.setSaveLog(!logfile_name.empty());
 	device_data_t *data = localData.internalData();
 
@@ -152,11 +120,13 @@ void cliDownloader(const std::string &vendor, const std::string &product, const 
 	});
 
 	auto data = diveImportedModel.thread.data();
+	QString deviceName = QString::fromStdString(device);
+	QString bluetoothAddress = extractBluetoothAddress(deviceName);
 	data->setVendor(QString::fromStdString(vendor));
 	data->setProduct(QString::fromStdString(product));
-	data->setBluetoothMode(looksLikeBluetoothAddress(QString::fromStdString(device)));
+	data->setBluetoothMode(!bluetoothAddress.isEmpty());
 	if (data->vendor() == "Uemis") {
-		QString devname = QString::fromStdString(device);
+		QString devname = deviceName;
 		int colon = devname.indexOf(QStringLiteral(":\\ (UEMISSDA)"));
 		if (colon >= 0) {
 			devname.truncate(colon + 2);
@@ -164,7 +134,7 @@ void cliDownloader(const std::string &vendor, const std::string &product, const 
 		}
 		data->setDevName(devname);
 	} else {
-		data->setDevName(QString::fromStdString(device));
+		data->setDevName(bluetoothAddress.isEmpty() ? deviceName : bluetoothAddress);
 	}
 
 	// some assumptions - should all be configurable

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -39,6 +39,8 @@ endif()
 
 # compile the core library part in C, part in C++
 set(SUBSURFACE_CORE_LIB_SRCS
+	bluetoothaddress.cpp
+	bluetoothaddress.h
 	checkcloudconnection.cpp
 	checkcloudconnection.h
 	cloudstorage.cpp

--- a/core/bluetoothaddress.cpp
+++ b/core/bluetoothaddress.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "bluetoothaddress.h"
+
+#include "errorhelper.h"
+#include <QRegularExpression>
+
+bool isBluetoothAddress(const QString &address)
+{
+	return !extractBluetoothAddress(address).isEmpty();
+}
+
+bool isBluetoothLowEnergyAddress(const QString &address)
+{
+	return address.startsWith("LE:", Qt::CaseInsensitive) && extractBluetoothAddress(address) == address.trimmed();
+}
+
+bool isBluetoothClassicAddress(const QString &address)
+{
+	return address.startsWith("BT:", Qt::CaseInsensitive) && extractBluetoothAddress(address) == address.trimmed();
+}
+
+QString bluetoothAddressWithoutPrefix(const QString &address)
+{
+	return isBluetoothLowEnergyAddress(address) || isBluetoothClassicAddress(address) ? address.mid(3) : address;
+}
+
+QString extractBluetoothAddress(const QString &address)
+{
+	// UUIDs identify BLE devices on Apple platforms and cannot be forced to Classic.
+	if (address.contains("BT:{", Qt::CaseInsensitive))
+		return {};
+
+	QRegularExpression compactMac("^(?:(?:LE|BT):)?[0-9A-F]{12}$", QRegularExpression::CaseInsensitiveOption);
+	if (compactMac.match(address.trimmed()).hasMatch())
+		return address.trimmed();
+
+	static const QString macAddress = "(?:(?:[0-9A-F]{2}:){5}[0-9A-F]{2}|(?:[0-9A-F]{2}-){5}[0-9A-F]{2})";
+	QRegularExpression re(QString("(?:(?:LE|BT):)?%1|(?:LE:)?{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}}").arg(macAddress),
+			      QRegularExpression::CaseInsensitiveOption);
+	return re.match(address).captured(0);
+}
+
+std::pair<QString, QString> extractBluetoothNameAddress(const QString &address)
+{
+	QString extractedAddress = extractBluetoothAddress(address);
+	if (extractedAddress == address.trimmed())
+		return { extractedAddress, QString() };
+	if (extractedAddress.isEmpty()) {
+		report_info("can't parse address %s", qPrintable(address));
+		return { QString(), QString() };
+	}
+
+	QRegularExpression re("^([^()]+)\\(([^)]*\\))$");
+	QRegularExpressionMatch m = re.match(address);
+	if (m.hasMatch())
+		return { extractedAddress, m.captured(1).trimmed() };
+	report_info("can't parse address %s", qPrintable(address));
+	return { QString(), QString() };
+}

--- a/core/bluetoothaddress.h
+++ b/core/bluetoothaddress.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef BLUETOOTHADDRESS_H
+#define BLUETOOTHADDRESS_H
+
+#include <QString>
+#include <utility>
+
+bool isBluetoothAddress(const QString &address);
+bool isBluetoothLowEnergyAddress(const QString &address);
+bool isBluetoothClassicAddress(const QString &address);
+QString bluetoothAddressWithoutPrefix(const QString &address);
+QString extractBluetoothAddress(const QString &address);
+std::pair<QString, QString> extractBluetoothNameAddress(const QString &address);
+
+#endif

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -503,36 +503,6 @@ void BTDiscovery::stopAgent()
 	discoveryAgent->stop();
 }
 
-bool isBluetoothAddress(const QString &address)
-{
-	return extractBluetoothAddress(address) != QString();
-}
-QString extractBluetoothAddress(const QString &address)
-{
-	QRegularExpression re("(LE:)*([0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}|{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}})",
-			      QRegularExpression::CaseInsensitiveOption);
-	QRegularExpressionMatch m = re.match(address);
-	return m.captured(0);
-}
-
-std::pair<QString, QString> extractBluetoothNameAddress(const QString &address)
-{
-	// sometimes our device text is of the form "name (address)", sometimes it's just "address"
-	// let's simply return the address
-	QString extractedAddress = extractBluetoothAddress(address);
-	if (extractedAddress == address.trimmed())
-		return { address, QString() };
-
-	QRegularExpression re("^([^()]+)\\(([^)]*\\))$");
-	QRegularExpressionMatch m = re.match(address);
-	if (m.hasMatch()) {
-		QString name = m.captured(1).trimmed();
-		return { extractedAddress, name };
-	}
-	report_info("can't parse address %s", qPrintable(address));
-	return { QString(), QString() };
-}
-
 void saveBtDeviceInfo(const QString &devaddr, QBluetoothDeviceInfo deviceInfo)
 {
 	btDeviceInfo[devaddr] = deviceInfo;

--- a/core/btdiscovery.h
+++ b/core/btdiscovery.h
@@ -10,6 +10,7 @@
 #include <QBluetoothDeviceDiscoveryAgent>
 #include <QBluetoothUuid>
 #include "core/libdivecomputer.h"
+#include "core/bluetoothaddress.h"
 
 #if defined(Q_OS_ANDROID)
 #include <QJniObject>
@@ -17,10 +18,7 @@
 #endif
 
 void saveBtDeviceInfo(const QString &devaddr, QBluetoothDeviceInfo deviceInfo);
-bool isBluetoothAddress(const QString &address);
 bool matchesKnownDiveComputerNames(QString btName);
-QString extractBluetoothAddress(const QString &address);
-std::pair<QString, QString> extractBluetoothNameAddress(const QString &address); // returns address/name pair
 QBluetoothDeviceInfo getBtDeviceInfo(const QString &devaddr);
 
 class BTDiscovery : public QObject {

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -49,6 +49,7 @@
 #include "core/qthelper.h"
 #include "core/pref.h"
 #include "core/file.h"
+#include "core/bluetoothaddress.h"
 #include <algorithm>
 #include <array>
 #include <charconv>
@@ -1318,8 +1319,11 @@ unsigned int get_supported_transports(device_data_t *data)
 		 */
 		if (data->bluetooth_mode) {
 			supported &= (DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE);
-			if (starts_with(data->devname, "LE:"))
+			QString devname = QString::fromStdString(data->devname);
+			if (isBluetoothLowEnergyAddress(devname))
 				supported &= DC_TRANSPORT_BLE;
+			else if (isBluetoothClassicAddress(devname))
+				supported &= DC_TRANSPORT_BLUETOOTH;
 		} else {
 			supported &= ~(DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE);
 		}
@@ -1399,9 +1403,9 @@ static dc_status_t irda_device_open(dc_iostream_t **iostream, dc_context_t *cont
 }
 
 #if defined(BT_SUPPORT) && !defined(__ANDROID__) && !defined(__APPLE__)
-static dc_status_t bluetooth_device_open(dc_context_t *context, device_data_t *data)
+static dc_status_t bluetooth_device_open(dc_context_t *context, device_data_t *data, const char *devname)
 {
-	dc_bluetooth_address_t address = dc_bluetooth_str2addr(data->devname.c_str());
+	dc_bluetooth_address_t address = dc_bluetooth_str2addr(devname);
 	dc_iterator_t *iterator = NULL;
 	dc_bluetooth_device_t *device = NULL;
 
@@ -1443,12 +1447,13 @@ dc_status_t divecomputer_device_open(device_data_t *data)
 
 #ifdef BT_SUPPORT
 	if (transports & DC_TRANSPORT_BLUETOOTH) {
-		dev_info("Opening rfcomm stream %s", data->devname.c_str());
+		std::string address = bluetoothAddressWithoutPrefix(QString::fromStdString(data->devname)).toStdString();
+		dev_info("Opening rfcomm stream %s", address.c_str());
 #if defined(__ANDROID__) || defined(__APPLE__)
 		// we don't have BT on iOS in the first place, so this is for Android and macOS
-		rc = rfcomm_stream_open(&data->iostream, context, data->devname.c_str());
+		rc = rfcomm_stream_open(&data->iostream, context, address.c_str());
 #else
-		rc = bluetooth_device_open(context, data);
+		rc = bluetooth_device_open(context, data, address.c_str());
 #endif
 		if (rc == DC_STATUS_SUCCESS)
 			return rc;

--- a/desktop-widgets/btdeviceselectiondialog.cpp
+++ b/desktop-widgets/btdeviceselectiondialog.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <QMenu>
+#include <QStandardItemModel>
 #include "core/btdiscovery.h"
 
 #include <QBluetoothUuid>
@@ -222,6 +223,7 @@ void BtDeviceSelectionDialog::currentItemChanged(QListWidgetItem *item, QListWid
 {
 	// If the list is cleared, we get a signal with a null item pointer
 	if (!item) {
+		updateBluetoothModeAvailability(nullptr);
 		ui->save->setEnabled(false);
 		return;
 	}
@@ -256,7 +258,25 @@ void BtDeviceSelectionDialog::currentItemChanged(QListWidgetItem *item, QListWid
 #endif
 	// Update the status message and the save button
 	ui->dialogStatus->setText(statusMessage);
+	updateBluetoothModeAvailability(&remoteDeviceInfo);
 	ui->save->setEnabled(enableSaveButton);
+}
+
+void BtDeviceSelectionDialog::updateBluetoothModeAvailability(const QBluetoothDeviceInfo *device)
+{
+	auto model = qobject_cast<QStandardItemModel *>(ui->btMode->model());
+	QStandardItem *classicItem = model ? model->item(2) : nullptr;
+	if (!classicItem)
+		return;
+
+	bool classicAvailable = !device || !device->address().isNull();
+	classicItem->setEnabled(classicAvailable);
+	if (!classicAvailable) {
+		if (ui->btMode->currentIndex() == 2)
+			ui->btMode->setCurrentIndex(0);
+		ui->dialogStatus->setText(ui->dialogStatus->text() + " " +
+					  tr("Bluetooth Classic is unavailable for devices identified by UUID."));
+	}
 }
 
 void BtDeviceSelectionDialog::localDeviceChanged(int index)
@@ -410,8 +430,10 @@ QString BtDeviceSelectionDialog::getSelectedDeviceAddress()
 		return markBLEAddress(device);
 	case 1:		// Force LE
 		return btDeviceAddress(device, true);
-	case 2:		// Force classical
-		return btDeviceAddress(device, false);
+	case 2:		// Force Classic
+		// Classic uses a MAC address. Apple platforms expose BLE devices as UUIDs,
+		// for which forcing Classic is not meaningful.
+		return device->address().isNull() ? QString() : "BT:" + btDeviceAddress(device, false);
 	}
 }
 

--- a/desktop-widgets/btdeviceselectiondialog.h
+++ b/desktop-widgets/btdeviceselectiondialog.h
@@ -45,6 +45,7 @@ private:
 
 	void updateLocalDeviceInformation();
 	void initializeDeviceDiscoveryAgent();
+	void updateBluetoothModeAvailability(const QBluetoothDeviceInfo *device);
 };
 
 #endif // BTDEVICESELECTIONDIALOG_H

--- a/desktop-widgets/btdeviceselectiondialog.ui
+++ b/desktop-widgets/btdeviceselectiondialog.ui
@@ -208,7 +208,7 @@
          </item>
          <item>
           <property name="text">
-           <string>Force classical</string>
+           <string>Force Classic</string>
           </property>
          </item>
         </widget>

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -6,6 +6,7 @@
 #include "core/divelist.h"
 #include "core/divelog.h"
 #include "core/errorhelper.h"
+#include "core/bluetoothaddress.h"
 #include "core/settings/qPrefDiveComputer.h"
 #include "core/subsurface-float.h"
 #include "core/subsurface-string.h"
@@ -441,9 +442,7 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 			// Need to ensure that any scan is shut down BEFORE starting the download
 			// because internally (as of 5.15.13) the QT discovery agent uses a QTimer
 			// that can only be shut off from the same thread it was started from.
-			QString devAddr = data->devName().startsWith("LE:")
-							 ? data->devName().right(data->devName().size()-3)
-							 : data->devName();
+			QString devAddr = bluetoothAddressWithoutPrefix(data->devName());
 			getBtDeviceInfo(devAddr);
 		}
 	} else

--- a/mobile-widgets/qml/DownloadFromDiveComputer.qml
+++ b/mobile-widgets/qml/DownloadFromDiveComputer.qml
@@ -379,13 +379,13 @@ Kirigami.Page {
 						var connectionString = comboConnection.currentText
 						// separate BT address and BT name (if applicable)
 						// pattern that matches BT addresses
-						var btAddr = "(LE:)?([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}";
+						var btAddr = "((LE|BT):)?([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}";
 
 						// On iOS we store UUID instead of device address.
 						if (Qt.platform.os === 'ios')
 							btAddr = "(LE:)?\{?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}";
 
-						var pattern = new RegExp(btAddr);
+						var pattern = new RegExp(btAddr, "i");
 						var devAddress = "";
 						devAddress = pattern.exec(connectionString);
 						if (devAddress !== null) {

--- a/tests/testhelper.cpp
+++ b/tests/testhelper.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "testhelper.h"
-#include "core/btdiscovery.h"
+#include "core/bluetoothaddress.h"
 
 void TestHelper::initTestCase()
 {
@@ -11,6 +11,15 @@ void TestHelper::recognizeBtAddress()
 {
 	QCOMPARE(isBluetoothAddress("01:a2:b3:c4:d5:06"), true);
 	QCOMPARE(isBluetoothAddress("LE:01:A2:B3:C4:D5:06"), true);
+	QCOMPARE(isBluetoothAddress("BT:01:A2:B3:C4:D5:06"), true);
+	QCOMPARE(isBluetoothAddress("BT:{6e50ff5d-cdd3-4c43-a80a-1ed4c7d2d2a5}"), false);
+	QCOMPARE(isBluetoothLowEnergyAddress("LE:01:A2:B3:C4:D5:06"), true);
+	QCOMPARE(isBluetoothClassicAddress("BT:01:A2:B3:C4:D5:06"), true);
+	QCOMPARE(isBluetoothClassicAddress("BT:{6e50ff5d-cdd3-4c43-a80a-1ed4c7d2d2a5}"), false);
+	QCOMPARE(bluetoothAddressWithoutPrefix("BT:01:A2:B3:C4:D5:06"), QString("01:A2:B3:C4:D5:06"));
+	QCOMPARE(bluetoothAddressWithoutPrefix("LE:01:A2:B3:C4:D5:06"), QString("01:A2:B3:C4:D5:06"));
+	QCOMPARE(isBluetoothAddress("01A2B3C4D506"), true);
+	QCOMPARE(isBluetoothAddress("01-A2-B3-C4-D5-06"), true);
 	QCOMPARE(isBluetoothAddress("01:A2:b3:04:05"), false);
 	QCOMPARE(isBluetoothAddress("LE:01:02:03:04:05"), false);
 	QCOMPARE(isBluetoothAddress("01:02:03:04:051:67"), false);
@@ -28,14 +37,23 @@ void TestHelper::parseNameAddress()
 	std::tie(address, name) = extractBluetoothNameAddress("01:a2:b3:c4:d5:06");
 	QCOMPARE(address, QString("01:a2:b3:c4:d5:06"));
 	QCOMPARE(name, QString());
+	std::tie(address, name) = extractBluetoothNameAddress("  01:a2:b3:c4:d5:06  ");
+	QCOMPARE(address, QString("01:a2:b3:c4:d5:06"));
+	QCOMPARE(name, QString());
 	std::tie(address, name) = extractBluetoothNameAddress("somename (01:a2:b3:c4:d5:06)");
 	QCOMPARE(address, QString("01:a2:b3:c4:d5:06"));
 	QCOMPARE(name, QString("somename"));
 	std::tie(address, name) = extractBluetoothNameAddress("garbage");
 	QCOMPARE(address, QString());
 	QCOMPARE(name, QString());
+	std::tie(address, name) = extractBluetoothNameAddress("somename (garbage)");
+	QCOMPARE(address, QString());
+	QCOMPARE(name, QString());
 	std::tie(address, name) = extractBluetoothNameAddress("somename (LE:{6e50ff5d-cdd3-4c43-a80a-1ed4c7d2d2a5})");
 	QCOMPARE(address, QString("LE:{6e50ff5d-cdd3-4c43-a80a-1ed4c7d2d2a5}"));
+	QCOMPARE(name, QString("somename"));
+	std::tie(address, name) = extractBluetoothNameAddress("somename (BT:01:a2:b3:c4:d5:06)");
+	QCOMPARE(address, QString("BT:01:a2:b3:c4:d5:06"));
 	QCOMPARE(name, QString("somename"));
 
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add an option to force Bluetooth Classic without falling back to BLE.
This can be achieved by using a 'BT:' prefix to a Bluetooth address in
the same way 'LE:' forces BLE.
This can be used in cases where it is known that BLE will not succed
with the import / firmware upload.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
