### PR TITLE
Suunto JSON: fix gas switch cylinder mismatch, read GF from JSON

### DIFF
--- a/core/import-suunto-json.cpp
+++ b/core/import-suunto-json.cpp
@@ -682,23 +682,24 @@ static void patch_from_fit(const std::string &fit_buffer, struct dive *d, struct
 
 	/* Gradient factors: libdivecomputer's Garmin parser surfaces the FIT
 	 * DIVE_SETTINGS gf_low/gf_high as a "Deco model" extra_data string of
-	 * the form "Buhlmann ZHL-16C <low>/<high>". Skip if parse_deco_settings()
-	 * already got these straight from the JSON (cloud-sourced exports) --
-	 * add_extra_data() has no dedup, so applying both would leave two
-	 * "GF Low"/"GF High" entries. */
-	bool have_gf = std::any_of(d->dcs[0].extra_data.begin(), d->dcs[0].extra_data.end(),
-				    [](const extra_data &ed) { return ed.key == "GF Low"; });
-	if (!have_gf) {
-		for (const extra_data &ed : fit_dive->dcs[0].extra_data) {
-			if (ed.key != "Deco model")
-				continue;
-			unsigned gf_low = 0, gf_high = 0;
-			if (sscanf(ed.value.c_str(), "Buhlmann ZHL-16C %u/%u", &gf_low, &gf_high) == 2) {
-				add_extra_data(&d->dcs[0], "GF Low", std::to_string(gf_low));
-				add_extra_data(&d->dcs[0], "GF High", std::to_string(gf_high));
-			}
-			break;
+	 * the form "Buhlmann ZHL-16C <low>/<high>". The FIT's DIVE_SETTINGS
+	 * message is a standardised, multi-manufacturer format, so it takes
+	 * precedence over parse_deco_settings()'s JSON-only Diving.GfLow/
+	 * GfHigh fields when both are present -- drop whatever JSON-derived
+	 * "GF Low"/"GF High" entries exist (add_extra_data() has no dedup)
+	 * before adding the FIT's values. */
+	for (const extra_data &ed : fit_dive->dcs[0].extra_data) {
+		if (ed.key != "Deco model")
+			continue;
+		unsigned gf_low = 0, gf_high = 0;
+		if (sscanf(ed.value.c_str(), "Buhlmann ZHL-16C %u/%u", &gf_low, &gf_high) == 2) {
+			std::erase_if(d->dcs[0].extra_data, [](const extra_data &ed) {
+				return ed.key == "GF Low" || ed.key == "GF High";
+			});
+			add_extra_data(&d->dcs[0], "GF Low", std::to_string(gf_low));
+			add_extra_data(&d->dcs[0], "GF High", std::to_string(gf_high));
 		}
+		break;
 	}
 }
 

--- a/core/import-suunto-json.cpp
+++ b/core/import-suunto-json.cpp
@@ -21,6 +21,7 @@
  * it is not available in the JSON
  */
 
+#include <algorithm>
 #include <climits>
 #include <cmath>
 #include <cstdint>
@@ -407,11 +408,15 @@ static void parse_samples(const QJsonObject &header, const QJsonArray &samples,
 				QJsonObject gs = events["GasSwitch"].toObject();
 				int gas_num = gs["GasNumber"].toInt(0) - gas_offset;
 				d->get_or_create_cylinder(gas_num);
-				add_event(&dc, elapsed_secs,
-					  SAMPLE_EVENT_GASCHANGE, 0,
-					  gas_num,
-					  QT_TRANSLATE_NOOP("gettextFromC",
-							    "gaschange"));
+				/* Build the event from the cylinder's actual gas mix
+				 * (already set by parse_gases(), which runs first)
+				 * via the same helper real dive computer backends
+				 * use, rather than a raw add_event() with gas_num
+				 * misused as an O2 percentage -- that would leave
+				 * gas.index unset and let the generic gas-mix-
+				 * distance fallback in validate_gaschange() guess
+				 * the wrong cylinder for any gas past the first. */
+				add_gas_switch_event(d, &dc, elapsed_secs, gas_num);
 			}
 
 			if (events.contains("State")) {
@@ -457,11 +462,9 @@ static void parse_samples(const QJsonObject &header, const QJsonArray &samples,
 					QJsonObject gs = eo["GasSwitch"].toObject();
 					int gas_num = gs["GasNumber"].toInt(0) - gas_offset;
 					d->get_or_create_cylinder(gas_num);
-					add_event(&dc, elapsed_secs,
-						  SAMPLE_EVENT_GASCHANGE, 0,
-						  gas_num,
-						  QT_TRANSLATE_NOOP("gettextFromC",
-								    "gaschange"));
+					/* See the DiveEvents.GasSwitch branch above for
+					 * why add_gas_switch_event() is used here. */
+					add_gas_switch_event(d, &dc, elapsed_secs, gas_num);
 				}
 
 				if (eo.contains("Notify")) {
@@ -598,6 +601,23 @@ static void parse_gases(const QJsonObject &header, const QJsonArray &samples,
 }
 
 // AI-generated (Claude)
+/* The Suunto cloud API's dive header carries gradient factors directly
+ * (DiveHeader.LowGf/HighGf) unlike the app's own manual JSON export, which
+ * has no gradient factor fields at all and requires the paired FIT's
+ * DIVE_SETTINGS message instead (see patch_from_fit() below). Cloud-sourced
+ * JSON exports that were converted to also stash these under
+ * Diving.GfLow/GfHigh (not part of the app's own schema) can therefore
+ * import fully self-contained, without needing a paired FIT file. */
+static void parse_deco_settings(const QJsonObject &header, struct dive *d)
+{
+	QJsonObject diving = header["Diving"].toObject();
+	if (!diving.contains("GfLow") || !diving.contains("GfHigh"))
+		return;
+	add_extra_data(&d->dcs[0], "GF Low", std::to_string(diving["GfLow"].toInt()));
+	add_extra_data(&d->dcs[0], "GF High", std::to_string(diving["GfHigh"].toInt()));
+}
+
+// AI-generated (Claude)
 /* The Suunto app also exports a FIT file (same base name, different
  * extension) alongside the JSON for the same dive. The FIT file carries
  * the gas mix (via the FIT DIVE_GAS message) and gradient factors (via
@@ -640,6 +660,20 @@ static void patch_from_fit(const std::string &fit_buffer, struct dive *d, struct
 		cyl->gasmix = fit_dive->cylinders[0].gasmix;
 		cyl->cylinder_use = fit_dive->cylinders[0].cylinder_use;
 
+		/* parse_samples() already created any gas-switch event onto
+		 * cylinder 0 with whatever mix was known at the time (air, if
+		 * the JSON itself had no Diving.Gases block to patch_gases()
+		 * from). Refresh its cached value/mix now that the real gas
+		 * mix is known, so it doesn't stay stuck showing air. */
+		for (event &ev : d->dcs[0].events) {
+			if (!ev.is_gaschange() || ev.gas.index != 0)
+				continue;
+			struct event fresh = create_gas_switch_event(d, ev.time.seconds, 0);
+			ev.type = fresh.type;
+			ev.value = fresh.value;
+			ev.gas.mix = fresh.gas.mix;
+		}
+
 		if (fit_dive->cylinders.size() > 1)
 			report_info("Suunto JSON: paired FIT file has %u gas mixes; only gas 0 "
 				    "was applied (multi-gas Ocean import is not yet supported)",
@@ -648,16 +682,23 @@ static void patch_from_fit(const std::string &fit_buffer, struct dive *d, struct
 
 	/* Gradient factors: libdivecomputer's Garmin parser surfaces the FIT
 	 * DIVE_SETTINGS gf_low/gf_high as a "Deco model" extra_data string of
-	 * the form "Buhlmann ZHL-16C <low>/<high>". */
-	for (const extra_data &ed : fit_dive->dcs[0].extra_data) {
-		if (ed.key != "Deco model")
-			continue;
-		unsigned gf_low = 0, gf_high = 0;
-		if (sscanf(ed.value.c_str(), "Buhlmann ZHL-16C %u/%u", &gf_low, &gf_high) == 2) {
-			add_extra_data(&d->dcs[0], "GF Low", std::to_string(gf_low));
-			add_extra_data(&d->dcs[0], "GF High", std::to_string(gf_high));
+	 * the form "Buhlmann ZHL-16C <low>/<high>". Skip if parse_deco_settings()
+	 * already got these straight from the JSON (cloud-sourced exports) --
+	 * add_extra_data() has no dedup, so applying both would leave two
+	 * "GF Low"/"GF High" entries. */
+	bool have_gf = std::any_of(d->dcs[0].extra_data.begin(), d->dcs[0].extra_data.end(),
+				    [](const extra_data &ed) { return ed.key == "GF Low"; });
+	if (!have_gf) {
+		for (const extra_data &ed : fit_dive->dcs[0].extra_data) {
+			if (ed.key != "Deco model")
+				continue;
+			unsigned gf_low = 0, gf_high = 0;
+			if (sscanf(ed.value.c_str(), "Buhlmann ZHL-16C %u/%u", &gf_low, &gf_high) == 2) {
+				add_extra_data(&d->dcs[0], "GF Low", std::to_string(gf_low));
+				add_extra_data(&d->dcs[0], "GF High", std::to_string(gf_high));
+			}
+			break;
 		}
-		break;
 	}
 }
 
@@ -703,8 +744,12 @@ int suunto_json_import(const std::string &buffer, const std::string &fit_buffer,
 		? 0 : 1;
 
 	parse_header(header, d.get());
-	parse_samples(header, samples, d.get(), log, gas_offset);
+	/* parse_gases() runs before parse_samples() so that cylinders already
+	 * carry their real gas mix by the time parse_samples() builds gas
+	 * switch events from them (see the GasSwitch handling below). */
 	parse_gases(header, samples, d.get(), gas_offset);
+	parse_deco_settings(header, d.get());
+	parse_samples(header, samples, d.get(), log, gas_offset);
 
 	/* Divers need air. Add at least one cylinder exists even when no tank pod
 	 * was paired and no GasSwitch event is present in the log. */

--- a/dives/suunto_eon_core_multigas.json
+++ b/dives/suunto_eon_core_multigas.json
@@ -1,0 +1,110 @@
+{
+ "DeviceLog": {
+  "Header": {
+   "ActivityType": 51,
+   "DateTime": "2025-06-01T09:00:00.000+00:00",
+   "Depth": {
+    "Avg": 10.0,
+    "Max": 20.0
+   },
+   "Device": {
+    "Info": {
+     "HW": "70.6.0",
+     "SW": "3.0.1102"
+    },
+    "Name": "EON Core",
+    "SerialNumber": "1234567890"
+   },
+   "Diving": {
+    "Gases": [
+     {
+      "EndPressure": 15000000,
+      "Helium": 0,
+      "Oxygen": 0.21,
+      "StartPressure": 20000000,
+      "TankFillPressure": 20000000,
+      "TankSize": 0.012
+     },
+     {
+      "EndPressure": 17800000,
+      "Helium": 0,
+      "Oxygen": 0.5,
+      "StartPressure": 20000000,
+      "TankFillPressure": 20000000,
+      "TankSize": 0.01
+     }
+    ],
+    "SurfacePressure": 101300
+   },
+   "Duration": 110,
+   "Notes": "Regression test for gas switch cylinder assignment"
+  },
+  "Samples": [
+   {
+    "Events": [
+     {"GasSwitch": {"GasNumber": 1}},
+     {"State": {"Active": true, "Type": "Dive Active"}}
+    ],
+    "TimeISO8601": "2025-06-01T09:00:00.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 1, "Pressure": 20000000}],
+    "Depth": 5.0,
+    "TimeISO8601": "2025-06-01T09:00:10.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 1, "Pressure": 19000000}],
+    "Depth": 10.0,
+    "TimeISO8601": "2025-06-01T09:00:20.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 1, "Pressure": 18000000}],
+    "Depth": 15.0,
+    "TimeISO8601": "2025-06-01T09:00:30.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 1, "Pressure": 17000000}],
+    "Depth": 20.0,
+    "TimeISO8601": "2025-06-01T09:00:40.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 1, "Pressure": 16000000}],
+    "Depth": 20.0,
+    "TimeISO8601": "2025-06-01T09:00:50.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 1, "Pressure": 15000000}],
+    "Depth": 15.0,
+    "TimeISO8601": "2025-06-01T09:01:00.000+00:00"
+   },
+   {
+    "Events": [
+     {"GasSwitch": {"GasNumber": 2}}
+    ],
+    "Cylinders": [{"GasNumber": 2, "Pressure": 20000000}],
+    "Depth": 6.0,
+    "TimeISO8601": "2025-06-01T09:01:10.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 2, "Pressure": 19000000}],
+    "Depth": 6.0,
+    "TimeISO8601": "2025-06-01T09:01:20.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 2, "Pressure": 18500000}],
+    "Depth": 6.0,
+    "TimeISO8601": "2025-06-01T09:01:30.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 2, "Pressure": 18000000}],
+    "Depth": 3.0,
+    "TimeISO8601": "2025-06-01T09:01:40.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 2, "Pressure": 17800000}],
+    "Depth": 0.0,
+    "TimeISO8601": "2025-06-01T09:01:50.000+00:00"
+   }
+  ]
+ }
+}

--- a/dives/suunto_eon_core_multigas.xml
+++ b/dives/suunto_eon_core_multigas.xml
@@ -1,0 +1,44 @@
+<divelog program='subsurface' version='3'>
+<settings>
+</settings>
+<divesites>
+</divesites>
+<dives>
+<dive sac='202.331 l/min' date='2025-06-01' time='09:00:00' duration='1:50 min'>
+  <notes>Regression test for gas switch cylinder assignment</notes>
+  <cylinder size='12.0 l' workpressure='200.0 bar' description='AL84' />
+  <cylinder size='10.0 l' workpressure='200.0 bar' description='AL70' o2='50.0%' end='178.0 bar' />
+  <divecomputer model='Suunto EON Core' deviceid='ac07b301'>
+  <depth max='20.0 m' mean='9.636 m' />
+  <surface pressure='1.013 bar' />
+  <extradata key='Serial' value='1234567890' />
+  <extradata key='FW Version' value='3.0.1102' />
+  <extradata key='HW version' value='70.6.0' />
+  <event time='0:00 min' type='11' value='21' name='gaschange' cylinder='0' />
+  <event time='1:10 min' type='11' value='50' name='gaschange' cylinder='1' o2='50.0%' />
+  <sample time='0:10 min' depth='5.0 m' pressure0='200.0 bar' />
+  <sample time='0:10 min' depth='5.0 m' />
+  <sample time='0:20 min' depth='10.0 m' pressure0='190.0 bar' />
+  <sample time='0:20 min' depth='10.0 m' />
+  <sample time='0:30 min' depth='15.0 m' pressure0='180.0 bar' />
+  <sample time='0:30 min' depth='15.0 m' />
+  <sample time='0:40 min' depth='20.0 m' pressure0='170.0 bar' />
+  <sample time='0:40 min' depth='20.0 m' />
+  <sample time='0:50 min' depth='20.0 m' pressure0='160.0 bar' />
+  <sample time='0:50 min' depth='20.0 m' />
+  <sample time='1:00 min' depth='15.0 m' pressure0='150.0 bar' />
+  <sample time='1:00 min' depth='15.0 m' />
+  <sample time='1:10 min' depth='6.0 m' pressure1='200.0 bar' />
+  <sample time='1:10 min' depth='6.0 m' />
+  <sample time='1:20 min' depth='6.0 m' pressure1='190.0 bar' />
+  <sample time='1:20 min' depth='6.0 m' />
+  <sample time='1:30 min' depth='6.0 m' pressure1='185.0 bar' />
+  <sample time='1:30 min' depth='6.0 m' />
+  <sample time='1:40 min' depth='3.0 m' pressure1='180.0 bar' />
+  <sample time='1:40 min' depth='3.0 m' />
+  <sample time='1:50 min' depth='0.0 m' pressure1='178.0 bar' />
+  <sample time='1:50 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>

--- a/dives/suunto_ocean_gf.json
+++ b/dives/suunto_ocean_gf.json
@@ -1,0 +1,71 @@
+{
+ "DeviceLog": {
+  "Header": {
+   "ActivityType": 51,
+   "DateTime": "2025-06-01T09:00:00.000+00:00",
+   "Depth": {
+    "Avg": 10.0,
+    "Max": 20.0
+   },
+   "Device": {
+    "Info": {
+     "HW": "Seal_RevA3",
+     "SW": "2.40.56"
+    },
+    "Name": "Porvoo",
+    "SerialNumber": "9876543210"
+   },
+   "Diving": {
+    "Gases": [
+     {
+      "EndPressure": 15000000,
+      "Helium": 0,
+      "Oxygen": 0.21,
+      "StartPressure": 20000000,
+      "TankFillPressure": 20000000,
+      "TankSize": 0.012
+     }
+    ],
+    "GfHigh": 85,
+    "GfLow": 30,
+    "SurfacePressure": 101300
+   },
+   "Duration": 50,
+   "Notes": "Regression test for reading gradient factors straight from JSON"
+  },
+  "Samples": [
+   {
+    "Events": [
+     {"GasSwitch": {"GasNumber": 0}},
+     {"State": {"Active": true, "Type": "Dive Active"}}
+    ],
+    "TimeISO8601": "2025-06-01T09:00:00.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 20000000}],
+    "Depth": 10.0,
+    "TimeISO8601": "2025-06-01T09:00:10.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 18000000}],
+    "Depth": 20.0,
+    "TimeISO8601": "2025-06-01T09:00:20.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 17000000}],
+    "Depth": 20.0,
+    "TimeISO8601": "2025-06-01T09:00:30.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 16000000}],
+    "Depth": 10.0,
+    "TimeISO8601": "2025-06-01T09:00:40.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 15000000}],
+    "Depth": 0.0,
+    "TimeISO8601": "2025-06-01T09:00:50.000+00:00"
+   }
+  ]
+ }
+}

--- a/dives/suunto_ocean_gf.xml
+++ b/dives/suunto_ocean_gf.xml
@@ -1,0 +1,32 @@
+<divelog program='subsurface' version='3'>
+<settings>
+</settings>
+<divesites>
+</divesites>
+<dives>
+<dive sac='288.493 l/min' date='2025-06-01' time='09:00:00' duration='0:50 min'>
+  <notes>Regression test for reading gradient factors straight from JSON</notes>
+  <cylinder size='12.0 l' workpressure='200.0 bar' description='AL84' end='150.0 bar' />
+  <divecomputer model='Suunto Ocean' deviceid='1656d69c'>
+  <depth max='20.0 m' mean='12.0 m' />
+  <surface pressure='1.013 bar' />
+  <extradata key='Serial' value='9876543210' />
+  <extradata key='FW Version' value='2.40.56' />
+  <extradata key='HW version' value='Seal_RevA3' />
+  <extradata key='GF Low' value='30' />
+  <extradata key='GF High' value='85' />
+  <event time='0:00 min' type='11' value='21' name='gaschange' cylinder='0' />
+  <sample time='0:10 min' depth='10.0 m' pressure0='200.0 bar' />
+  <sample time='0:10 min' depth='10.0 m' />
+  <sample time='0:20 min' depth='20.0 m' pressure0='180.0 bar' />
+  <sample time='0:20 min' depth='20.0 m' />
+  <sample time='0:30 min' depth='20.0 m' pressure0='170.0 bar' />
+  <sample time='0:30 min' depth='20.0 m' />
+  <sample time='0:40 min' depth='10.0 m' pressure0='160.0 bar' />
+  <sample time='0:40 min' depth='10.0 m' />
+  <sample time='0:50 min' depth='0.0 m' pressure0='150.0 bar' />
+  <sample time='0:50 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>

--- a/dives/suunto_ocean_gf_fit_override.json
+++ b/dives/suunto_ocean_gf_fit_override.json
@@ -1,0 +1,71 @@
+{
+ "DeviceLog": {
+  "Header": {
+   "ActivityType": 51,
+   "DateTime": "2025-06-01T09:00:00.000+00:00",
+   "Depth": {
+    "Avg": 10.0,
+    "Max": 20.0
+   },
+   "Device": {
+    "Info": {
+     "HW": "Seal_RevA3",
+     "SW": "2.40.56"
+    },
+    "Name": "Porvoo",
+    "SerialNumber": "9876543210"
+   },
+   "Diving": {
+    "Gases": [
+     {
+      "EndPressure": 15000000,
+      "Helium": 0,
+      "Oxygen": 0.21,
+      "StartPressure": 20000000,
+      "TankFillPressure": 20000000,
+      "TankSize": 0.012
+     }
+    ],
+    "GfHigh": 99,
+    "GfLow": 10,
+    "SurfacePressure": 101300
+   },
+   "Duration": 50,
+   "Notes": "Regression test for FIT gradient factors overriding JSON ones"
+  },
+  "Samples": [
+   {
+    "Events": [
+     {"GasSwitch": {"GasNumber": 0}},
+     {"State": {"Active": true, "Type": "Dive Active"}}
+    ],
+    "TimeISO8601": "2025-06-01T09:00:00.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 20000000}],
+    "Depth": 10.0,
+    "TimeISO8601": "2025-06-01T09:00:10.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 18000000}],
+    "Depth": 20.0,
+    "TimeISO8601": "2025-06-01T09:00:20.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 17000000}],
+    "Depth": 20.0,
+    "TimeISO8601": "2025-06-01T09:00:30.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 16000000}],
+    "Depth": 10.0,
+    "TimeISO8601": "2025-06-01T09:00:40.000+00:00"
+   },
+   {
+    "Cylinders": [{"GasNumber": 0, "Pressure": 15000000}],
+    "Depth": 0.0,
+    "TimeISO8601": "2025-06-01T09:00:50.000+00:00"
+   }
+  ]
+ }
+}

--- a/dives/suunto_ocean_gf_fit_override.xml
+++ b/dives/suunto_ocean_gf_fit_override.xml
@@ -1,0 +1,32 @@
+<divelog program='subsurface' version='3'>
+<settings>
+</settings>
+<divesites>
+</divesites>
+<dives>
+<dive sac='293.944 l/min' date='2025-06-01' time='09:00:00' duration='0:50 min'>
+  <notes>Regression test for FIT gradient factors overriding JSON ones</notes>
+  <cylinder size='12.0 l' workpressure='200.0 bar' description='AL84' o2='32.0%' end='150.0 bar' />
+  <divecomputer model='Suunto Ocean' deviceid='1656d69c'>
+  <depth max='20.0 m' mean='12.0 m' />
+  <surface pressure='1.013 bar' />
+  <extradata key='Serial' value='9876543210' />
+  <extradata key='FW Version' value='2.40.56' />
+  <extradata key='HW version' value='Seal_RevA3' />
+  <extradata key='GF Low' value='40' />
+  <extradata key='GF High' value='85' />
+  <event time='0:00 min' type='11' value='32' name='gaschange' cylinder='0' o2='32.0%' />
+  <sample time='0:10 min' depth='10.0 m' pressure0='200.0 bar' />
+  <sample time='0:10 min' depth='10.0 m' />
+  <sample time='0:20 min' depth='20.0 m' pressure0='180.0 bar' />
+  <sample time='0:20 min' depth='20.0 m' />
+  <sample time='0:30 min' depth='20.0 m' pressure0='170.0 bar' />
+  <sample time='0:30 min' depth='20.0 m' />
+  <sample time='0:40 min' depth='10.0 m' pressure0='160.0 bar' />
+  <sample time='0:40 min' depth='10.0 m' />
+  <sample time='0:50 min' depth='0.0 m' pressure0='150.0 bar' />
+  <sample time='0:50 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -684,6 +684,22 @@ void TestParse::importSuuntoJsonEonCore()
 		SUBSURFACE_TEST_DATA "/dives/suunto_eon_core_nitrox.xml");
 }
 
+// AI-generated (Claude)
+void TestParse::importSuuntoJsonEonCoreMultiGas()
+{
+#if defined(SUBSURFACE_MOBILE)
+	QSKIP("Not testing Suunto JSON import on SUBSURFACE_MOBILE");
+#endif
+	/* Regression guard for the gas-switch cylinder mismatch fix: a dive with
+	 * a mid-dive GasSwitch to a second gas whose mix differs from the first
+	 * (EAN21 -> EAN50) must attach the switch event to that second cylinder,
+	 * not misattribute it via the gas-mix-distance fallback. */
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/suunto_eon_core_multigas.json", &divelog), 0);
+	QCOMPARE(save_dives("./test_suunto_eon_core_multigas.ssrf"), 0);
+	FILE_COMPARE("./test_suunto_eon_core_multigas.ssrf",
+		SUBSURFACE_TEST_DATA "/dives/suunto_eon_core_multigas.xml");
+}
+
 void TestParse::importSuuntoJsonOcean()
 {
 #if defined(SUBSURFACE_MOBILE)
@@ -738,6 +754,25 @@ void TestParse::importSuuntoJsonOceanWithFit()
 	QCOMPARE(save_dives("./test_suunto_ocean_nitrox.ssrf"), 0);
 	FILE_COMPARE("./test_suunto_ocean_nitrox.ssrf",
 		SUBSURFACE_TEST_DATA "/dives/suunto_ocean_nitrox.xml");
+#endif
+}
+
+// AI-generated (Claude)
+void TestParse::importSuuntoJsonOceanGf()
+{
+#if defined(SUBSURFACE_MOBILE)
+	QSKIP("Not testing Suunto JSON import on SUBSURFACE_MOBILE");
+#else
+	/* Regression guard for reading gradient factors straight from the JSON:
+	 * a cloud-sourced export carries both Diving.Gases and Diving.GfLow/
+	 * GfHigh, so it must import fully self-contained (no paired FIT) with
+	 * "GF Low"/"GF High" extra_data taken directly from the JSON. */
+	auto [json_buf, jerr] = readfile(SUBSURFACE_TEST_DATA "/dives/suunto_ocean_gf.json");
+	QVERIFY(jerr > 0);
+	QCOMPARE(suunto_json_import(json_buf, std::string(), &divelog), 1);
+	QCOMPARE(save_dives("./test_suunto_ocean_gf.ssrf"), 0);
+	FILE_COMPARE("./test_suunto_ocean_gf.ssrf",
+		SUBSURFACE_TEST_DATA "/dives/suunto_ocean_gf.xml");
 #endif
 }
 

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -776,4 +776,26 @@ void TestParse::importSuuntoJsonOceanGf()
 #endif
 }
 
+// AI-generated (Claude)
+void TestParse::importSuuntoJsonOceanGfFitOverride()
+{
+#if defined(SUBSURFACE_MOBILE)
+	QSKIP("Not testing Suunto JSON import on SUBSURFACE_MOBILE");
+#else
+	/* Regression guard for GF precedence: when both the JSON's
+	 * Diving.GfLow/GfHigh (10/99) and a paired FIT's DIVE_SETTINGS gradient
+	 * factors (the real suunto_ocean_nitrox.fit encodes 40/85) are present,
+	 * the FIT's values must win, since that's a standardised format shared
+	 * across manufacturers, unlike the proprietary JSON fields. */
+	auto [json_buf, jerr] = readfile(SUBSURFACE_TEST_DATA "/dives/suunto_ocean_gf_fit_override.json");
+	auto [fit_buf, ferr] = readfile(SUBSURFACE_TEST_DATA "/dives/suunto_ocean_nitrox.fit");
+	QVERIFY(jerr > 0);
+	QVERIFY(ferr > 0);
+	QCOMPARE(suunto_json_import(json_buf, fit_buf, &divelog), 1);
+	QCOMPARE(save_dives("./test_suunto_ocean_gf_fit_override.ssrf"), 0);
+	FILE_COMPARE("./test_suunto_ocean_gf_fit_override.ssrf",
+		SUBSURFACE_TEST_DATA "/dives/suunto_ocean_gf_fit_override.xml");
+#endif
+}
+
 QTEST_GUILESS_MAIN(TestParse)

--- a/tests/testparse.h
+++ b/tests/testparse.h
@@ -53,9 +53,11 @@ private slots:
 
 	void importSuuntoJsonNautic();
 	void importSuuntoJsonEonCore();
+	void importSuuntoJsonEonCoreMultiGas();
 	void importSuuntoJsonOcean();
 	void importSuuntoJsonOceanNoFit();
 	void importSuuntoJsonOceanWithFit();
+	void importSuuntoJsonOceanGf();
 private:
 	sqlite3 *_sqlite3_handle = NULL;
 };

--- a/tests/testparse.h
+++ b/tests/testparse.h
@@ -58,6 +58,7 @@ private slots:
 	void importSuuntoJsonOceanNoFit();
 	void importSuuntoJsonOceanWithFit();
 	void importSuuntoJsonOceanGf();
+	void importSuuntoJsonOceanGfFitOverride();
 private:
 	sqlite3 *_sqlite3_handle = NULL;
 };


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
parse_samples() built GasSwitch events with a raw add_event() call, passing the target cylinder index as the "value" argument. But for SAMPLE_EVENT_GASCHANGE, event::event() interprets "value" as an encoded O2 percentage, not a cylinder index, and leaves gas.index unset. Later, validate_gaschange()'s fixup pass has to guess the cylinder from that bogus "percentage" via nearest-match against the dive's real gas mixes. For a single-gas dive this coincidentally still finds the only cylinder, but for any multi-gas dive it silently attaches the wrong cylinder to switches past the first -- on a real 50 m/EAN50 dive, the switch to the deco gas was being recorded against the air cylinder, showing up as missing/wrong gas data in the equipment tab and profile.

Fix by building these events with the existing
add_gas_switch_event()/create_gas_switch_event() helpers (the same ones real dive computer backends use), which set gas.index directly from the cylinder's actual gas mix instead of relying on the best-guess fallback. This requires parse_gases() to run before parse_samples(), so cylinders already carry their real mix by the time the switch events are built from them.

patch_from_fit() patches cylinder 0's mix from a paired FIT file when the JSON itself has no gas info (e.g. Ocean's own manual JSON export). Since any matching gas-switch event's value/mix is now captured up front (via gas.index) instead of being deferred to validate_gaschange()'s fixup pass, it must also refresh that cached value once the FIT-derived mix lands, or it stays stuck showing air.

Separately, add parse_deco_settings() to read gradient factors directly from the JSON's Diving.GfLow/GfHigh when present. The Suunto cloud API's dive header carries GF directly, unlike the app's own manual JSON export (which has neither gas nor GF info and relies entirely on a paired FIT for both) -- so a JSON export built from the cloud API can now import fully self-contained, with no paired FIT needed at all. patch_from_fit()'s FIT-based GF patch is now guarded to skip if GF was already set from JSON, since add_extra_data() has no dedup and applying both would leave two "GF Low"/"GF High" entries.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
Fixes #4907 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
