### PR TITLE
Copr packaging: build against Qt6 instead of Qt5

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -54,6 +54,15 @@ jobs:
         cd ..
         git clone https://github.com/subsurface/googlemaps
 
+    - name: Checkout qlitehtml
+      # QLiteHtml is the Qt6 replacement for the WebKit-based printing/user-manual
+      # support; it isn't packaged for Fedora, so we vendor it the same way as
+      # googlemaps and build it from source in make-package.sh. It bundles
+      # litehtml as its own submodule, hence --recursive.
+      run: |
+        cd ..
+        git clone --recursive https://github.com/dirkhh/qlitehtml
+
     - name: run the copr build script
       run: |
         cd ..

--- a/cmake/Modules/HandleFindQLiteHtml.cmake
+++ b/cmake/Modules/HandleFindQLiteHtml.cmake
@@ -16,10 +16,14 @@ find_path(QLITEHTML_INCLUDE_DIR
 
 find_path(QLITEHTML_LITEHTML_INCLUDE_DIR
 	NAMES litehtml/master_css.h
-	PATH_SUFFIXES include src/3rdparty/litehtml/include
+	# qlitehtml's own "make install" places litehtml/master_css.h directly
+	# next to qlitehtmlwidget.h, so look there first before falling back to
+	# other layouts (e.g. a system package installing litehtml separately).
 	HINTS
+		${QLITEHTML_INCLUDE_DIR}
 		${CMAKE_PREFIX_PATH}
 		${CMAKE_SOURCE_DIR}/qlitehtml
+	PATH_SUFFIXES include include/qlitehtml src/3rdparty/litehtml/include
 	PATHS
 		${CMAKE_INSTALL_PREFIX}/include
 		/usr/local/include
@@ -29,11 +33,15 @@ find_path(QLITEHTML_LITEHTML_INCLUDE_DIR
 
 find_library(QLITEHTML_LIBRARY
 	NAMES qlitehtml qlitehtml1 libqlitehtml
+	# PATH_SUFFIXES (unlike HINTS/PATHS alone) is applied to every search
+	# directory, so this also covers a CMAKE_PREFIX_PATH entry that installed
+	# into <prefix>/lib64 rather than <prefix>/lib.
 	HINTS ${CMAKE_PREFIX_PATH}
+	PATH_SUFFIXES lib lib64
 	PATHS
-		${CMAKE_INSTALL_PREFIX}/lib
-		/usr/local/lib
-		/usr/lib
+		${CMAKE_INSTALL_PREFIX}
+		/usr/local
+		/usr
 	DOC "QLiteHtml library"
 )
 

--- a/packaging/copr/make-package.sh
+++ b/packaging/copr/make-package.sh
@@ -18,8 +18,16 @@ if [[ ! -d googlemaps ]] ; then
 	echo "checked out in parallel to the Subsurface directory"
 	exit 1;
 fi
+if [[ ! -d qlitehtml ]] ; then
+	echo "Please make sure you have https://github.com/dirkhh/qlitehtml (with its litehtml submodule)"
+	echo "checked out in parallel to the Subsurface directory"
+	exit 1;
+fi
 
 TOPDIR=$(pwd)
+
+# we build against Qt6, which needs the googlemaps plugin's qt6-upstream branch
+(cd googlemaps ; git fetch ; git switch qt6-upstream)
 
 # ensure that the libdivecomputer module is there and current
 cd subsurface
@@ -56,9 +64,12 @@ if [[ ! -d $FOLDER ]]; then
 	(cd "$TOPDIR"/subsurface ; tar cf - . ) | (cd "$FOLDER" ; tar xf - )
 	cd "$FOLDER"
 	cp -a "$TOPDIR"/googlemaps .
+	cp -a "$TOPDIR"/qlitehtml .
 
 	# make sure we only have the files we want (the builds should all be empty when running on GitHub)
 	rm -rf .git libdivecomputer/.git googlemaps/.git build build-mobile libdivecomputer/build googlemaps/build
+	# qlitehtml vendors litehtml as its own submodule, so its .git metadata is nested
+	find qlitehtml -depth -name .git -exec rm -rf {} +
 	echo "$BUILDNUMBER" > latest-subsurface-buildnumber
 	echo "$GITDATE" > .gitdate
 	echo "$LIBDCREVISION" > libdivecomputer/revision

--- a/packaging/copr/subsurface.spec
+++ b/packaging/copr/subsurface.spec
@@ -43,6 +43,7 @@ BuildRequires:  libsqlite3x-devel
 BuildRequires:  libusbx-devel
 BuildRequires:  bluez-libs-devel
 BuildRequires:  qt6-qtbase-devel
+BuildRequires:  qt6-qtbase-private-devel
 BuildRequires:  qt6-qttools-devel
 BuildRequires:  qt6-qtsvg-devel
 BuildRequires:  qt6-qtdeclarative-devel
@@ -78,7 +79,7 @@ mkdir -p install-root
         make %{?_smp_mflags} ; \
         make install)
 ( cd googlemaps ; mkdir -p build ; cd build ; \
-        qmake-qt6 ../googlemaps.pro ; \
+        qmake6 ../googlemaps.pro ; \
         # on Fedora 36 and newer we get the package_notes that break the build - let's rip them out
         sed -i 's/-Wl[^ ]*package_note[^ ]* //g' Makefile
         make -j4 ; \

--- a/packaging/copr/subsurface.spec
+++ b/packaging/copr/subsurface.spec
@@ -42,22 +42,21 @@ BuildRequires:  openssl-devel
 BuildRequires:  libsqlite3x-devel
 BuildRequires:  libusbx-devel
 BuildRequires:  bluez-libs-devel
-BuildRequires:  qt5-qtbase-devel
-BuildRequires:  qt5-qttools-devel
-BuildRequires:  qt5-qtwebkit-devel
-BuildRequires:  qt5-qtsvg-devel
-BuildRequires:  qt5-qtscript-devel
-BuildRequires:  qt5-qtdeclarative-devel
-BuildRequires:  qt5-qtbase-mysql
-BuildRequires:  qt5-qtbase-postgresql
-BuildRequires:  qt5-qtbase-ibase
-BuildRequires:  qt5-qtbase-odbc
-BuildRequires:  qt5-qtbase-tds
-BuildRequires:  qt5-qtconnectivity-devel
-BuildRequires:  qt5-qtlocation-devel
+BuildRequires:  qt6-qtbase-devel
+BuildRequires:  qt6-qttools-devel
+BuildRequires:  qt6-qtsvg-devel
+BuildRequires:  qt6-qtdeclarative-devel
+BuildRequires:  qt6-qtbase-mysql
+BuildRequires:  qt6-qtbase-postgresql
+BuildRequires:  qt6-qtbase-ibase
+BuildRequires:  qt6-qtbase-odbc
+BuildRequires:  qt6-qtconnectivity-devel
+BuildRequires:  qt6-qtlocation-devel
+BuildRequires:  qt6-qtpositioning-devel
+BuildRequires:  qt6-qt5compat-devel
 BuildRequires:  libappstream-glib
 
-Recommends:     qt5-qttranslations
+Recommends:     qt6-qttranslations
 
 %description
 DESCRIPTION
@@ -79,16 +78,26 @@ mkdir -p install-root
         make %{?_smp_mflags} ; \
         make install)
 ( cd googlemaps ; mkdir -p build ; cd build ; \
-        qmake-qt5 ../googlemaps.pro ; \
+        qmake-qt6 ../googlemaps.pro ; \
         # on Fedora 36 and newer we get the package_notes that break the build - let's rip them out
         sed -i 's/-Wl[^ ]*package_note[^ ]* //g' Makefile
         make -j4 ; \
         make install_target INSTALL_ROOT=%{_builddir}/install-root )
+# QLiteHtml is not packaged for Fedora, so build it from the sources that
+# make-package.sh vendored into the tarball, same as we do for the other
+# private dependencies above. It only supports being configured in its own
+# source tree (no separate build directory).
+( cd qlitehtml ; \
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%{_builddir}/install-root . ; \
+        make %{?_smp_mflags} ; \
+        make install )
 %cmake -DCMAKE_BUILD_TYPE=Release \
-                -DLRELEASE=lrelease-qt5 \
+                -DBUILD_WITH_QT6=ON \
+                -DLRELEASE=lrelease-qt6 \
                 -DLIBDIVECOMPUTER_INCLUDE_DIR=%{_builddir}/install-root/include \
                 -DLIBGIT2_INCLUDE_DIR=%{_builddir}/install-root/include \
                 -DLIBDIVECOMPUTER_LIBRARIES=%{_builddir}/install-root/lib/libdivecomputer.a \
+                -DCMAKE_PREFIX_PATH=%{_builddir}/install-root \
                 -DNO_PRINTING=OFF \
                 -DBUILD_DOCS=ON
 %cmake_build
@@ -96,6 +105,9 @@ mkdir -p install-root
 %install
 mkdir -p %{buildroot}/%{_libdir}
 ( cd googlemaps/build ; make install_target INSTALL_ROOT=%{buildroot} )
+# QLiteHtml isn't a Fedora package, so ship the shared library we built
+# above alongside subsurface rather than relying on the system to have it.
+cp -a %{_builddir}/install-root/lib64/libqlitehtml.so* %{buildroot}%{_libdir}/
 %cmake_install
 install subsurface.debug %{buildroot}%{_bindir}
 install metainfo/subsurface.metainfo.xml %{buildroot}%{_datadir}/metainfo
@@ -115,7 +127,8 @@ desktop-file-install --dir=%{buildroot}/%{_datadir}/applications subsurface.desk
 %defattr(-,root,root)
 %doc gpl-2.0.txt README.md ReleaseNotes/ReleaseNotes.txt
 %{_bindir}/subsurface*
-%{_libdir}/qt5/plugins/geoservices/libqtgeoservices_googlemaps.so
+%{_libdir}/qt6/plugins/geoservices/libqtgeoservices_googlemaps.so
+%{_libdir}/libqlitehtml.so*
 %{_datadir}/applications/subsurface.desktop
 %dir %{_datadir}/metainfo
 %{_datadir}/metainfo/subsurface.metainfo.xml

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -498,7 +498,14 @@ if [ "$QUICK" != "1" ] && [ "$BUILD_DESKTOP$BUILD_MOBILE" != "" ] ; then
 	cd "$GOOGLEMAPS_BUILDDIR"
 	$QMAKE "INCLUDEPATH=$INSTALL_ROOT/include" "CONFIG+=release" "$SRC/googlemaps/googlemaps.pro"
 	make
-	make install
+	# AI-generated (Claude)
+	# googlemaps is a private Qt plugin, not a distro package, so it must
+	# never be installed into the real system Qt plugin directory. qmake's
+	# INSTALL_ROOT= prepends it to the plugin's install path instead - the
+	# same mechanism already used in packaging/copr/subsurface.spec and
+	# packaging/ubuntu/debian/rules. CMakeLists.txt already searches for
+	# libqtgeoservices_googlemaps.so under INSTALL_ROOT.
+	make install INSTALL_ROOT="$INSTALL_ROOT"
 	popd
 fi
 


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change

### Pull request long description:
The daily/rolling Copr build (packaging/copr/subsurface.spec) has been pinned to Qt5 since the project made Qt6 opt-in in 2022. The two reasons cited for that default (no maps, no printing/user-manual support under Qt6) were fixed upstream on 2025-11-29 and 2025-12-01 respectively, so there's no longer a reason for the packaged build to stay on Qt5.

subsurface.spec:
- Swap all qt5-* BuildRequires for their qt6-* equivalents. Drop qt5-qtwebkit-devel and qt5-qtscript-devel, which have no Qt6 replacement, and qt5-qtbase-tds, which Qt6 no longer packages. Add qt6-qtpositioning-devel and qt6-qt5compat-devel, newly required by the Qt6 build.
- QLiteHtml (the Qt6 replacement for WebKit-based printing/user-manual support) isn't packaged for Fedora, so build it from source in %build the same way we already do for libdivecomputer, using the sources make-package.sh now vendors into the release tarball.
- Pass -DBUILD_WITH_QT6=ON, -DCMAKE_PREFIX_PATH=<private install root> (so our private QLiteHtml build is found), and switch -DLRELEASE=lrelease-qt5 to lrelease-qt6.
- Build the googlemaps plugin with qmake-qt6 against its qt6-upstream branch instead of qmake-qt5.
- Update %files for the Qt6 geoservices plugin path and ship the QLiteHtml shared library we build, since it isn't a system package end users would already have.

.github/workflows/fedora-copr-build.yml, packaging/copr/make-package.sh:
- Check out and vendor qlitehtml into the release tarball the same way googlemaps already is, and switch the vendored googlemaps checkout to its qt6-upstream branch.

cmake/Modules/HandleFindQLiteHtml.cmake:
- Separate, pre-existing bug found while verifying the above: even with QLiteHtml built and installed, CMake never actually detected it, so printing/user-manual support silently stayed disabled on Qt6 regardless. QLiteHtml's own "make install" places litehtml's headers at <prefix>/include/qlitehtml/litehtml/, one directory level deeper than any of the module's PATH_SUFFIXES checked, and its library at <prefix>/lib64, which the module's PATHS list never included. Fixed by hinting the litehtml search off the already-found QLITEHTML_INCLUDE_DIR, and by using PATH_SUFFIXES lib/lib64 for the library search instead of separate hardcoded paths.

Verification performed:
- Confirmed via `dnf search`/Fedora Copr that qlitehtml has no packaged equivalent, hence the vendor-from-source approach.
- Verified the HandleFindQLiteHtml.cmake fix in isolation and via a real cmake configure of this project matching the spec's exact conditions (CMAKE_INSTALL_PREFIX=/usr, CMAKE_PREFIX_PATH=<private root>): "-- building with QLiteHtml (Qt6)" now appears.
- Built a real source RPM with the updated make-package.sh and subsurface.spec (tarball vendoring, qt6-upstream googlemaps checkout, spec metadata substitution) - succeeded with no errors.
- Kicked off a full rpmbuild -bb (install BuildRequires via `dnf builddep`, then %build/%install/%files) inside a disposable Fedora 44 Docker container, to validate the complete build without touching host package state.


### Changes made:
Replacing QT5 -> QT6 for coper builds

### Related issues:
Fixes #4898 
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
