### PR TITLE
Mobile: fix planner combo boxes writing to the wrong row

### DIFF
--- a/mobile-widgets/qml/DivePlannerEdit.qml
+++ b/mobile-widgets/qml/DivePlannerEdit.qml
@@ -295,9 +295,11 @@ TemplatePage {
 			delegate: RowLayout {
 				width: cylinderListView.width
 				spacing: Kirigami.Units.smallSpacing
+				// give the row index a name that signal arguments cannot shadow
+				readonly property int rowIndex: index
 
 				TemplateLabel {
-					text: index + 1
+					text: rowIndex + 1
 					Layout.preferredWidth: Kirigami.Units.gridUnit * 1.5
 					horizontalAlignment: Text.AlignHCenter
 					verticalAlignment: Text.AlignVCenter
@@ -310,7 +312,7 @@ TemplatePage {
 					onActivated: {
 						if (currentIndex !== -1) {
 							// Update the 'type' property in the model with the selected cylinder text
-							cylinderListModel.setProperty(index, "type", currentText);
+							cylinderListModel.setProperty(rowIndex, "type", currentText);
 
 							// This updates the dive plan summary in real-time
 							generatePlan();
@@ -324,7 +326,7 @@ TemplatePage {
 					text: mix
 					onTextChanged: {
 						if (text !== mix) {
-							cylinderListModel.setProperty(index, "mix", text);
+							cylinderListModel.setProperty(rowIndex, "mix", text);
 							generatePlan();
 						}
 					}
@@ -356,7 +358,7 @@ TemplatePage {
 					visible: overallDivemode.currentIndex == 1
 					onClicked: {
 						// Update 'use': if checked is true, set 'use' to 1 (Diluent); otherwise, set to 0 (OC-gas)
-						cylinderListModel.setProperty(index, "use", checked ? 1 : 0);
+						cylinderListModel.setProperty(rowIndex, "use", checked ? 1 : 0);
 						generatePlan();
 					}
 				}
@@ -368,7 +370,7 @@ TemplatePage {
 					validator: IntValidator { bottom: 0; top: 10000 }
 					onTextChanged: {
 						if (Number(text) !== pressure) {
-							cylinderListModel.setProperty(index, "pressure", Number(text));
+							cylinderListModel.setProperty(rowIndex, "pressure", Number(text));
 							generatePlan();
 						}
 					}
@@ -379,7 +381,7 @@ TemplatePage {
 					font.bold: true
 					enabled: cylinderListModel.count > 1
 					onClicked: {
-						cylinderListModel.remove(index);
+						cylinderListModel.remove(rowIndex);
 						generatePlan();
 					}
 				}
@@ -457,6 +459,8 @@ TemplatePage {
 			delegate: RowLayout {
 				width: segmentListView.width
 				spacing: Kirigami.Units.smallSpacing
+				// give the row index a name that signal arguments cannot shadow
+				readonly property int rowIndex: index
 
 				SsrfTextField {
 					Layout.preferredWidth: Kirigami.Units.gridUnit * 3
@@ -465,7 +469,7 @@ TemplatePage {
 					validator: IntValidator { bottom: 0; top: 900 }
 					onTextChanged: {
 						if (Number(text) !== depth) {
-							segmentListModel.setProperty(index, "depth", Number(text));
+							segmentListModel.setProperty(rowIndex, "depth", Number(text));
 							generatePlan();
 						}
 					}
@@ -479,7 +483,7 @@ TemplatePage {
 					validator: IntValidator { bottom: 1; top: 999 }
 					onTextChanged: {
 						if (Number(text) !== duration) {
-							segmentListModel.setProperty(index, "duration", Number(text));
+							segmentListModel.setProperty(rowIndex, "duration", Number(text));
 							generatePlan();
 						}
 					}
@@ -491,7 +495,7 @@ TemplatePage {
 					model: gasNumberModel
 					currentIndex: gas
 					onActivated: {
-						segmentListModel.setProperty(index, "gas", currentIndex)
+						segmentListModel.setProperty(rowIndex, "gas", currentIndex)
 						generatePlan();
 					}
 					onActiveFocusChanged: segmentListView.interactive = !activeFocus
@@ -512,7 +516,7 @@ TemplatePage {
 					onTextChanged: {
 						if (cylinderListModel.get(gas) && cylinderListModel.get(gas).use === 1) {
 							if (Math.round(Number(text) * 1000) !== setpoint) {
-								segmentListModel.setProperty(index, "setpoint", Math.round(Number(text) * 1000));
+								segmentListModel.setProperty(rowIndex, "setpoint", Math.round(Number(text) * 1000));
 								generatePlan();
 							}
 						}
@@ -527,7 +531,7 @@ TemplatePage {
 					currentIndex: divemode === 2 ? 1 : divemode
 					visible: overallDivemode.currentIndex == 2
 					onActivated: {
-						segmentListModel.setProperty(index, "divemode", currentIndex === 1 ? 2 : currentIndex);
+						segmentListModel.setProperty(rowIndex, "divemode", currentIndex === 1 ? 2 : currentIndex);
 						generatePlan();
 					}
 					onActiveFocusChanged: segmentListView.interactive = !activeFocus
@@ -538,7 +542,7 @@ TemplatePage {
 					font.bold: true
 					enabled: segmentListModel.count > 1
 					onClicked: {
-						segmentListModel.remove(index);
+						segmentListModel.remove(rowIndex);
 						generatePlan();
 					}
 


### PR DESCRIPTION
### Describe the pull request:
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
In the mobile dive planner the activated signal of a ComboBox comes with
an index argument that shadows the row index of the delegate in the old
style signal handlers. So changing a cylinder type, a segment gas or a
segment dive mode wrote to the row matching the position of the selection
in the drop down instead of the row being edited. With a single cylinder
the write was simply out of range and silently dropped (only a "set:
index N out of range" warning on the console), so the plan was always
calculated with the default AL80 - which is why the gas volume to tank
pressure conversion always assumed roughly 11l no matter which tank was
selected.

The cylinder type handler regressed when commit f7d8bd43f replaced the
undefined parent.index with the shadowed index; the two segment handlers
when commit 970d22ed6 switched them from onCurrentIndexChanged (which has
no arguments) to onActivated. This matches the report that 6.0.5576 was
still fine.

The fix names the signal argument explicitly so that the unqualified
index resolves to the delegate row again, same as the surrounding
onTextChanged handlers.

### Changes made:
1) Cylinder type combo box: name the activated signal argument so the
   model write targets the delegate row
2) Segment gas combo box: same
3) Segment dive mode combo box: same

### Related issues:
Fixes #4819

### Additional information:
Easy to reproduce in the planner: with a single cylinder, pick any tank
other than the first drop down entry and compare the gas volume to
pressure ratio in the plan output - it stays at the AL80 value. With two
or more cylinders the change is applied to the wrong row instead. The
shadowing mechanism can also be demonstrated with a small standalone QML
testcase (ComboBox inside a ListView delegate), happy to attach it if
useful.

### Documentation change:
None, this restores the intended behavior.

### Mentions:

