### PR TITLE
Desktop: Improve the Merge of Weight Systems.

### DIFF
--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -1857,21 +1857,34 @@ static void merge_cylinders(struct dive &res, const struct dive &a, const struct
 	}
 }
 
-/* Check whether a weightsystem table contains a given weightsystem */
-static bool has_weightsystem(const weightsystem_table &t, const weightsystem_t &w)
-{
-	return any_of(t.begin(), t.end(), [&w] (auto &w2) { return w == w2; });
-}
-
 static void merge_equipment(struct dive &res, const struct dive &a, const struct dive &b)
 {
-	for (auto &ws: a.weightsystems) {
-		if (!has_weightsystem(res.weightsystems, ws))
-			res.weightsystems.push_back(ws);
+	/* Produce the multiset union of the two weightsystem lists:
+	 * For each distinct weightsystem, include max(count_in_a, count_in_b) copies.
+	 * This means:
+	 * - Weights that exist only in one dive are kept as-is.
+	 * - Weights that are identical in both dives are de-duplicated.
+	 * - If one dive has more copies of a weight than the other, the higher
+	 *   count is kept (rather than adding them all up, which would be wrong).
+	 */
+	// Track which entries in b have already been "consumed" by a match in a.
+	std::vector<bool> b_matched(b.weightsystems.size(), false);
+
+	for (const auto &ws_a: a.weightsystems) {
+		res.weightsystems.push_back(ws_a);
+		// Mark one matching entry in b as consumed, so it doesn't get added again.
+		for (size_t j = 0; j < b.weightsystems.size(); ++j) {
+			if (!b_matched[j] && b.weightsystems[j] == ws_a) {
+				b_matched[j] = true;
+				break;
+			}
+		}
 	}
-	for (auto &ws: b.weightsystems) {
-		if (!has_weightsystem(res.weightsystems, ws))
-			res.weightsystems.push_back(ws);
+	// Add any unmatched entries from b (i.e. those not present in a at all, or
+	// present fewer times in a than in b).
+	for (size_t j = 0; j < b.weightsystems.size(); ++j) {
+		if (!b_matched[j])
+			res.weightsystems.push_back(b.weightsystems[j]);
 	}
 }
 

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "qt-models/weightmodel.h"
 #include "core/subsurface-string.h"
+#include <QScopedValueRollback>
 #include "core/gettextfromc.h"
 #include "core/metrics.h"
 #include "core/qthelper.h"
@@ -78,6 +79,16 @@ QVariant WeightModel::data(const QModelIndex &index, int role) const
 // Ownership of passed in weight system will be taken. Caller must not use it any longer.
 void WeightModel::setTempWS(int row, weightsystem_t ws)
 {
+	// Guard against re-entrant calls: emitting dataChanged causes the view to
+	// call setEditorData → QComboBox::setCurrentIndex → textHighlighted signal
+	// → testActivationString → setModelData → back into setTempWS.  Without
+	// this guard the recursion is unbounded and crashes the application.
+	// Use QScopedValueRollback so the flag is always cleared when we return,
+	// even if an exception or early return occurs inside.
+	if (inSetTempWS)
+		return;
+	QScopedValueRollback<bool> guard(inSetTempWS, true);
+
 	if (!d || row < 0 || static_cast<size_t>(row) >= d->weightsystems.size()) // Sanity check: row must exist
 		return;
 
@@ -113,15 +124,28 @@ void WeightModel::clearTempWS()
 void WeightModel::commitTempWS()
 {
 #ifndef SUBSURFACE_MOBILE
-	if (tempRow < 0 || !d || static_cast<size_t>(tempRow) > d->weightsystems.size())
+	if (tempRow < 0 || !d || static_cast<size_t>(tempRow) >= d->weightsystems.size()) {
+		// Row is no longer valid (e.g. dive changed or row removed while an
+		// editor was open). Clear the temporary state so the model does not
+		// stay stuck reporting tempWS. Don't emit dataChanged for a row that
+		// may not exist any longer.
+		tempRow = -1;
+		tempWS = weightsystem_t();
 		return;
+	}
 	// Only submit a command if the type changed
 	weightsystem_t ws = d->weightsystems[tempRow];
 	if (ws.description != tempWS.description || gettextFromC::tr(ws.description.c_str()) != QString::fromStdString(tempWS.description)) {
-		int count = Command::editWeight(tempRow, tempWS, false);
+		// Clear tempRow before the command is executed to avoid re-entrant
+		// access via signals emitted during command execution.
+		int row = tempRow;
+		weightsystem_t newWS = std::move(tempWS);
+		tempRow = -1;
+		int count = Command::editWeight(row, std::move(newWS), false);
 		emit divesEdited(count);
+	} else {
+		tempRow = -1;
 	}
-	tempRow = -1;
 #endif
 }
 

--- a/qt-models/weightmodel.h
+++ b/qt-models/weightmodel.h
@@ -44,6 +44,10 @@ private:
 	// If we temporarily change a line because the user is selecting a weight type
 	int tempRow;
 	weightsystem_t tempWS;
+	// Re-entry guard: setTempWS emits dataChanged, which causes the view to call
+	// setEditorData → QComboBox::setCurrentIndex → textHighlighted → setModelData
+	// → setTempWS again.  This flag breaks the recursive cycle.
+	bool inSetTempWS = false;
 };
 
 #endif

--- a/tests/testmerge.cpp
+++ b/tests/testmerge.cpp
@@ -4,6 +4,7 @@
 #include "core/dive.h" // for save_dives()
 #include "core/divelog.h"
 #include "core/divesite.h"
+#include "core/equipment.h"
 #include "core/file.h"
 #include "core/trip.h"
 #include "core/pref.h"
@@ -64,6 +65,101 @@ void TestMerge::testMergeBackwards()
 	QStringList written = outS.readAll().split("\n");
 	while (readin.size() && written.size())
 		QCOMPARE(written.takeFirst().trimmed(), readin.takeFirst().trimmed());
+}
+
+void TestMerge::testMergeWeights()
+{
+	// Helper lambda to make a weightsystem_t
+	auto make_ws = [](int grams, const char *description) -> weightsystem_t {
+		return weightsystem_t { weight_t{ .grams = grams }, std::string(description), false };
+	};
+
+	// Helper lambda to count occurrences of a weightsystem in a table
+	auto count_ws = [](const weightsystem_table &table, const weightsystem_t &ws) {
+		return static_cast<int>(std::count(table.begin(), table.end(), ws));
+	};
+
+	// --- Test 1: Bug #4888 ---
+	// Both dives have 3×1kg "Weight" → merged should have exactly 3, not 1.
+	{
+		dive a, b;
+		for (int i = 0; i < 3; i++) {
+			a.weightsystems.push_back(make_ws(1000, "belt"));
+			b.weightsystems.push_back(make_ws(1000, "belt"));
+		}
+		auto merged = dive::create_merged_dive(a, b, 0, false);
+		QCOMPARE(count_ws(merged->weightsystems, make_ws(1000, "belt")), 3);
+		QCOMPARE(static_cast<int>(merged->weightsystems.size()), 3);
+	}
+
+	// --- Test 2: A has more than B ---
+	// A: 3×1kg, B: 2×1kg → merged: 3×1kg (take max)
+	{
+		dive a, b;
+		for (int i = 0; i < 3; i++)
+			a.weightsystems.push_back(make_ws(1000, "belt"));
+		for (int i = 0; i < 2; i++)
+			b.weightsystems.push_back(make_ws(1000, "belt"));
+		auto merged = dive::create_merged_dive(a, b, 0, false);
+		QCOMPARE(count_ws(merged->weightsystems, make_ws(1000, "belt")), 3);
+		QCOMPARE(static_cast<int>(merged->weightsystems.size()), 3);
+	}
+
+	// --- Test 3: B has more than A ---
+	// A: 1×1kg, B: 3×1kg → merged: 3×1kg (take max)
+	{
+		dive a, b;
+		a.weightsystems.push_back(make_ws(1000, "belt"));
+		for (int i = 0; i < 3; i++)
+			b.weightsystems.push_back(make_ws(1000, "belt"));
+		auto merged = dive::create_merged_dive(a, b, 0, false);
+		QCOMPARE(count_ws(merged->weightsystems, make_ws(1000, "belt")), 3);
+		QCOMPARE(static_cast<int>(merged->weightsystems.size()), 3);
+	}
+
+	// --- Test 4: Distinct weights from each dive are all kept ---
+	// A: 1×2kg ankle, B: 1×3kg belt → merged: both
+	{
+		dive a, b;
+		a.weightsystems.push_back(make_ws(2000, "ankle"));
+		b.weightsystems.push_back(make_ws(3000, "belt"));
+		auto merged = dive::create_merged_dive(a, b, 0, false);
+		QCOMPARE(count_ws(merged->weightsystems, make_ws(2000, "ankle")), 1);
+		QCOMPARE(count_ws(merged->weightsystems, make_ws(3000, "belt")), 1);
+		QCOMPARE(static_cast<int>(merged->weightsystems.size()), 2);
+	}
+
+	// --- Test 5: Mixed – A has 1×1kg + 1×2kg, B has 2×1kg ---
+	// Merged: 2×1kg + 1×2kg (the 1kg count is max(1,2)=2; 2kg is unique to A)
+	{
+		dive a, b;
+		a.weightsystems.push_back(make_ws(1000, "belt"));
+		a.weightsystems.push_back(make_ws(2000, "belt"));
+		b.weightsystems.push_back(make_ws(1000, "belt"));
+		b.weightsystems.push_back(make_ws(1000, "belt"));
+		auto merged = dive::create_merged_dive(a, b, 0, false);
+		QCOMPARE(count_ws(merged->weightsystems, make_ws(1000, "belt")), 2);
+		QCOMPARE(count_ws(merged->weightsystems, make_ws(2000, "belt")), 1);
+		QCOMPARE(static_cast<int>(merged->weightsystems.size()), 3);
+	}
+
+	// --- Test 6: One dive has no weights ---
+	// A: 2×1kg, B: empty → merged: 2×1kg
+	{
+		dive a, b;
+		a.weightsystems.push_back(make_ws(1000, "belt"));
+		a.weightsystems.push_back(make_ws(1000, "belt"));
+		auto merged = dive::create_merged_dive(a, b, 0, false);
+		QCOMPARE(count_ws(merged->weightsystems, make_ws(1000, "belt")), 2);
+		QCOMPARE(static_cast<int>(merged->weightsystems.size()), 2);
+	}
+
+	// --- Test 7: Both dives have no weights ---
+	{
+		dive a, b;
+		auto merged = dive::create_merged_dive(a, b, 0, false);
+		QCOMPARE(static_cast<int>(merged->weightsystems.size()), 0);
+	}
 }
 
 QTEST_GUILESS_MAIN(TestMerge)

--- a/tests/testmerge.h
+++ b/tests/testmerge.h
@@ -12,6 +12,7 @@ private slots:
 
 	void testMergeEmpty();
 	void testMergeBackwards();
+	void testMergeWeights();
 };
 
 #endif


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

> [!IMPORTANT]
> Translations are managed through Transifex. Do not open pull requests that
> directly edit translation files. See the
> [translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
When merging dives, treat weight systems as the multisets that they are:
If more than one entry of the same type / weight exists in one dive, add
all of them to the merged dive.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. when merging dives, treat weight systems as the multisets that they are: If more than one entry of the same type / weight exists in one dive, add all of them to the merged dive;
2. fix a crash when changing the type of an existing weight system.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4888.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Reported-by: @Fixer-11
