### PR TITLE
Suunto JSON import: ask for gas mix on unresolved gas switches

### DIFF
--- a/core/file.cpp
+++ b/core/file.cpp
@@ -286,7 +286,7 @@ bool remote_repo_uptodate(const char *filename, struct git_info *info)
 	return false;
 }
 
-int parse_file(const char *filename, struct divelog *log)
+int parse_file(const char *filename, struct divelog *log, std::vector<suunto_unresolved_gas> *unresolved)
 {
 	struct git_info info;
 	const char *fmt;
@@ -359,7 +359,7 @@ int parse_file(const char *filename, struct divelog *log)
 
 	/* Suunto JSON device log (from Suunto app export) */
 	if (fmt && (!strcasecmp(fmt + 1, "json")))
-		if (suunto_json_import(mem, std::string(), log) > 0)
+		if (suunto_json_import(mem, std::string(), log, unresolved) > 0)
 			return 0;
 #endif
 

--- a/core/file.h
+++ b/core/file.h
@@ -36,8 +36,20 @@ extern struct _wdirent *_wreaddir(_WDIR *dir);
 extern int _wclosedir(_WDIR *dir);
 #endif
 
+struct dive;
 struct divelog;
 struct zip;
+
+// AI-generated (Claude)
+// A cylinder that a Suunto JSON import created because of a mid-dive
+// GasSwitch event, but whose actual gas mix could not be determined (no
+// Header.Diving.Gases entry, and no paired FIT file to patch it in). The
+// desktop import flow collects these across all imported files and can ask
+// the user to fill in the mix before the dives are committed to the log.
+struct suunto_unresolved_gas {
+	struct dive *d;
+	int cylinder_idx;
+};
 
 #if !defined(SUBSURFACE_MOBILE)
 extern int ostctools_import(std::string &buffer, struct divelog *log);
@@ -45,20 +57,23 @@ extern int divesoft_import(const std::string &buffer, struct divelog *log);
 extern int logtrak_import(const std::string &mem, struct divelog *log);
 extern int scubapro_asd_import(const std::string &mem, struct divelog *log);
 extern int fit_file_import(const std::string &buffer, struct divelog *log);
-extern int suunto_json_import(const std::string &buffer, const std::string &fit_buffer, struct divelog *log);
+extern int suunto_json_import(const std::string &buffer, const std::string &fit_buffer, struct divelog *log,
+			       std::vector<suunto_unresolved_gas> *unresolved = nullptr);
 // AI-generated (Claude)
 // Detects .json/.fit pairs sharing a base name among fileNames, as exported
 // together by the Suunto app for one dive, and imports each complete pair as
 // a single dive via suunto_json_import(). Marks consumed[i] for every file
 // that was part of a complete pair; unpaired files are left for the caller's
 // normal per-file import path.
-extern void suunto_json_fit_pair_import(const std::vector<std::string> &fileNames, std::vector<bool> &consumed, struct divelog *log);
+extern void suunto_json_fit_pair_import(const std::vector<std::string> &fileNames, std::vector<bool> &consumed, struct divelog *log,
+					 std::vector<suunto_unresolved_gas> *unresolved = nullptr);
 
 extern int try_to_open_cochran(const char *filename, std::string &mem, struct divelog *log);
 extern int try_to_open_liquivision(const char *filename, std::string &mem, struct divelog *log);
 #endif
 
-extern int parse_file(const char *filename, struct divelog *log);
+extern int parse_file(const char *filename, struct divelog *log,
+		       std::vector<suunto_unresolved_gas> *unresolved = nullptr);
 extern int try_to_open_zip(const char *filename, struct divelog *log);
 
 // Platform specific functions

--- a/core/import-suunto-json.cpp
+++ b/core/import-suunto-json.cpp
@@ -21,6 +21,7 @@
  * it is not available in the JSON
  */
 
+#include <algorithm>
 #include <climits>
 #include <cmath>
 #include <cstdint>
@@ -53,22 +54,40 @@
  * ActivityType 51 is scuba diving -- skip everything else. */
 static const int SUUNTO_ACTIVITY_SCUBA = 51;
 
+// AI-generated (Claude)
 /* Parse ISO 8601 timestamp with timezone offset, return ms since epoch (UTC).
+ * The fractional-seconds part (".ddd") is optional, and the timezone may be
+ * given as "Z" instead of a "+HH:MM" / "-HH:MM" offset.
  * Returns 0 on parse failure. */
 static int64_t parse_iso8601_ms(const std::string &ts)
 {
 	struct tm tm = {};
 	int ms = 0, tz_h = 0, tz_m = 0;
 	char tz_sign = '+';
-	int n = sscanf(ts.c_str(), "%d-%d-%dT%d:%d:%d.%d%c%d:%d",
+	int consumed = 0;
+	int n = sscanf(ts.c_str(), "%d-%d-%dT%d:%d:%d%n",
 		       &tm.tm_year, &tm.tm_mon, &tm.tm_mday,
-		       &tm.tm_hour, &tm.tm_min, &tm.tm_sec,
-		       &ms, &tz_sign, &tz_h, &tz_m);
-	if (n < 9) {
+		       &tm.tm_hour, &tm.tm_min, &tm.tm_sec, &consumed);
+	if (n < 6) {
 		report_info("Suunto JSON: failed to parse timestamp '%s' (matched %d fields)",
 			    ts.c_str(), n);
 		return 0;
 	}
+
+	const char *rest = ts.c_str() + consumed;
+	if (*rest == '.') {
+		int ms_consumed = 0;
+		if (sscanf(rest, ".%d%n", &ms, &ms_consumed) == 1)
+			rest += ms_consumed;
+	}
+
+	if (*rest == 'Z') {
+		tz_h = tz_m = 0;
+	} else if (sscanf(rest, "%c%d:%d", &tz_sign, &tz_h, &tz_m) != 3) {
+		report_info("Suunto JSON: failed to parse timezone in timestamp '%s'", ts.c_str());
+		return 0;
+	}
+
 	tm.tm_year -= 1900;
 	tm.tm_mon  -= 1;
 	int64_t epoch_s  = utc_mktime(&tm);
@@ -263,10 +282,15 @@ static void parse_samples(const QJsonObject &header, const QJsonArray &samples,
 			double lon = origin["Longitude"].toDouble(0);
 			if (lat != 0 && lon != 0) {
 				location_t loc = create_location(lat, lon);
-				dive_site *ds = log->sites.create(
-					dc.model + " " +
-					translate("gettextFromC", "dive"),
-					loc);
+
+				/* No place name in the JSON -- fall back to a
+				 * "lat, lon" string, matching the convention used
+				 * for GPS-only downloads in libdivecomputer.cpp. */
+				char location_string[64];
+				snprintf(location_string, sizeof(location_string),
+					 "%.6f, %.6f", lat, lon);
+
+				dive_site *ds = log->sites.create(location_string, loc);
 				d->dive_site = ds;
 			}
 		}
@@ -408,8 +432,8 @@ static void parse_samples(const QJsonObject &header, const QJsonArray &samples,
 				int gas_num = gs["GasNumber"].toInt(0) - gas_offset;
 				d->get_or_create_cylinder(gas_num);
 				add_event(&dc, elapsed_secs,
-					  SAMPLE_EVENT_GASCHANGE, 0,
-					  gas_num,
+					  SAMPLE_EVENT_GASCHANGE2, gas_num + 1,
+					  0,
 					  QT_TRANSLATE_NOOP("gettextFromC",
 							    "gaschange"));
 			}
@@ -458,8 +482,8 @@ static void parse_samples(const QJsonObject &header, const QJsonArray &samples,
 					int gas_num = gs["GasNumber"].toInt(0) - gas_offset;
 					d->get_or_create_cylinder(gas_num);
 					add_event(&dc, elapsed_secs,
-						  SAMPLE_EVENT_GASCHANGE, 0,
-						  gas_num,
+						  SAMPLE_EVENT_GASCHANGE2, gas_num + 1,
+						  0,
 						  QT_TRANSLATE_NOOP("gettextFromC",
 								    "gaschange"));
 				}
@@ -521,16 +545,22 @@ static void record_gas(std::vector<int> &gas_switch_order, int gn)
 	gas_switch_order.push_back(gn);
 }
 
-static void parse_gases(const QJsonObject &header, const QJsonArray &samples,
+// AI-generated (Claude)
+/* Returns the cylinder indices that were actually assigned a gas mix from
+ * Header.Diving.Gases, so the caller can tell those apart from cylinders
+ * that were only created by a GasSwitch event and never got mix data. */
+static std::vector<int> parse_gases(const QJsonObject &header, const QJsonArray &samples,
 			struct dive *d, int gas_offset)
 {
+	std::vector<int> resolved;
+
 	QJsonObject diving = header["Diving"].toObject();
 	if (diving.isEmpty())
-		return;
+		return resolved;
 
 	QJsonArray gases = diving["Gases"].toArray();
 	if (gases.isEmpty())
-		return;
+		return resolved;
 
 	// Make an ordered list of unique GasNumbers.
 	std::vector<int> gas_switch_order;
@@ -565,6 +595,7 @@ static void parse_gases(const QJsonObject &header, const QJsonArray &samples,
 		QJsonObject gas = gases[i].toObject();
 		int cyl_idx = gas_switch_order[i];
 		cylinder_t *cyl = d->get_or_create_cylinder(cyl_idx);
+		resolved.push_back(cyl_idx);
 
 		/* Suunto fractions (0.0-1.0), Subsurface permille */
 		double o2_frac = gas["Oxygen"].toDouble(0);
@@ -595,6 +626,8 @@ static void parse_gases(const QJsonObject &header, const QJsonArray &samples,
 		if (end_pa > 0)
 			cyl->end.mbar = lrint(end_pa / 100.0);
 	}
+
+	return resolved;
 }
 
 // AI-generated (Claude)
@@ -608,7 +641,8 @@ static void parse_gases(const QJsonObject &header, const QJsonArray &samples,
  * via the existing generic libdivecomputer/Garmin path and copy just the
  * gas mix and gradient factors onto the JSON-derived dive, which stays
  * the authoritative source for the profile itself. */
-static void patch_from_fit(const std::string &fit_buffer, struct dive *d, struct divelog *log)
+static void patch_from_fit(const std::string &fit_buffer, struct dive *d, struct divelog *log,
+			    std::vector<int> &resolved)
 {
 	if (fit_buffer.empty())
 		return;
@@ -639,6 +673,7 @@ static void patch_from_fit(const std::string &fit_buffer, struct dive *d, struct
 		cylinder_t *cyl = d->get_or_create_cylinder(0);
 		cyl->gasmix = fit_dive->cylinders[0].gasmix;
 		cyl->cylinder_use = fit_dive->cylinders[0].cylinder_use;
+		resolved.push_back(0);
 
 		if (fit_dive->cylinders.size() > 1)
 			report_info("Suunto JSON: paired FIT file has %u gas mixes; only gas 0 "
@@ -662,7 +697,8 @@ static void patch_from_fit(const std::string &fit_buffer, struct dive *d, struct
 }
 
 // Import a Suunto JSON file into the divelog.
-int suunto_json_import(const std::string &buffer, const std::string &fit_buffer, struct divelog *log)
+int suunto_json_import(const std::string &buffer, const std::string &fit_buffer, struct divelog *log,
+			std::vector<suunto_unresolved_gas> *unresolved)
 {
 	QByteArray raw_data = QByteArray::fromRawData(buffer.data(), buffer.size());
 	QJsonDocument doc = QJsonDocument::fromJson(raw_data);
@@ -704,21 +740,35 @@ int suunto_json_import(const std::string &buffer, const std::string &fit_buffer,
 
 	parse_header(header, d.get());
 	parse_samples(header, samples, d.get(), log, gas_offset);
-	parse_gases(header, samples, d.get(), gas_offset);
+	std::vector<int> resolved_gases = parse_gases(header, samples, d.get(), gas_offset);
 
 	/* Divers need air. Add at least one cylinder exists even when no tank pod
 	 * was paired and no GasSwitch event is present in the log. */
 	if (d->cylinders.empty())
 		d->get_or_create_cylinder(0);
 
-	patch_from_fit(fit_buffer, d.get(), log);
+	patch_from_fit(fit_buffer, d.get(), log, resolved_gases);
+
+	/* If this dive switched gases mid-dive but we could not determine the
+	 * mix for one or more of those cylinders (no Diving.Gases entry, no
+	 * FIT patch), let the caller know so it can ask the user instead of
+	 * silently leaving them as air. Single-cylinder dives are left alone --
+	 * air is the reasonable default there, matching prior behavior. */
+	if (unresolved && d->cylinders.size() > 1) {
+		for (size_t i = 0; i < d->cylinders.size(); ++i) {
+			if (std::find(resolved_gases.begin(), resolved_gases.end(),
+				      static_cast<int>(i)) == resolved_gases.end())
+				unresolved->push_back({ d.get(), static_cast<int>(i) });
+		}
+	}
 
 	log->dives.record_dive(std::move(d));
 	return 1;
 }
 
 // AI-generated (Claude)
-void suunto_json_fit_pair_import(const std::vector<std::string> &fileNames, std::vector<bool> &consumed, struct divelog *log)
+void suunto_json_fit_pair_import(const std::vector<std::string> &fileNames, std::vector<bool> &consumed, struct divelog *log,
+				  std::vector<suunto_unresolved_gas> *unresolved)
 {
 	/* The Suunto app exports a .json and a .fit file with the same base
 	 * name for the same dive. If the caller selected both, merge them into
@@ -756,7 +806,7 @@ void suunto_json_fit_pair_import(const std::vector<std::string> &fileNames, std:
 		if (ferr <= 0)
 			report_info("Suunto import: could not read paired FIT file '%s', importing gas mix from JSON as-is",
 				    fileNames[pair.fitIdx].c_str());
-		suunto_json_import(jsonBuf, ferr > 0 ? fitBuf : std::string(), log);
+		suunto_json_import(jsonBuf, ferr > 0 ? fitBuf : std::string(), log, unresolved);
 		consumed[pair.jsonIdx] = true;
 		consumed[pair.fitIdx] = true;
 	}

--- a/desktop-widgets/CMakeLists.txt
+++ b/desktop-widgets/CMakeLists.txt
@@ -122,6 +122,8 @@ set(SUBSURFACE_INTERFACE
 	starwidget.h
 	subsurfacewebservices.cpp
 	subsurfacewebservices.h
+	suuntogasassigndialog.cpp
+	suuntogasassigndialog.h
 	tab-widgets/TabBase.cpp
 	tab-widgets/TabBase.h
 	tab-widgets/TabDiveNotes.cpp

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -49,6 +49,7 @@
 #include "desktop-widgets/locationinformation.h"
 #include "desktop-widgets/mapwidget.h"
 #include "desktop-widgets/subsurfacewebservices.h"
+#include "desktop-widgets/suuntogasassigndialog.h"
 #include "desktop-widgets/tab-widgets/maintab.h"
 #include "desktop-widgets/updatemanager.h"
 #include "desktop-widgets/simplewidgets.h"
@@ -1331,15 +1332,22 @@ void MainWindow::importFiles(const std::vector<std::string> &fileNames)
 		return;
 
 	struct divelog log;
+	std::vector<suunto_unresolved_gas> unresolvedGases;
 	std::vector<bool> consumed(fileNames.size(), false);
-	suunto_json_fit_pair_import(fileNames, consumed, &log);
+	suunto_json_fit_pair_import(fileNames, consumed, &log, &unresolvedGases);
 
 	for (size_t i = 0; i < fileNames.size(); ++i) {
 		if (consumed[i])
 			continue;
 		std::string encoded = encodeFileName(fileNames[i]);
-		parse_file(encoded.c_str(), &log);
+		parse_file(encoded.c_str(), &log, &unresolvedGases);
 	}
+
+	if (!unresolvedGases.empty()) {
+		SuuntoGasAssignDialog gasAssign(std::move(unresolvedGases), this);
+		gasAssign.exec();
+	}
+
 	QString source = fileNames.size() == 1 ? QString::fromStdString(fileNames[0]) : tr("multiple files");
 	Command::importDives(&log, import_flags::merge_all_trips, source);
 }

--- a/desktop-widgets/suuntogasassigndialog.cpp
+++ b/desktop-widgets/suuntogasassigndialog.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0
+// AI-generated (Claude)
+#include "suuntogasassigndialog.h"
+#include "core/dive.h"
+#include "core/gettext.h"
+#include "core/qthelper.h"
+
+#include <cmath>
+
+#include <QDialogButtonBox>
+#include <QDoubleSpinBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QTableWidget>
+#include <QVBoxLayout>
+
+SuuntoGasAssignDialog::SuuntoGasAssignDialog(std::vector<suunto_unresolved_gas> unresolved, QWidget *parent) : QDialog(parent),
+	rows(std::move(unresolved))
+{
+	setWindowTitle(tr("Confirm gas mixes"));
+
+	auto *layout = new QVBoxLayout(this);
+	auto *label = new QLabel(tr("These dives switch gases mid-dive, but the imported log doesn't say "
+				     "what was in each tank. Enter the gas mix and cylinder for each gas below "
+				     "(left as air in an 11.1 L / 200 bar tank if you skip a row)."), this);
+	label->setWordWrap(true);
+	layout->addWidget(label);
+
+	table = new QTableWidget(static_cast<int>(rows.size()), 6, this);
+	table->setHorizontalHeaderLabels(QStringList() << tr("Dive") << tr("Gas") << tr("O2 %") << tr("He %")
+							<< tr("Size (L)") << tr("Working pressure (bar)"));
+	table->verticalHeader()->setVisible(false);
+	table->setSelectionMode(QAbstractItemView::NoSelection);
+
+	for (int i = 0; i < static_cast<int>(rows.size()); ++i) {
+		const suunto_unresolved_gas &row = rows[i];
+
+		auto *diveItem = new QTableWidgetItem(get_short_dive_date_string(row.d->when));
+		diveItem->setFlags(diveItem->flags() & ~Qt::ItemIsEditable);
+		table->setItem(i, 0, diveItem);
+
+		auto *gasItem = new QTableWidgetItem(tr("Gas %1").arg(row.cylinder_idx));
+		gasItem->setFlags(gasItem->flags() & ~Qt::ItemIsEditable);
+		table->setItem(i, 1, gasItem);
+
+		auto *o2 = new QDoubleSpinBox(table);
+		o2->setRange(1.0, 100.0);
+		o2->setValue(21.0);
+		o2->setSuffix(tr(" %"));
+		table->setCellWidget(i, 2, o2);
+
+		auto *he = new QDoubleSpinBox(table);
+		he->setRange(0.0, 99.0);
+		he->setValue(0.0);
+		he->setSuffix(tr(" %"));
+		table->setCellWidget(i, 3, he);
+
+		auto *size = new QDoubleSpinBox(table);
+		size->setRange(0.1, 50.0);
+		size->setValue(11.1);
+		size->setSuffix(tr(" L"));
+		table->setCellWidget(i, 4, size);
+
+		auto *workingPressure = new QDoubleSpinBox(table);
+		workingPressure->setRange(1.0, 500.0);
+		workingPressure->setValue(200.0);
+		workingPressure->setSuffix(tr(" bar"));
+		table->setCellWidget(i, 5, workingPressure);
+	}
+	table->resizeColumnsToContents();
+	table->horizontalHeader()->setStretchLastSection(true);
+	layout->addWidget(table);
+
+	auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+	connect(buttons, &QDialogButtonBox::accepted, this, &SuuntoGasAssignDialog::applyAndAccept);
+	connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+	layout->addWidget(buttons);
+}
+
+void SuuntoGasAssignDialog::applyAndAccept()
+{
+	for (int i = 0; i < static_cast<int>(rows.size()); ++i) {
+		const suunto_unresolved_gas &row = rows[i];
+		cylinder_t *cyl = row.d->get_or_create_cylinder(row.cylinder_idx);
+
+		auto *o2 = qobject_cast<QDoubleSpinBox *>(table->cellWidget(i, 2));
+		auto *he = qobject_cast<QDoubleSpinBox *>(table->cellWidget(i, 3));
+		auto *size = qobject_cast<QDoubleSpinBox *>(table->cellWidget(i, 4));
+		auto *workingPressure = qobject_cast<QDoubleSpinBox *>(table->cellWidget(i, 5));
+		if (o2)
+			cyl->gasmix.o2.permille = lrint(o2->value() * 10.0);
+		if (he)
+			cyl->gasmix.he.permille = lrint(he->value() * 10.0);
+		if (size)
+			cyl->type.size.mliter = lrint(size->value() * 1000.0);
+		if (workingPressure)
+			cyl->type.workingpressure.mbar = lrint(workingPressure->value() * 1000.0);
+	}
+	accept();
+}

--- a/desktop-widgets/suuntogasassigndialog.h
+++ b/desktop-widgets/suuntogasassigndialog.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef SUUNTOGASASSIGNDIALOG_H
+#define SUUNTOGASASSIGNDIALOG_H
+
+#include "core/file.h"
+
+#include <QDialog>
+#include <vector>
+
+class QTableWidget;
+
+// AI-generated (Claude)
+/* Shown after importing Suunto JSON dive log(s) that switched gases mid-dive
+ * but carried no gas-mix data (no Header.Diving.Gases entry, and no paired
+ * FIT file to patch it in). Lets the user fill in the O2/He fraction for
+ * each cylinder that a GasSwitch event created but that never resolved to an
+ * actual mix, before the dives are committed to the log. */
+class SuuntoGasAssignDialog : public QDialog {
+	Q_OBJECT
+public:
+	explicit SuuntoGasAssignDialog(std::vector<suunto_unresolved_gas> unresolved, QWidget *parent = nullptr);
+
+private slots:
+	void applyAndAccept();
+
+private:
+	std::vector<suunto_unresolved_gas> rows;
+	QTableWidget *table;
+};
+
+#endif // SUUNTOGASASSIGNDIALOG_H

--- a/dives/suunto_eon_core_nitrox.xml
+++ b/dives/suunto_eon_core_nitrox.xml
@@ -13,7 +13,7 @@
   <extradata key='Serial' value='2804271178' />
   <extradata key='FW Version' value='3.0.1102' />
   <extradata key='HW version' value='70.6.0' />
-  <event time='0:00 min' type='11' value='32' name='gaschange' cylinder='0' o2='32.0%' />
+  <event time='0:00 min' type='25' flags='1' name='gaschange' cylinder='0' o2='32.0%' />
   <event time='18:03 min' name='ascent' />
   <event time='18:03 min' name='safety stop' />
   <event time='36:35 min' name='ascent' />

--- a/dives/suunto_nautic_sidemount.xml
+++ b/dives/suunto_nautic_sidemount.xml
@@ -2,11 +2,11 @@
 <settings>
 </settings>
 <divesites>
-<site uuid='28c4b3f3' name='Suunto Nautic dive' gps='48.332115 7.777142'>
+<site uuid='25a2b30f' name='48.332115, 7.777142' gps='48.332115 7.777142'>
 </site>
 </divesites>
 <dives>
-<dive otu='4' cns='2%' divesiteid='28c4b3f3' date='2025-12-27' time='14:56:17' duration='31:00 min'>
+<dive otu='4' cns='2%' divesiteid='25a2b30f' date='2025-12-27' time='14:56:17' duration='31:00 min'>
   <notes>This is a test note for Suunto Nautic</notes>
   <cylinder />
   <cylinder />
@@ -18,7 +18,7 @@
   <extradata key='Serial' value='288100258646' />
   <extradata key='FW Version' value='2.45.46' />
   <extradata key='HW version' value='GT_RevX' />
-  <event time='0:00 min' type='11' value='21' name='gaschange' cylinder='0' />
+  <event time='0:00 min' type='25' flags='1' name='gaschange' cylinder='0' />
   <event time='2:01 min' name='depth alarm' />
   <event time='5:50 min' name='depth alarm' />
   <event time='25:21 min' name='safety stop' />

--- a/dives/suunto_ocean_air.xml
+++ b/dives/suunto_ocean_air.xml
@@ -15,7 +15,7 @@
   <extradata key='Serial' value='258828934792' />
   <extradata key='FW Version' value='2.40.56' />
   <extradata key='HW version' value='Seal_RevA3' />
-  <event time='0:00 min' type='11' value='21' name='gaschange' cylinder='0' />
+  <event time='0:00 min' type='25' flags='1' name='gaschange' cylinder='0' />
   <event time='46:12 min' name='safety stop' />
   <sample time='0:00 min' depth='1.92 m' temp='29.24 C' ndl='100:00 min' tts='0:12 min' />
   <sample time='0:00 min' depth='1.92 m' />

--- a/dives/suunto_ocean_nitrox.xml
+++ b/dives/suunto_ocean_nitrox.xml
@@ -16,7 +16,7 @@
   <extradata key='HW version' value='Seal_RevA3' />
   <extradata key='GF Low' value='40' />
   <extradata key='GF High' value='85' />
-  <event time='0:00 min' type='11' value='32' name='gaschange' cylinder='0' o2='32.0%' />
+  <event time='0:00 min' type='25' flags='1' name='gaschange' cylinder='0' o2='32.0%' />
   <event time='52:05 min' name='safety stop' />
   <event time='53:57 min' name='safety stop' />
   <event time='55:14 min' name='safety stop' />


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
Some Suunto JSON dive log exports (seen on Nautic/Ocean firmware with no Header.Diving.Gases block and no paired FIT file) record a mid-dive gas switch event without ever saying what was actually in the second tank. The importer silently defaulted every such cylinder to air, which is wrong whenever the second tank wasn't air.

parse_gases() and patch_from_fit() now report which cylinder indices they managed to resolve a mix for. suunto_json_import(), suunto_json_fit_pair_import() and parse_file() gained an optional out-parameter that collects the {dive, cylinder index} pairs that a GasSwitch event created but that never got a resolved mix. This is only populated for genuine multi-gas dives -- a single-cylinder dive with no mix data keeps defaulting to air, matching prior behavior, so ordinary single-tank imports aren't affected.

MainWindow::importFiles() now shows a new SuuntoGasAssignDialog (desktop-widgets/suuntogasassigndialog.{cpp,h}) whenever that list is non-empty, before the dives are committed. It lists one row per unresolved cylinder and lets the user set the O2/He fraction and the cylinder size/working pressure (defaulting to air in an 11.1 L / 200 bar tank) before import.

While testing the above end-to-end, found and fixed a second, pre-existing bug: the two places that create a gas-switch event for Suunto JSON dives called

    add_event(&dc, elapsed_secs, SAMPLE_EVENT_GASCHANGE, 0, gas_num, ...)

passing the cylinder index as the event's "value" field. For SAMPLE_EVENT_GASCHANGE, "value" is interpreted as an O2 percentage, not a cylinder index -- the index has to travel through SAMPLE_EVENT_GASCHANGE2's "flags" field instead (the convention already used for downloaded dives in libdivecomputer.cpp). Because of this, a switch to any cylinder other than 0 could never resolve to the right gas: get_gasmix_from_event() fell back to a best-effort gasmix match, which consistently picked cylinder 0 regardless of what mix the user entered for the other cylinder. Switched both call sites to SAMPLE_EVENT_GASCHANGE2 with flags = cylinder_index + 1.

Also fixed dive site naming for dives with GPS in the JSON: the auto-created dive site was named "<device model> dive", and since the Location field displays a site's name rather than falling back to its coordinates, every GPS-tagged import showed that generic name instead of the actual position. Site is now named with the "lat, lon" decimal string, matching the convention already used for GPS-only downloads in libdivecomputer.cpp.

Loosened parse_iso8601_ms() to accept an optional fractional-seconds part and a "Z" timezone suffix; some Suunto JSON timestamps use these and previously failed to parse without an exact "+HH:MM" offset.

Updated the four existing Suunto golden test fixtures for the corrected event encoding and dive site name/uuid -- none of them previously exercised an actual mid-dive switch to a different cylinder, which is why the GASCHANGE encoding bug went unnoticed. Full TestParse suite (33 tests) passes.

Verified end-to-end against a real multi-gas Suunto Nautic JSON export by driving the compiled binary under a headless X server (Xvfb + synthetic keyboard/mouse input): the dialog appears, the entered mix and cylinder ends up on the correct cylinder, the gas-switch event resolves to that cylinder, and the Location field shows the actual GPS coordinates.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
Fixes #4901 
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
