### PR TITLE
Align suit UI from Equipment tab to use the same tag functionality as Notes tags

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveEquipment.ui
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.ui
@@ -77,7 +77,7 @@
               <bool>true</bool>
              </property>
             </widget>
-            <widget class="QLineEdit" name="suit">
+            <widget class="TagWidget" name="suit">
              <property name="readOnly">
               <bool>false</bool>
              </property>
@@ -94,6 +94,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TagWidget</class>
+   <extends>QPlainTextEdit</extends>
+   <header>desktop-widgets/tagwidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This change updates the TabDiveEquipment UI by replacing the `QLineEdit` widget for the "suit" field with a `TagWidget`. The `TagWidget` extends `QPlainTextEdit`, as defined in `desktop-widgets/tagwidget.h`. This replacement allows for richer tag input functionality, potentially improving user interaction and usability in this context.

The `.ui` file has been updated to reference the custom `TagWidget` implementation to ensure seamless integration.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This pull request enhances the user experience within the TabDiveEquipment UI by migrating the "suit" input field from a standard QLineEdit to the custom TagWidget the align with the Notes tab. This change addresses limitations associated with single-line inputs, allowing for easier management of complex or multiple suit entries, and ensures consistency with other tag-based inputs throughout the application.

<img width="717" height="181" alt="Screenshot 2026-07-11 at 8 52 15 PM" src="https://github.com/user-attachments/assets/4b7cdc52-5fac-4f82-bc0c-c201d1e7ba67" />

### Changes made:
1) Modified the TabDiveEquipment UI file to replace the existing QLineEdit instance for the "suit" field with the custom TagWidget class.

2) Updated the underlying UI form definition to correctly promote the widget and reference the TagWidget implementation.

3) Verified that signal/slot connections for the "suit" field remain functional with the new widget type.

### Related issues:

### Additional information:
This change enables users to input multiple suit types or associated tags more effectively. Testing can be performed by opening the Dive Equipment tab and verifying that the "suit" field now accepts multiline input and handles tag formatting as expected by the TagWidget implementation.

### Documentation change:

### Mentions:

