### PR TITLE
Fix map pointer

### DIFF
--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -780,7 +780,15 @@ static dc_status_t libdc_header_parser(dc_parser_t *parser, device_data_t *devda
 		snprintf(location_string, sizeof(location_string), "%.6f, %.6f", location.lat.udeg / 1000000.0, location.lon.udeg / 1000000.0);
 
 		unregister_dive_from_dive_site(dive);
-		devdata->log->sites.create(location_string, location)->add_dive(dive);
+		// AI-generated (Claude)
+		// Reuse a nearby existing site (same tolerance as parse-xml.cpp's
+		// GPS-only site matching) instead of always creating a new
+		// coordinate-named site, so repeat dives at essentially the same
+		// spot share one dive site rather than accumulating near-duplicates.
+		dive_site *site = devdata->log->sites.get_by_gps_proximity(location, 20);
+		if (!site)
+			site = devdata->log->sites.create(location_string, location);
+		site->add_dive(dive);
 
 		add_extra_data(&dive->dcs[0], "Start location", location_string);
 		got_location = true;

--- a/core/pref.cpp
+++ b/core/pref.cpp
@@ -20,6 +20,8 @@ preferences::preferences() :
 	show_developer(true),
 	three_m_based_grid(false),
 	map_short_names(false),
+	map_dedup_nearby_sites(true),
+	map_dedup_distance(50),
 	include_unused_tanks(false),
 	display_default_tank_infos(true),
 	auto_recalculate_thumbnails(true),

--- a/core/pref.h
+++ b/core/pref.h
@@ -102,6 +102,10 @@ struct preferences {
 	bool        show_developer;
 	bool        three_m_based_grid;
 	bool        map_short_names;
+	bool        map_show_only_selected_dive_site;
+	int         map_selected_dive_site_radius; // km; 0 means show only the exact selected site
+	bool        map_dedup_nearby_sites; // merge markers for same-named sites that are close together
+	int         map_dedup_distance; // meters; how close same-named sites must be to get merged
 
 	// ********** Equipment tab *******
 	std::string default_cylinder;

--- a/core/settings/qPrefDisplay.cpp
+++ b/core/settings/qPrefDisplay.cpp
@@ -70,6 +70,10 @@ void qPrefDisplay::loadSync(bool doSync)
 	}
 	disk_three_m_based_grid(doSync);
 	disk_map_short_names(doSync);
+	disk_map_show_only_selected_dive_site(doSync);
+	disk_map_selected_dive_site_radius(doSync);
+	disk_map_dedup_nearby_sites(doSync);
+	disk_map_dedup_distance(doSync);
 }
 
 void qPrefDisplay::set_divelist_font(const QString &value)
@@ -154,6 +158,15 @@ HANDLE_PREFERENCE_BOOL(Display, "show_developer", show_developer);
 HANDLE_PREFERENCE_BOOL(Display, "three_m_based_grid", three_m_based_grid);
 
 HANDLE_PREFERENCE_BOOL(Display, "map_short_names", map_short_names);
+
+// AI-generated (Claude)
+HANDLE_PREFERENCE_BOOL(Display, "map_show_only_selected_dive_site", map_show_only_selected_dive_site);
+
+HANDLE_PREFERENCE_INT(Display, "map_selected_dive_site_radius", map_selected_dive_site_radius);
+
+HANDLE_PREFERENCE_BOOL(Display, "map_dedup_nearby_sites", map_dedup_nearby_sites);
+
+HANDLE_PREFERENCE_INT(Display, "map_dedup_distance", map_dedup_distance);
 
 void qPrefDisplay::setCorrectFont()
 {

--- a/core/settings/qPrefDisplay.h
+++ b/core/settings/qPrefDisplay.h
@@ -27,6 +27,10 @@ class qPrefDisplay : public QObject {
 	Q_PROPERTY(bool singleColumnPortrait READ singleColumnPortrait WRITE set_singleColumnPortrait NOTIFY singleColumnPortraitChanged)
 	Q_PROPERTY(bool three_m_based_grid READ three_m_based_grid WRITE set_three_m_based_grid NOTIFY three_m_based_gridChanged)
 	Q_PROPERTY(bool map_short_names READ map_short_names WRITE set_map_short_names NOTIFY map_short_namesChanged)
+	Q_PROPERTY(bool map_show_only_selected_dive_site READ map_show_only_selected_dive_site WRITE set_map_show_only_selected_dive_site NOTIFY map_show_only_selected_dive_siteChanged)
+	Q_PROPERTY(int map_selected_dive_site_radius READ map_selected_dive_site_radius WRITE set_map_selected_dive_site_radius NOTIFY map_selected_dive_site_radiusChanged)
+	Q_PROPERTY(bool map_dedup_nearby_sites READ map_dedup_nearby_sites WRITE set_map_dedup_nearby_sites NOTIFY map_dedup_nearby_sitesChanged)
+	Q_PROPERTY(int map_dedup_distance READ map_dedup_distance WRITE set_map_dedup_distance NOTIFY map_dedup_distanceChanged)
 
 public:
 	static qPrefDisplay *instance();
@@ -56,6 +60,10 @@ public:
 	static bool singleColumnPortrait() { return st_singleColumnPortrait; }
 	static bool three_m_based_grid() { return prefs.three_m_based_grid; }
 	static bool map_short_names() { return prefs.map_short_names; }
+	static bool map_show_only_selected_dive_site() { return prefs.map_show_only_selected_dive_site; }
+	static int map_selected_dive_site_radius() { return prefs.map_selected_dive_site_radius; }
+	static bool map_dedup_nearby_sites() { return prefs.map_dedup_nearby_sites; }
+	static int map_dedup_distance() { return prefs.map_dedup_distance; }
 
 public slots:
 	static void set_animation_speed(int value);
@@ -77,6 +85,10 @@ public slots:
 	static void set_singleColumnPortrait(bool value);
 	static void set_three_m_based_grid(bool value);
 	static void set_map_short_names(bool value);
+	static void set_map_show_only_selected_dive_site(bool value);
+	static void set_map_selected_dive_site_radius(int value);
+	static void set_map_dedup_nearby_sites(bool value);
+	static void set_map_dedup_distance(int value);
 
 signals:
 	void animation_speedChanged(int value);
@@ -98,6 +110,10 @@ signals:
 	void singleColumnPortraitChanged(bool value);
 	void three_m_based_gridChanged(bool value);
 	void map_short_namesChanged(bool value);
+	void map_show_only_selected_dive_siteChanged(bool value);
+	void map_selected_dive_site_radiusChanged(int value);
+	void map_dedup_nearby_sitesChanged(bool value);
+	void map_dedup_distanceChanged(int value);
 
 private:
 	qPrefDisplay() {}
@@ -111,6 +127,10 @@ private:
 	static void disk_show_developer(bool doSync);
 	static void disk_three_m_based_grid(bool doSync);
 	static void disk_map_short_names(bool doSync);
+	static void disk_map_show_only_selected_dive_site(bool doSync);
+	static void disk_map_selected_dive_site_radius(bool doSync);
+	static void disk_map_dedup_nearby_sites(bool doSync);
+	static void disk_map_dedup_distance(bool doSync);
 
 	// functions to handle class variables
 	static void load_lastDir();

--- a/desktop-widgets/preferences/preferences_defaults.cpp
+++ b/desktop-widgets/preferences/preferences_defaults.cpp
@@ -34,6 +34,12 @@ void PreferencesDefaults::refreshSettings()
 		ui->gridGeneric->setChecked(true);
 
 	ui->checkBox_map_short_names->setChecked(qPrefDisplay::map_short_names());
+	ui->checkBox_map_dedup->setChecked(qPrefDisplay::map_dedup_nearby_sites());
+	ui->spinBox_map_dedup_distance->setValue(qPrefDisplay::map_dedup_distance());
+	ui->spinBox_map_dedup_distance->setEnabled(qPrefDisplay::map_dedup_nearby_sites());
+	ui->checkBox_map_only_selected->setChecked(qPrefDisplay::map_show_only_selected_dive_site());
+	ui->spinBox_map_radius->setValue(qPrefDisplay::map_selected_dive_site_radius());
+	ui->spinBox_map_radius->setEnabled(qPrefDisplay::map_show_only_selected_dive_site());
 }
 
 void PreferencesDefaults::syncSettings()
@@ -43,4 +49,8 @@ void PreferencesDefaults::syncSettings()
 	qPrefDisplay::set_animation_speed(ui->velocitySlider->value());
 	qPrefDisplay::set_three_m_based_grid(ui->grid3MBased->isChecked());
 	qPrefDisplay::set_map_short_names(ui->checkBox_map_short_names->isChecked());
+	qPrefDisplay::set_map_dedup_nearby_sites(ui->checkBox_map_dedup->isChecked());
+	qPrefDisplay::set_map_dedup_distance(ui->spinBox_map_dedup_distance->value());
+	qPrefDisplay::set_map_show_only_selected_dive_site(ui->checkBox_map_only_selected->isChecked());
+	qPrefDisplay::set_map_selected_dive_site_radius(ui->spinBox_map_radius->value());
 }

--- a/desktop-widgets/preferences/preferences_defaults.ui
+++ b/desktop-widgets/preferences/preferences_defaults.ui
@@ -154,20 +154,97 @@
      <property name="title">
       <string>Map Display Options</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <layout class="QVBoxLayout" name="verticalLayout_map">
       <item>
-       <widget class="QLabel" name="label_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Short Names:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkBox_map_short_names">
+          <property name="text">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBox_map_dedup">
         <property name="text">
-         <string>Short Names:</string>
+         <string>Merge markers for nearby dive sites with the same name</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="checkBox_map_short_names">
+       <layout class="QHBoxLayout" name="horizontalLayout_map_dedup_distance">
+        <item>
+         <widget class="QLabel" name="label_map_dedup_distance">
+          <property name="text">
+           <string>Merge distance (m):</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinBox_map_dedup_distance">
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100000</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_map_dedup_distance">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBox_map_only_selected">
         <property name="text">
-         <string notr="true"/>
+         <string>Show only the selected dive site on the map</string>
         </property>
        </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_map_radius">
+        <item>
+         <widget class="QLabel" name="label_map_radius">
+          <property name="text">
+           <string>Also show sites within (km):</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinBox_map_radius">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>20000</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_map_radius">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -220,6 +297,18 @@
      <y>276</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>checkBox_map_only_selected</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spinBox_map_radius</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkBox_map_dedup</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spinBox_map_dedup_distance</receiver>
+   <slot>setEnabled(bool)</slot>
   </connection>
  </connections>
 </ui>

--- a/map-widget/qmlmapwidgethelper.cpp
+++ b/map-widget/qmlmapwidgethelper.cpp
@@ -54,7 +54,13 @@ void MapWidgetHelper::centerOnDiveSite(struct dive_site *ds)
 void MapWidgetHelper::setSelected(const std::vector<dive_site *> divesites)
 {
 	m_mapLocationModel->setSelected(std::move(divesites));
-	m_mapLocationModel->selectionChanged();
+	// AI-generated (Claude)
+	// A plain selection-flag update (dataChanged on existing rows) is not
+	// enough: a site that was previously merged away by dedup, or hidden
+	// because nothing was selected yet, may now need its own marker since
+	// it just became selected (selected sites are exempt from dedup). Only
+	// a full reload() re-evaluates which sites belong in the model at all.
+	m_mapLocationModel->reload(m_map);
 	updateEditMode();
 }
 

--- a/qt-models/maplocationmodel.cpp
+++ b/qt-models/maplocationmodel.cpp
@@ -11,8 +11,19 @@
 #include "desktop-widgets/mapwidget.h"
 #endif
 #include <map>
+#include <QRegularExpression>
 
-#define MIN_DISTANCE_BETWEEN_DIVE_SITES_M 50.0
+// AI-generated (Claude)
+// Some dive computer downloads (see core/libdivecomputer.cpp) name a dive
+// site after its own GPS coordinates (e.g. "12.345678, -6.789012") when the
+// device provides a GPS fix but no site name. Such a name carries no real
+// identity -- it is effectively unnamed -- so for map dedup purposes treat
+// it the same as an empty name.
+static bool looksLikeCoordinates(const QString &name)
+{
+	static const QRegularExpression re(QStringLiteral("^-?\\d{1,3}\\.\\d+,\\s*-?\\d{1,3}\\.\\d+$"));
+	return re.match(name).hasMatch();
+}
 
 // MKW If "Map Short Names" preference is set, only return the last component
 // of the full dive site name.
@@ -159,9 +170,34 @@ void MapLocationModel::reload(QObject *map)
 	// of the non-hidden dives. Moreover, the selected dive sites are those
 	// that we filter for.
 	bool diveSiteMode = DiveFilter::instance()->diveSiteMode();
-	if (diveSiteMode)
+#endif
+	if (diveSiteMode) {
+#if !defined(SUBSURFACE_MOBILE) && !defined(SUBSURFACE_DOWNLOADER)
 		m_selectedDs = DiveFilter::instance()->filteredDiveSites();
 #endif
+	} else {
+		// Determine the full set of selected dive sites up front, so that
+		// "only show selected dive site" (below) knows about all of them,
+		// not just the ones encountered so far in the loop.
+		for (const auto &ds: divelog.sites) {
+			if (hasVisibleDive(*ds) && hasSelectedDive(*ds))
+				m_selectedDs.push_back(ds.get());
+		}
+	}
+
+	// AI-generated (Claude)
+	// Optionally hide every dive site except the selected one(s), or restrict
+	// to sites within a given radius of a selected site.
+	bool onlySelected = !diveSiteMode && qPrefDisplay::map_show_only_selected_dive_site();
+	double radius_m = qPrefDisplay::map_selected_dive_site_radius() * 1000.0;
+	std::vector<QGeoCoordinate> selectedCoords;
+	if (onlySelected) {
+		for (const dive_site *sel: m_selectedDs) {
+			if (sel->has_gps_location())
+				selectedCoords.emplace_back(sel->location.lat.udeg * 0.000001, sel->location.lon.udeg * 0.000001);
+		}
+	}
+
 	for (const auto &ds: divelog.sites) {
 		QGeoCoordinate dsCoord;
 
@@ -180,22 +216,44 @@ void MapLocationModel::reload(QObject *map)
 			qreal longitude = ds->location.lon.udeg * 0.000001;
 			dsCoord = QGeoCoordinate(latitude, longitude);
 		}
-		if (!diveSiteMode && hasSelectedDive(*ds) && !range_contains(m_selectedDs, ds.get()))
-			m_selectedDs.push_back(ds.get());
 		QString name = siteMapDisplayName(ds->name);
-		if (!diveSiteMode) {
-			// don't add dive locations with the same name, unless they are
-			// at least MIN_DISTANCE_BETWEEN_DIVE_SITES_M apart
-			auto it = locationNameMap.find(name);
-			if (it != locationNameMap.end()) {
-				const MapLocation &existingLocation = m_mapLocations[it->second];
-				QGeoCoordinate coord = existingLocation.coordinate;
-				if (dsCoord.distanceTo(coord) < MIN_DISTANCE_BETWEEN_DIVE_SITES_M)
+		bool isSelected = range_contains(m_selectedDs, ds.get());
+		if (onlySelected && !isSelected) {
+			bool withinRadius = radius_m > 0 &&
+				std::any_of(selectedCoords.begin(), selectedCoords.end(),
+					    [&dsCoord, radius_m](const QGeoCoordinate &c) { return dsCoord.distanceTo(c) <= radius_m; });
+			if (!withinRadius)
+				continue;
+		}
+		if (!diveSiteMode && !isSelected && qPrefDisplay::map_dedup_nearby_sites()) {
+			// Named sites only merge with another site of the exact same
+			// name within map_dedup_distance() meters, so two distinct,
+			// deliberately named sites are never accidentally combined.
+			// Unnamed sites (no name given by the user, or a name that is
+			// just the site's own GPS coordinates) have no identity worth
+			// preserving, so they merge into any nearby marker, named or
+			// not, within the same distance. Never skip the currently
+			// selected dive site, or its marker would be missing from the
+			// map. The toggle and the distance are user preferences.
+			// (AI-generated (Claude))
+			if (name.isEmpty() || looksLikeCoordinates(name)) {
+				bool mergedIntoExisting = std::any_of(m_mapLocations.begin(), m_mapLocations.end(),
+					[&dsCoord](const MapLocation &existingLocation) {
+						return dsCoord.distanceTo(existingLocation.coordinate) < qPrefDisplay::map_dedup_distance();
+					});
+				if (mergedIntoExisting)
 					continue;
+			} else {
+				auto it = locationNameMap.find(name);
+				if (it != locationNameMap.end()) {
+					const MapLocation &existingLocation = m_mapLocations[it->second];
+					QGeoCoordinate coord = existingLocation.coordinate;
+					if (dsCoord.distanceTo(coord) < qPrefDisplay::map_dedup_distance())
+						continue;
+				}
 			}
 		}
-		bool selected = range_contains(m_selectedDs, ds.get());
-		m_mapLocations.emplace_back(ds.get(), dsCoord, name, selected);
+		m_mapLocations.emplace_back(ds.get(), dsCoord, name, isSelected);
 		if (!diveSiteMode)
 			locationNameMap[name] = m_mapLocations.size() - 1;
 	}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
    Map: make dedup distance configurable, fix coordinate-named and stale-selection merging
    
    Follow-up to 62715d849 ("Map: fix missing marker for selected dive
    site, add visibility controls"), driven by testing with real
    downloaded dive data.
    
    1. Make the dedup merge distance a preference
    
       MIN_DISTANCE_BETWEEN_DIVE_SITES_M was a hardcoded 50.0m constant in
       MapLocationModel::reload(). Replace it with a new
       map_dedup_distance preference (default 50m, same as before),
       editable via Preferences > Display > Map Display Options next to
       the existing "Merge markers for nearby dive sites with the same
       name" checkbox added in the previous commit.
    
    2. Fix dive sites named after their own GPS coordinates never merging
    
       core/libdivecomputer.cpp names a newly created dive site after its
       own coordinates (e.g. "12.345678, -6.789012") when a dive computer
       reports a GPS fix but no site name. Two such sites almost never
       share the exact same coordinate string, so the name+distance dedup
       in MapLocationModel::reload() could never merge them no matter the
       configured distance -- by design, dedup only merges sites with the
       exact same name, to avoid accidentally combining two distinct,
       deliberately named sites that happen to be close together.
    
       Fixed on both ends:
    
       - core/libdivecomputer.cpp now calls get_by_gps_proximity(location,
         20) before creating a new site, reusing an existing one within
         20m (the same tolerance parse-xml.cpp already uses for GPS-only
         site matching) instead of always creating a new coordinate-named
         site. Future downloads at essentially the same spot will share a
         site instead of accumulating near-duplicates.
    
       - qt-models/maplocationmodel.cpp adds looksLikeCoordinates(), which
         recognizes a name matching that "lat, lon" pattern and treats it
         like an empty name for dedup purposes: such sites now merge into
         any nearby marker, named or not, purely by distance, instead of
         requiring an exact (and in practice unachievable) name match.
         This covers sites that were already downloaded with this naming
         pattern before the libdivecomputer.cpp fix above, without
         requiring a re-download.
    
    3. Fix a site not merging until an unrelated settings change
       Reported as: opening Subsurface shows only one marker for two
       nearby sites (correctly merged), but opening Preferences (which
       triggers a full settings-changed map reload) makes a second, bold
       "selected" marker appear -- and once that happens, it stays visible
       regardless of what preference is changed afterward.
    
       Root cause: MapWidget::reload() (triggered by dataReset on file
       load) runs before the initial dive selection is established, so at
       that point no site is yet exempt from dedup and the pair correctly
       merges into one marker. Shortly after, dive selection completes and
       routes through DiveListView::selectDiveSitesOnMap() ->
       MapWidget::setSelected() -> MapWidgetHelper::setSelected(), which
       only called MapLocationModel::selectionChanged(). That function
       merely flips the "selected" flag on markers already present in the
       model; it cannot re-add a site that reload() had already merged
       away before selection was known. The site remains invisible until
       something else triggers a full reload() -- such as the
       settingsChanged signal emitted when the Preferences dialog is
       applied -- at which point the now-selected site is correctly
       exempted from dedup and gets its own marker, and stays that way for
       as long as it remains selected.
    
       Fix: MapWidgetHelper::setSelected() now calls
       MapLocationModel::reload() instead of the narrower
       selectionChanged(), so every selection change fully re-evaluates
       which sites belong in the model, consistent with how the model
       already reacts to file loads, settings changes, and filter mode
       changes elsewhere in this same class.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
Fixes #4903 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
