### PR TITLE
[fix] android: Use timeout for USB serial driver read

### DIFF
--- a/android-mobile/src/org/subsurfacedivelog/mobile/AndroidSerial.java
+++ b/android-mobile/src/org/subsurfacedivelog/mobile/AndroidSerial.java
@@ -269,7 +269,7 @@ public class AndroidSerial {
 			while (toReadFromHwLength > 0 && (startTime + timeout > (new Date()).getTime() || timeout == 0)) {
 				// Read and append to buffer
 				byte[] readFromHwData = new byte[arraylength];
-				int actuallyReadFromHwLength = usbSerialPort.read(readFromHwData, 0); // This behaves differently on different chipsets. CP210x blocks, FTDI seems to return instantly.
+				int actuallyReadFromHwLength = usbSerialPort.read(readFromHwData, timeout); // This behaves differently on different chipsets. CP210x blocks, FTDI seems to return instantly.
 				for (int i = 0; i < actuallyReadFromHwLength; i++ ) {
 					readBuffer.add(readFromHwData[i]);
 				}


### PR DESCRIPTION
Fixes issue #4883

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->

Even though there's a timeout handling routine for serial read, the actual access to the underlying USB serial driver used a blocking, indefinite read. This would result in the timeout mechanism only to kick in after a new byte was received, defeating the purpose of the timeout.

With this change the previously configured timeout is also handed over to the usb-serial-for-android libraries `UsbSerialPort.read` function, actually enabling the timeout mechanism.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) using timeouted read from `UsbSerialPort` instead of infinite wait

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4883
