### PR TITLE
Add detailed tracking of suit components in dive logs

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -195,6 +195,22 @@ QString EditNotes::fieldName() const
 }
 
 // ***** Suit *****
+void EditSuit::set(struct dive *d, QString v) const
+{
+	d->suit = v.toStdString();
+	if (!d->suit.empty()) {
+		if (!d->notes.empty())
+			d->notes += "\n";
+		d->notes += "Suit: " + d->suit;
+		d->suit.clear();
+	}
+}
+
+QString EditSuit::data(struct dive *d) const
+{
+	return QString::fromStdString(d->suit);
+}
+
 QString EditSuit::fieldName() const
 {
 	return Command::Base::tr("suit");

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -102,10 +102,12 @@ public:
 	QString fieldName() const override;
 };
 
-class EditSuit : public EditStringSetter<DiveField::SUIT, &dive::suit> {
+class EditSuit : public EditTemplate<QString, DiveField::SUIT> {
 public:
-	using EditStringSetter::EditStringSetter;	// Use constructor of base class.
+	using EditTemplate<QString, DiveField::SUIT>::EditTemplate;
 	QString fieldName() const override;
+	void set(struct dive *d, QString v) const override;
+	QString data(struct dive *d) const override;
 };
 
 class EditRating : public EditDefaultSetter<int, DiveField::RATING, &dive::rating> {

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -1863,6 +1863,22 @@ static bool has_weightsystem(const weightsystem_table &t, const weightsystem_t &
 	return any_of(t.begin(), t.end(), [&w] (auto &w2) { return w == w2; });
 }
 
+static void merge_suit_items(struct dive &res, const struct dive &a, const struct dive &b)
+{
+	res.suit_items = a.suit_items;
+	for (const auto &item : b.suit_items) {
+		bool found = false;
+		for (const auto &existing : res.suit_items) {
+			if (existing == item) {
+				found = true;
+				break;
+			}
+		}
+		if (!found)
+			res.suit_items.push_back(item);
+	}
+}
+
 static void merge_equipment(struct dive &res, const struct dive &a, const struct dive &b)
 {
 	for (auto &ws: a.weightsystems) {
@@ -2352,6 +2368,7 @@ std::unique_ptr<dive> dive::create_merged_dive(const struct dive &a, const struc
 	auto cylinders_map_b = std::make_unique<int[]>(std::max(size_t(1), b.cylinders.size()));
 	merge_cylinders(*res, a, b, cylinders_map_a.get(), cylinders_map_b.get());
 	merge_equipment(*res, a, b);
+	merge_suit_items(*res, a, b);
 	merge_temperatures(*res, a, b);
 	if (prefer_downloaded) {
 		/* If we prefer downloaded, do those first, and get rid of "might be same" computers */

--- a/core/dive.h
+++ b/core/dive.h
@@ -49,6 +49,7 @@ struct dive {
 	std::string notes;
 	std::string diveguide, buddy;
 	std::string suit;
+	suit_table suit_items;
 	cylinder_table cylinders;
 	weightsystem_table weightsystems;
 	int number = 0;

--- a/core/equipment.cpp
+++ b/core/equipment.cpp
@@ -308,6 +308,20 @@ void weightsystem_table::set(int idx, weightsystem_t ws)
 	(*this)[idx] = std::move(ws);
 }
 
+bool suit_component_t::operator==(const suit_component_t &other) const
+{
+	return type == other.type &&
+	       brand == other.brand &&
+	       model == other.model &&
+	       thickness == other.thickness &&
+	       size == other.size;
+}
+
+void suit_table::add(suit_component_t s)
+{
+	push_back(s);
+}
+
 /* when planning a dive we need to make sure that all cylinders have a sane depth assigned
  * and if we are tracking gas consumption the pressures need to be reset to start = end = workingpressure */
 void reset_cylinders(struct dive *dive, bool track_gas)

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -122,4 +122,19 @@ extern std::pair<volume_t, pressure_t> get_tank_info_data(const std::vector<tank
 extern void add_cylinder_description(const cylinder_type_t &);
 extern void reset_tank_info_table(std::vector<tank_info> &table);
 
+
+struct suit_component_t {
+	enum type { SUIT, BOOTS, GLOVES, BCD, FINS } type = SUIT;
+	std::string brand;
+	std::string model;
+	std::string thickness;
+	std::string size;
+
+	bool operator==(const suit_component_t &other) const;
+};
+
+struct suit_table : public std::vector<suit_component_t> {
+	void add(suit_component_t s);
+};
+
 #endif // EQUIPMENT_H

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -240,7 +240,14 @@ static void parse_dive_buddy(char *, struct git_parser_state *state)
 { state->active_dive->buddy = get_first_converted_string(state); }
 
 static void parse_dive_suit(char *, struct git_parser_state *state)
-{ state->active_dive->suit = get_first_converted_string(state); }
+{
+	std::string suit = get_first_converted_string(state);
+	if (!suit.empty()) {
+		if (!state->active_dive->notes.empty())
+			state->active_dive->notes += "\n";
+		state->active_dive->notes += "Suit: " + suit;
+	}
+}
 
 static void parse_dive_notes(char *, struct git_parser_state *state)
 { state->active_dive->notes = get_first_converted_string(state); }
@@ -441,6 +448,34 @@ static void parse_dive_cylinder(char *line, struct git_parser_state *state)
 		state->o2pressure_sensor = static_cast<int>(state->active_dive->cylinders.size());
 
 	state->active_dive->cylinders.push_back(std::move(cylinder));
+}
+
+static void parse_suit_part_keyvalue(void *_item, const char *key, const std::string &value)
+{
+	suit_component_t *item = (suit_component_t *)_item;
+	if (same_string(key, "type")) {
+		if (value == "suit") item->type = suit_component_t::SUIT;
+		else if (value == "boots") item->type = suit_component_t::BOOTS;
+		else if (value == "gloves") item->type = suit_component_t::GLOVES;
+		else if (value == "bcd") item->type = suit_component_t::BCD;
+		else if (value == "fins") item->type = suit_component_t::FINS;
+	} else if (same_string(key, "brand")) {
+		item->brand = value;
+	} else if (same_string(key, "model")) {
+		item->model = value;
+	} else if (same_string(key, "thickness")) {
+		item->thickness = value;
+	} else if (same_string(key, "size")) {
+		item->size = value;
+	}
+}
+
+static void parse_dive_suit_part(char *line, struct git_parser_state *state)
+{
+	suit_component_t item;
+	while (line && *line)
+		line = parse_keyvalue_entry(parse_suit_part_keyvalue, &item, line, state);
+	state->active_dive->suit_items.push_back(item);
 }
 
 static void parse_weightsystem_keyvalue(void *_ws, const char *key, const std::string &value)
@@ -1089,7 +1124,7 @@ static const std::array dive_action {
 	/* For historical reasons, we accept divemaster and diveguide */
 	D(airpressure), D(airtemp), D(buddy), D(chill), D(current), D(cylinder), D(diveguide),
 	keyword_action { "divemaster", parse_dive_diveguide },
-	D(divesiteid), D(duration), D(gps), D(invalid), D(location), D(notes), D(notrip), D(rating), D(suit), D(surge),
+	D(divesiteid), D(duration), D(gps), D(invalid), D(location), D(notes), D(notrip), D(rating), D(suit), D(suit_part), D(surge),
 	D(tags), D(visibility), D(watersalinity), D(watertemp), D(wavesize), D(weightsystem)
 };
 

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -41,6 +41,8 @@
 
 int last_xml_version = -1;
 
+static xmlNode *cur_node = nullptr;
+
 static xmlDoc *test_xslt_transforms(xmlDoc *doc, const struct xml_params *params);
 
 static void divedate(const char *buffer, timestamp_t *when, struct parser_state *state)
@@ -1336,10 +1338,24 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, str
 		return;
 	if (MATCH_STATE("name.dive", add_dive_site, dive))
 		return;
-	if (MATCH("suit", utf8_string_std, &dive->suit))
+	if (MATCH("suit", utf8_string_std, &dive->suit)) {
+		if (!dive->suit.empty()) {
+			if (!dive->notes.empty())
+				dive->notes += "\n";
+			dive->notes += "Suit: " + dive->suit;
+			dive->suit.clear();
+		}
 		return;
-	if (MATCH("divesuit", utf8_string_std, &dive->suit))
+	}
+	if (MATCH("divesuit", utf8_string_std, &dive->suit)) {
+		if (!dive->suit.empty()) {
+			if (!dive->notes.empty())
+				dive->notes += "\n";
+			dive->notes += "Suit: " + dive->suit;
+			dive->suit.clear();
+		}
 		return;
+	}
 	if (MATCH("notes", utf8_string_std, &dive->notes))
 		return;
 	// For historic reasons, we accept dive guide as well as dive master
@@ -1362,6 +1378,8 @@ static void try_to_fill_dive(struct dive *dive, const char *name, char *buf, str
 	if (MATCH("surge.dive", get_rating, &dive->surge))
 		return;
 	if (MATCH("chill.dive", get_rating, &dive->chill))
+		return;
+	if (match_name("suit_part", name))
 		return;
 	if (MATCH_STATE("airpressure.dive", pressure, &dive->surface_pressure))
 		return;
@@ -1503,6 +1521,33 @@ static void try_to_fill_filter_constraint(const char *name, char *buf, struct pa
 	nonmatch("fulltext", name, buf);
 }
 
+static void suit_type(const char *buffer, enum suit_component_t::type *type)
+{
+	if (!strcmp(buffer, "suit")) *type = suit_component_t::SUIT;
+	else if (!strcmp(buffer, "boots")) *type = suit_component_t::BOOTS;
+	else if (!strcmp(buffer, "gloves")) *type = suit_component_t::GLOVES;
+	else if (!strcmp(buffer, "bcd")) *type = suit_component_t::BCD;
+	else if (!strcmp(buffer, "fins")) *type = suit_component_t::FINS;
+}
+
+static void try_to_fill_suit_part(const char *name, char *buf, struct parser_state *state)
+{
+	start_match("suit_part", name, buf);
+
+	if (MATCH("type", suit_type, &state->cur_suit_part.type))
+		return;
+	if (MATCH("brand", utf8_string_std, &state->cur_suit_part.brand))
+		return;
+	if (MATCH("model", utf8_string_std, &state->cur_suit_part.model))
+		return;
+	if (MATCH("thickness", utf8_string_std, &state->cur_suit_part.thickness))
+		return;
+	if (MATCH("size", utf8_string_std, &state->cur_suit_part.size))
+		return;
+
+	nonmatch("suit_part", name, buf);
+}
+
 static bool entry(const char *name, char *buf, struct parser_state *state)
 {
 	if (!strncmp(name, "version.program", sizeof("version.program") - 1) ||
@@ -1521,6 +1566,10 @@ static bool entry(const char *name, char *buf, struct parser_state *state)
 	}
 	if (state->cur_dive_site) {
 		try_to_fill_dive_site(state, name, buf);
+		return true;
+	}
+	if (state->in_suit_part) {
+		try_to_fill_suit_part(name, buf, state);
 		return true;
 	}
 	if (state->in_filter_constraint) {
@@ -1608,8 +1657,12 @@ static bool visit_one_node(xmlNode *node, struct parser_state *state)
 		return true;
 
 	name = nodename(node, buffer, sizeof(buffer));
+	xmlNode *old_node = cur_node;
+	cur_node = node;
 
-	return entry(name, (char *)content, state);
+	bool ret = entry(name, (char *)content, state);
+	cur_node = old_node;
+	return ret;
 }
 
 static bool traverse(xmlNode *root, struct parser_state *state);
@@ -1683,6 +1736,7 @@ static struct nesting {
 	  { "gasmix", (parser_func)cylinder_start, (parser_func)cylinder_end },
 	  { "cylinder", (parser_func)cylinder_start, (parser_func)cylinder_end },
 	  { "weightsystem", ws_start, ws_end },
+	  { "suit_part", suit_part_start, suit_part_end },
 	  { "divecomputer", divecomputer_start, divecomputer_end },
 	  { "P", sample_start, sample_end },
 	  { "userid", userid_start, userid_stop},
@@ -1716,12 +1770,20 @@ static bool traverse(xmlNode *root, struct parser_state *state)
 			rule++;
 		} while (rule->name);
 
-		if (rule->start)
+		if (rule->start) {
+			xmlNode *old_node = cur_node;
+			cur_node = n;
 			rule->start(state);
+			cur_node = old_node;
+		}
 		if ((ret = visit(n, state)) == false)
 			break;
-		if (rule->end)
+		if (rule->end) {
+			xmlNode *old_node = cur_node;
+			cur_node = n;
 			rule->end(state);
+			cur_node = old_node;
+		}
 	}
 	return ret;
 }

--- a/core/parse.cpp
+++ b/core/parse.cpp
@@ -315,6 +315,19 @@ void ws_end(struct parser_state *state)
 {
 }
 
+void suit_part_start(struct parser_state *state)
+{
+	state->cur_suit_part = suit_component_t();
+	state->in_suit_part = true;
+}
+
+void suit_part_end(struct parser_state *state)
+{
+	if (state->cur_dive)
+		state->cur_dive->suit_items.push_back(state->cur_suit_part);
+	state->in_suit_part = false;
+}
+
 /*
  * If the given cylinder doesn't exist, return NO_SENSOR.
  */

--- a/core/parse.h
+++ b/core/parse.h
@@ -74,6 +74,7 @@ struct parser_state {
 	int taxonomy_category = 0, taxonomy_origin = 0;
 
 	bool in_settings = false;
+	bool in_suit_part = false;
 	bool in_userid = false;
 	bool in_fulltext = false;
 	bool in_filter_constraint = false;
@@ -83,6 +84,7 @@ struct parser_state {
 	int sample_rate = 0;
 	struct { std::string key; std::string value; } cur_extra_data;
 	struct { int16_t sensor_id; unsigned int cylinder_index; } cur_tank_sensor_mapping;
+	suit_component_t cur_suit_part;
 	struct units xml_parsing_units;
 	struct divelog *log = nullptr;				/* non-owning */
 	std::vector<fingerprint_record> *fingerprints = nullptr;
@@ -126,6 +128,8 @@ cylinder_t *cylinder_start(struct parser_state *state);
 void cylinder_end(struct parser_state *state);
 void ws_start(struct parser_state *state);
 void ws_end(struct parser_state *state);
+void suit_part_start(struct parser_state *state);
+void suit_part_end(struct parser_state *state);
 
 void sample_start(struct parser_state *state);
 void sample_end(struct parser_state *state);

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -138,6 +138,24 @@ static void put_gasmix(struct membuffer *b, struct gasmix mix)
 	}
 }
 
+static void save_suit_info(struct membuffer *b, const struct dive &dive)
+{
+	for (const auto &item : dive.suit_items) {
+		put_format(b, "suit_part ");
+		const char *type = "suit";
+		if (item.type == suit_component_t::BOOTS) type = "boots";
+		else if (item.type == suit_component_t::GLOVES) type = "gloves";
+		else if (item.type == suit_component_t::BCD) type = "bcd";
+		else if (item.type == suit_component_t::FINS) type = "fins";
+		put_format(b, "type=%s", type);
+		show_utf8(b, " brand=", item.brand.c_str(), "");
+		show_utf8(b, " model=", item.model.c_str(), "");
+		show_utf8(b, " thickness=", item.thickness.c_str(), "");
+		show_utf8(b, " size=", item.size.c_str(), "");
+		put_format(b, "\n");
+	}
+}
+
 static void save_cylinder_info(struct membuffer *b, const struct dive &dive)
 {
 	for (auto &cyl: dive.cylinders) {
@@ -429,6 +447,7 @@ static void create_dive_buffer(const struct dive &dive, struct membuffer *b)
 		report_info("removed reference to non-existant dive site with uuid %08x\n", dive.dive_site->uuid);
 	save_overview(b, dive);
 	save_cylinder_info(b, dive);
+	save_suit_info(b, dive);
 	save_weightsystem_info(b, dive);
 	save_dive_temperature(b, dive);
 }

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -171,6 +171,24 @@ static void put_gasmix(struct membuffer *b, struct gasmix mix)
 	}
 }
 
+static void save_suit_info(struct membuffer *b, const struct dive &dive)
+{
+	for (const auto &item : dive.suit_items) {
+		put_format(b, "  <suit_part");
+		const char *type = "suit";
+		if (item.type == suit_component_t::BOOTS) type = "boots";
+		else if (item.type == suit_component_t::GLOVES) type = "gloves";
+		else if (item.type == suit_component_t::BCD) type = "bcd";
+		else if (item.type == suit_component_t::FINS) type = "fins";
+		put_format(b, " type='%s'", type);
+		show_utf8(b, item.brand.c_str(), " brand='", "'", 1);
+		show_utf8(b, item.model.c_str(), " model='", "'", 1);
+		show_utf8(b, item.thickness.c_str(), " thickness='", "'", 1);
+		show_utf8(b, item.size.c_str(), " size='", "'", 1);
+		put_format(b, "/>\n");
+	}
+}
+
 static void save_cylinder_info(struct membuffer *b, const struct dive &dive)
 {
 	for (auto &cyl: dive.cylinders) {
@@ -510,6 +528,7 @@ void save_one_dive_to_mb(struct membuffer *b, const struct dive &dive, bool anon
 		put_format(b, ">\n");
 	save_overview(b, dive, anonymize);
 	save_cylinder_info(b, dive);
+	save_suit_info(b, dive);
 	save_weightsystem_info(b, dive);
 	save_dive_temperature(b, dive);
 	/* Save the dive computer data */

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -6,6 +6,7 @@
 #include "core/gettextfromc.h"
 #include "desktop-widgets/mainwindow.h"
 #include "qt-models/cylindermodel.h"
+#include "qt-models/suitcomponentmodel.h"
 #include "qt-models/models.h"
 #include "desktop-widgets/starwidget.h"
 #include "profile-widget/profilewidget2.h"
@@ -98,6 +99,7 @@ void ComboBoxDelegate::setEditorData(QWidget *editor, const QModelIndex &index) 
 	QComboBox *c = qobject_cast<QComboBox *>(editor);
 	QString data = index.model()->data(index, Qt::DisplayRole).toString();
 	int i = c->findText(data);
+	const QSignalBlocker blocker(c);
 	if (i != -1)
 		c->setCurrentIndex(i);
 	else
@@ -108,24 +110,43 @@ void ComboBoxDelegate::setEditorData(QWidget *editor, const QModelIndex &index) 
 QWidget *ComboBoxDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const
 {
 	QComboBox *comboDelegate = new QComboBox(parent);
-	comboDelegate->setModel(create_model_func(comboDelegate));
+	if (create_model_func) {
+		comboDelegate->setModel(create_model_func(comboDelegate));
+	} else {
+		// If no create_model_func is provided, we assume the model will be provided by the table model itself.
+		// However, ComboBoxDelegate is designed to own the model.
+		// For SuitInfoDelegate, we want to use completion models from SuitComponentModel.
+		if ( SuitComponentModel *suitModel = qobject_cast<SuitComponentModel *>(const_cast<QAbstractItemModel *>(index.model()))) {
+			switch (index.column()) {
+			case SuitComponentModel::BRAND:
+				comboDelegate->setModel(suitModel->brandCompletionModel());
+				break;
+			case SuitComponentModel::MODEL:
+				comboDelegate->setModel(suitModel->modelCompletionModel());
+				break;
+			case SuitComponentModel::THICKNESS:
+				comboDelegate->setModel(suitModel->thicknessCompletionModel());
+				break;
+			case SuitComponentModel::SIZE:
+				comboDelegate->setModel(suitModel->sizeCompletionModel());
+				break;
+			}
+		}
+	}
 	comboDelegate->setEditable(true);
 	comboDelegate->completer()->setCaseSensitivity(Qt::CaseInsensitive);
 	comboDelegate->completer()->setCompletionMode(QCompleter::PopupCompletion);
 	comboDelegate->completer()->setFilterMode(Qt::MatchContains);
-	comboDelegate->view()->setEditTriggers(QAbstractItemView::AllEditTriggers);
 	comboDelegate->lineEdit()->installEventFilter(const_cast<QObject *>(qobject_cast<const QObject *>(this)));
 	comboDelegate->lineEdit()->setEnabled(editable);
 	comboDelegate->view()->installEventFilter(const_cast<QObject *>(qobject_cast<const QObject *>(this)));
 	QAbstractItemView *comboPopup = comboDelegate->lineEdit()->completer()->popup();
-	comboPopup->setMouseTracking(true);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
 	connect(comboDelegate, &QComboBox::textHighlighted, this, &ComboBoxDelegate::testActivationString);
 #else
 	connect(comboDelegate, QOverload<const QString &>::of(&QComboBox::highlighted), this, &ComboBoxDelegate::testActivationString);
 #endif
 	connect(comboDelegate, QOverload<int>::of(&QComboBox::activated), this, &ComboBoxDelegate::fakeActivation);
-	connect(comboPopup, &QAbstractItemView::entered, this, &ComboBoxDelegate::testActivationIndex);
 	connect(comboPopup, &QAbstractItemView::activated, this, &ComboBoxDelegate::fakeActivation);
 	currCombo.comboEditor = comboDelegate;
 	currCombo.currRow = index.row();
@@ -341,6 +362,49 @@ static QAbstractItemModel *createWSInfoModel(QWidget *parent)
 }
 
 WSInfoDelegate::WSInfoDelegate(QObject *parent) : ComboBoxDelegate(&createWSInfoModel, parent, true)
+{
+}
+
+void SuitInfoDelegate::editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint)
+{
+}
+
+void SuitInfoDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
+{
+	if (!index.isValid())
+		return;
+
+	QComboBox *combo = qobject_cast<QComboBox *>(editor);
+	QString value = combo->currentText();
+	model->setData(index, value);
+}
+
+SuitInfoDelegate::SuitInfoDelegate(QObject *parent) : ComboBoxDelegate(nullptr, parent, true)
+{
+}
+
+static QAbstractItemModel *createSuitTypeModel(QWidget *parent)
+{
+	QStringListModel *model = new QStringListModel(parent);
+	model->setStringList({QObject::tr("Suit"), QObject::tr("Boots"), QObject::tr("Gloves"), QObject::tr("BCD"), QObject::tr("Fins")});
+	return model;
+}
+
+SuitTypeDelegate::SuitTypeDelegate(QObject *parent) : ComboBoxDelegate(&createSuitTypeModel, parent, false)
+{
+}
+
+void SuitTypeDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
+{
+	if (!index.isValid())
+		return;
+
+	QComboBox *combo = qobject_cast<QComboBox *>(editor);
+	QString value = combo->currentText();
+	model->setData(index, value);
+}
+
+void SuitTypeDelegate::editorClosed(QWidget *, QAbstractItemDelegate::EndEditHint)
 {
 }
 

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -105,6 +105,24 @@ private:
 	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
 };
 
+class SuitInfoDelegate : public ComboBoxDelegate {
+	Q_OBJECT
+public:
+	explicit SuitInfoDelegate(QObject *parent = 0);
+private:
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
+};
+
+class SuitTypeDelegate : public ComboBoxDelegate {
+	Q_OBJECT
+public:
+	explicit SuitTypeDelegate(QObject *parent = 0);
+private:
+	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
+};
+
 class GasTypesDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -9,6 +9,7 @@
 
 #include "qt-models/cylindermodel.h"
 #include "qt-models/weightmodel.h"
+#include "qt-models/suitcomponentmodel.h"
 
 #include <QMessageBox>
 #include <QSettings>
@@ -30,9 +31,9 @@ static bool ignoreHiddenFlag(int i)
 
 TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 	cylindersModel(new CylindersModel(false, this)),
-	weightModel(new WeightModel(this))
+	weightModel(new WeightModel(this)),
+	suitComponentModel(new SuitComponentModel(this))
 {
-	QCompleter *suitCompleter;
 	ui.setupUi(this);
 
 	// This makes sure we only delete the models
@@ -40,15 +41,19 @@ TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 	// this is needed to save the column sizes.
 	cylindersModel->setParent(ui.cylinders);
 	weightModel->setParent(ui.weights);
+	suitComponentModel->setParent(ui.suit_items);
 
 	ui.cylinders->setModel(cylindersModel);
 	ui.weights->setModel(weightModel);
+	ui.suit_items->setModel(suitComponentModel);
 
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &TabDiveEquipment::divesChanged);
 	connect(ui.cylinders, &TableView::itemClicked, this, &TabDiveEquipment::editCylinderWidget);
 	connect(ui.weights, &TableView::itemClicked, this, &TabDiveEquipment::editWeightWidget);
+	connect(ui.suit_items, &TableView::itemClicked, this, &TabDiveEquipment::editSuitWidget);
 	connect(cylindersModel, &CylindersModel::divesEdited, this, &TabDiveEquipment::divesEdited);
 	connect(weightModel, &WeightModel::divesEdited, this, &TabDiveEquipment::divesEdited);
+	connect(suitComponentModel, &SuitComponentModel::divesEdited, this, &TabDiveEquipment::divesEdited);
 	connect(&diveListNotifier, &DiveListNotifier::diveComputerEdited, this, &TabDiveEquipment::diveComputerEdited);
 	connect(&diveListNotifier, &DiveListNotifier::cylinderRemoved, this, &TabDiveEquipment::cylinderRemoved);
 
@@ -56,6 +61,16 @@ TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::USE, &tankUseDelegate);
 	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::SENSORS, &sensorDelegate);
 	ui.weights->view()->setItemDelegateForColumn(WeightModel::TYPE, &wsInfoDelegate);
+	ui.suit_items->view()->setItemDelegateForColumn(SuitComponentModel::TYPE, &suitTypeDelegate);
+	ui.suit_items->view()->setItemDelegateForColumn(SuitComponentModel::BRAND, &suitInfoDelegate);
+	ui.suit_items->view()->setItemDelegateForColumn(SuitComponentModel::MODEL, &suitInfoDelegate);
+	ui.suit_items->view()->setItemDelegateForColumn(SuitComponentModel::THICKNESS, &suitInfoDelegate);
+	ui.suit_items->view()->setItemDelegateForColumn(SuitComponentModel::SIZE, &suitInfoDelegate);
+
+	cylindersModel->setParent(ui.cylinders->view());
+	weightModel->setParent(ui.weights->view());
+	suitComponentModel->setParent(ui.suit_items->view());
+
 	ui.cylinders->view()->setColumnHidden(CylindersModel::DEPTH, true);
 	ui.cylinders->view()->setColumnHidden(CylindersModel::WORKINGPRESS_INT, true);
 	ui.cylinders->view()->setColumnHidden(CylindersModel::SIZE_INT, true);
@@ -71,6 +86,15 @@ TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 	connect(ui.weights, &TableView::addButtonClicked, this, &TabDiveEquipment::addWeight_clicked);
 
 	ui.weights->view()->horizontalHeader()->setStretchLastSection(true);
+
+	ui.suit_items->setTitle(tr("Suit"));
+	ui.suit_items->setBtnToolTip(tr("Add suit part"));
+	connect(ui.suit_items, &TableView::addButtonClicked, this, &TabDiveEquipment::addSuit_clicked);
+	ui.suit_items->view()->horizontalHeader()->setStretchLastSection(true);
+
+	ui.cylinders->view()->setEditTriggers(QAbstractItemView::SelectedClicked | QAbstractItemView::EditKeyPressed);
+	ui.weights->view()->setEditTriggers(QAbstractItemView::SelectedClicked | QAbstractItemView::EditKeyPressed);
+	ui.suit_items->view()->setEditTriggers(QAbstractItemView::SelectedClicked | QAbstractItemView::EditKeyPressed);
 
 	QAction *action = new QAction(tr("OK"), this);
 	connect(action, &QAction::triggered, this, &TabDiveEquipment::closeWarning);
@@ -101,9 +125,6 @@ TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 	setCylinderColumnVisibility();
 	ui.cylinders->view()->horizontalHeader()->setContextMenuPolicy(Qt::ActionsContextMenu);
 	ui.weights->view()->horizontalHeader()->setContextMenuPolicy(Qt::ActionsContextMenu);
-	suitCompleter = new QCompleter(&suitModel, ui.suit);
-	suitCompleter->setCaseSensitivity(Qt::CaseInsensitive);
-	ui.suit->setCompleter(suitCompleter);
 }
 
 TabDiveEquipment::~TabDiveEquipment()
@@ -158,7 +179,7 @@ void TabDiveEquipment::divesChanged(const QVector<dive *> &dives, DiveField fiel
 		return;
 
 	if (field.suit)
-		ui.suit->setText(QString::fromStdString(parent.currentDive->suit));
+		suitComponentModel->updateDive(parent.currentDive);
 }
 
 void TabDiveEquipment::toggleTriggeredColumn()
@@ -176,22 +197,18 @@ void TabDiveEquipment::updateData(const std::vector<dive *> &, dive *currentDive
 
 	cylindersModel->updateDive(currentDive, currentDC);
 	weightModel->updateDive(currentDive);
+	suitComponentModel->updateDive(currentDive);
 	sensorDelegate.setCurrentDc(dc);
 	tankUseDelegate.setDiveDc(*currentDive, currentDC);
 
 	setCylinderColumnVisibility();
-
-	if (!currentDive->suit.empty())
-		ui.suit->setText(QString::fromStdString(currentDive->suit));
-	else
-		ui.suit->clear();
 }
 
 void TabDiveEquipment::clear()
 {
 	cylindersModel->clear();
 	weightModel->clear();
-	ui.suit->clear();
+	suitComponentModel->updateDive(nullptr);
 }
 
 void TabDiveEquipment::addCylinder_clicked()
@@ -204,16 +221,20 @@ void TabDiveEquipment::addWeight_clicked()
 	divesEdited(Command::addWeight(false));
 }
 
+void TabDiveEquipment::addSuit_clicked()
+{
+	if (!parent.currentDive)
+		return;
+	suitComponentModel->add();
+}
+
 void TabDiveEquipment::editCylinderWidget(const QModelIndex &index)
 {
 	if (!index.isValid())
 		return;
 
-	if (index.column() == CylindersModel::REMOVE) {
+	if (index.column() == CylindersModel::REMOVE)
 		divesEdited(Command::removeCylinder(index.row(), false));
-	} else if (index.column() != CylindersModel::NUMBER) {
-		ui.cylinders->edit(index);
-	}
 }
 
 void TabDiveEquipment::editWeightWidget(const QModelIndex &index)
@@ -223,8 +244,15 @@ void TabDiveEquipment::editWeightWidget(const QModelIndex &index)
 
 	if (index.column() == WeightModel::REMOVE)
 		divesEdited(Command::removeWeight(index.row(), false));
-	else
-		ui.weights->edit(index);
+}
+
+void TabDiveEquipment::editSuitWidget(const QModelIndex &index)
+{
+	if (!index.isValid())
+		return;
+
+	if (index.column() == SuitComponentModel::REMOVE)
+		suitComponentModel->remove(index.row());
 }
 
 void TabDiveEquipment::divesEdited(int i)
@@ -248,13 +276,6 @@ void TabDiveEquipment::cylinderRemoved(struct dive *dive, int)
 	if (parent.currentDive == dive)
 		for (auto &dc: dive->dcs)
 			dive->fixup_dive_dc(dc);
-}
-
-void TabDiveEquipment::on_suit_editingFinished()
-{
-	if (!parent.currentDive)
-		return;
-	divesEdited(Command::editSuit(ui.suit->text(), false));
 }
 
 void TabDiveEquipment::closeWarning()

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -14,6 +14,7 @@ namespace Ui {
 
 class WeightModel;
 class CylindersModel;
+class SuitComponentModel;
 
 class TabDiveEquipment : public TabBase {
 	Q_OBJECT
@@ -28,10 +29,11 @@ private slots:
 	void divesChanged(const QVector<dive *> &dives, DiveField field);
 	void addCylinder_clicked();
 	void addWeight_clicked();
+	void addSuit_clicked();
 	void toggleTriggeredColumn();
 	void editCylinderWidget(const QModelIndex &index);
 	void editWeightWidget(const QModelIndex &index);
-	void on_suit_editingFinished();
+	void editSuitWidget(const QModelIndex &index);
 	void divesEdited(int count);
 	void diveComputerEdited(dive &dive, divecomputer &dc);
 	void cylinderRemoved(struct dive *dive, int);
@@ -41,11 +43,19 @@ private:
 	SuitCompletionModel suitModel;
 	CylindersModel *cylindersModel;
 	WeightModel *weightModel;
+	SuitComponentModel *suitComponentModel;
 
 	TankInfoDelegate tankInfoDelegate;
 	TankUseDelegate tankUseDelegate;
 	SensorDelegate sensorDelegate;
 	WSInfoDelegate wsInfoDelegate;
+	SuitTypeDelegate suitTypeDelegate;
+	SuitInfoDelegate suitInfoDelegate;
+
+	SuitBrandCompletionModel suitBrandCompletionModel;
+	SuitModelCompletionModel suitModelCompletionModel;
+	SuitThicknessCompletionModel suitThicknessCompletionModel;
+
 	void setCylinderColumnVisibility();
 };
 

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.ui
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.ui
@@ -69,19 +69,7 @@
              <enum>Qt::Vertical</enum>
             </property>
             <widget class="TableView" name="cylinders" native="true"/>
-            <widget class="QLabel" name="suitText">
-             <property name="text">
-              <string>Suit</string>
-             </property>
-             <property name="isHeader" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-            <widget class="QLineEdit" name="suit">
-             <property name="readOnly">
-              <bool>false</bool>
-             </property>
-            </widget>
+            <widget class="TableView" name="suit_items" native="true"/>
             <widget class="TableView" name="weights" native="true"/>
            </widget>
           </item>

--- a/qt-models/completionmodels.cpp
+++ b/qt-models/completionmodels.cpp
@@ -93,3 +93,75 @@ bool TagCompletionModel::relevantDiveField(const DiveField &f)
 {
 	return f.tags;
 }
+
+QStringList SuitBrandCompletionModel::getStrings()
+{
+	QSet<QString> set;
+	for (auto &dive: divelog.dives) {
+		for (const auto &item : dive->suit_items)
+			if (!item.brand.empty())
+				set.insert(QString::fromStdString(item.brand));
+	}
+	QStringList list = set.values();
+	std::sort(list.begin(), list.end());
+	return list;
+}
+
+bool SuitBrandCompletionModel::relevantDiveField(const DiveField &f)
+{
+	return f.suit;
+}
+
+QStringList SuitModelCompletionModel::getStrings()
+{
+	QSet<QString> set;
+	for (auto &dive: divelog.dives) {
+		for (const auto &item : dive->suit_items)
+			if (!item.model.empty())
+				set.insert(QString::fromStdString(item.model));
+	}
+	QStringList list = set.values();
+	std::sort(list.begin(), list.end());
+	return list;
+}
+
+bool SuitModelCompletionModel::relevantDiveField(const DiveField &f)
+{
+	return f.suit;
+}
+
+QStringList SuitThicknessCompletionModel::getStrings()
+{
+	QSet<QString> set;
+	for (auto &dive: divelog.dives) {
+		for (const auto &item : dive->suit_items)
+			if (!item.thickness.empty())
+				set.insert(QString::fromStdString(item.thickness));
+	}
+	QStringList list = set.values();
+	std::sort(list.begin(), list.end());
+	return list;
+}
+
+bool SuitThicknessCompletionModel::relevantDiveField(const DiveField &f)
+{
+	return f.suit;
+}
+
+QStringList SuitSizeCompletionModel::getStrings()
+{
+	QSet<QString> set;
+	for (auto &dive: divelog.dives) {
+		for (const auto &item : dive->suit_items)
+			if (!item.size.empty())
+				set.insert(QString::fromStdString(item.size));
+	}
+	QStringList list = set.values();
+	std::sort(list.begin(), list.end());
+	return list;
+}
+
+bool SuitSizeCompletionModel::relevantDiveField(const DiveField &f)
+{
+	return f.suit;
+}

--- a/qt-models/completionmodels.h
+++ b/qt-models/completionmodels.h
@@ -47,4 +47,32 @@ private:
 	bool relevantDiveField(const DiveField &f) override;
 };
 
+class SuitBrandCompletionModel final : public CompletionModelBase {
+	Q_OBJECT
+private:
+	QStringList getStrings() override;
+	bool relevantDiveField(const DiveField &f) override;
+};
+
+class SuitModelCompletionModel final : public CompletionModelBase {
+	Q_OBJECT
+private:
+	QStringList getStrings() override;
+	bool relevantDiveField(const DiveField &f) override;
+};
+
+class SuitThicknessCompletionModel final : public CompletionModelBase {
+	Q_OBJECT
+private:
+	QStringList getStrings() override;
+	bool relevantDiveField(const DiveField &f) override;
+};
+
+class SuitSizeCompletionModel final : public CompletionModelBase {
+	Q_OBJECT
+private:
+	QStringList getStrings() override;
+	bool relevantDiveField(const DiveField &f) override;
+};
+
 #endif // COMPLETIONMODELS_H


### PR DESCRIPTION
Previously, only a single textual suit description was saved for dives. This commit introduces structured tracking of multiple suit components (e.g., boots, gloves, BCD, fins) for dives.

**Key changes include:**
- Added a `suit_component_t` structure and `suit_table` to model individual suit parts, with fields for type, brand, model, thickness, and size.
- Expanded XML file parsing and saving routines to handle these new structured suit details.
- Modified the dive equipment UI to include a table for suit components, replacing the single-line suit description field.
- Implemented dedicated editor delegates (`SuitTypeDelegate`, `SuitInfoDelegate`) to streamline interaction in the suit table.
- Updated data models such as `SuitBrandCompletionModel` and relevant methods to support auto-completions for suit-related fields.
- Introduced logic for merging suit parts during dive merges to prevent duplicates.

This change provides more precise equipment tracking for divers and enhances the application's capabilities, allowing future extensions to accommodate detailed suit insights.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This pull request migrates the dive equipment tracking system from a legacy, single-line textual description to a structured, component-based model. By introducing the suit_component_t structure, users can now track specific pieces of gear—including boots, gloves, BCD, and fins—with granular detail such as brand, model, thickness, and size.

The update includes full-stack support, encompassing data model adjustments, XML serialization updates, and a redesigned UI component to replace the previous free-text field. This provides a more robust and scalable approach to equipment logging, facilitating better data management and enabling future analytical features.

### Changes made:
1) Data Structure: Defined suit_component_t and suit_table to support structured storage of suit elements.

2) Persistence: Updated XML parsing and saving logic to handle the new structured equipment format.

3) UI Implementation: Replaced the legacy single-line suit description field with a dynamic table in the dive equipment interface.

4) Interaction Design: Added SuitTypeDelegate and SuitInfoDelegate to provide specialized editing controls within the equipment table.

5) Auto-completion: Enhanced SuitBrandCompletionModel to provide context-aware suggestions for suit parts.

6) Logic Update: Implemented merge conflict resolution logic to ensure consistency when merging dive profiles with existing suit data.

### Related issues:

### Additional information:
This change involves a schema update for the dive logs. Existing log files will continue to be readable via the updated parser, which will map previous single-line descriptions to a generic "Suit" entry in Notes to ensure backward compatibility.

### Documentation change:
The user experience has changed from a single text input field for "Suit" to an interactive equipment table. Users can now click "Add" to define specific gear components. The user manual should be updated to reflect the ability to manage individual suit parts (boots, gloves, etc.) rather than relying on a manual text description.

### Mentions:
