### PR TITLE
Update SAC calculation to ignore NOT_USED cylinders

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3713,7 +3713,7 @@ image::images/Pref_eqpmnt.jpg["FIGURE: Preferences: equipment",align="center"]
   ** *Show unused cylinders*: Checking this checkbox allows showing all cylinders entered for a dive
      in the Cylinder Table of the *Equipment* tab, even if one or more cylinders were actually not used.
      This will also include unused cylinders in data exports and when dives are cloned for the planner
-     or merged into one dive.
+     or merged into one dive. Unused cylinders are not included when calculating SAC or total gas consumption for the dive.
 
 === Media
 

--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -376,6 +376,9 @@ static double calculate_airuse(const struct dive &dive)
 		return 0.0;
 
 	for (auto [i, cyl]: enumerated_range(dive.cylinders)) {
+		if (cyl.cylinder_use == NOT_USED)
+			continue;
+
 		pressure_t start, end;
 
 		start = cyl.start.mbar ? cyl.start : cyl.sample_start;

--- a/tests/testformatDiveGasString.cpp
+++ b/tests/testformatDiveGasString.cpp
@@ -1,5 +1,6 @@
 #include "testformatDiveGasString.h"
 
+#include "../core/divelist.h"
 #include "../core/dive.h"
 #include "../core/string-format.h"
 
@@ -50,6 +51,36 @@ void TestformatDiveGasString::test_nitrox_not_use()
 	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "32%");
+}
+
+void TestformatDiveGasString::test_sac_ignores_not_used_cylinder()
+{
+	struct dive one_dive;
+	cylinder_t *cylinder = one_dive.get_or_create_cylinder(0);
+	cylinder->type.size.mliter = 10000;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
+	cylinder->cylinder_use = OC_GAS;
+
+	divecomputer dc;
+	dc.divemode = OC;
+	dc.duration.seconds = 60;
+	dc.meandepth.mm = 10000;
+	one_dive.dcs.push_back(dc);
+
+	dive_table table;
+	table.update_cylinder_related_info(one_dive);
+
+	struct dive two_dive = one_dive;
+	cylinder = two_dive.get_or_create_cylinder(1);
+	cylinder->type.size.mliter = 10000;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
+	cylinder->cylinder_use = NOT_USED;
+
+	table.update_cylinder_related_info(two_dive);
+
+	QCOMPARE(one_dive.sac, two_dive.sac);
 }
 
 void TestformatDiveGasString::test_nitrox_deco()

--- a/tests/testformatDiveGasString.h
+++ b/tests/testformatDiveGasString.h
@@ -9,6 +9,7 @@ private slots:
 	void test_air();
 	void test_nitrox();
 	void test_nitrox_not_use();
+	void test_sac_ignores_not_used_cylinder();
 	void test_nitrox_deco();
 	void test_reverse_nitrox_deco();
 	void test_trimix();


### PR DESCRIPTION
Update calculate_airuse() to skip cylinders marked as NOT_USED

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When diving with Garmin air integrated computers between me and my buddy, we share our tank transmitter data between our computers. This allows us to see each other's tank pressure during the dive. When the Garmin dive log is imported into Subsurface, both tanks are included under the Equipment tab - the primary one as "OC-gas" the other as "not used". Before this PR, SAC rate was calculated against all tanks reporting consumed air. After this PR, tanks marked as NOT_USED are excluded from the calculate_airuse() function. This prevents SAC from being inflated by unused partner tanks or linked sensor tanks that are not actually breathed.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Excludes cylinders marked as NOT_USED from calculate_airuse()
2) Adds a regression test that checks the SAC rate after an additional NOT_USED tank is added to a dive

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes the question I raised in the User Group here: https://groups.google.com/g/subsurface-divelog/c/g0_J0Mm54yM/m/ef3XA62BAAAJ

### Additional information:
Here are two screenshots of dive logs where the Barbados dives had inaccurate SAC rate calculations.

**Before:**
<img width="751" height="455" alt="Screenshot 2026-07-12 194508" src="https://github.com/user-attachments/assets/f698063b-54d2-4368-b1e7-3024b4e5765d" />

**After:**
<img width="741" height="443" alt="Screenshot 2026-07-12 195447" src="https://github.com/user-attachments/assets/952fa3dd-7dad-4c50-a984-eaabf8a40462" />

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Added a sentence to the User Manual explicitly mentioning that unused cylinders are not included in SAC calculations.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
