### PR TITLE
copr: use pkgconfig(libgit2) instead of libgit2-devel

### DIFF
--- a/packaging/copr/subsurface.spec
+++ b/packaging/copr/subsurface.spec
@@ -34,7 +34,7 @@ BuildRequires:  libxml2-devel
 BuildRequires:  libxslt-devel
 BuildRequires:  libssh2-devel
 BuildRequires:  libcurl-devel
-BuildRequires:  libgit2-devel
+BuildRequires:  pkgconfig(libgit2)
 BuildRequires:  libmtp-devel
 BuildRequires:  LibRaw-devel
 BuildRequires:  netpbm-devel


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
Fedora rawhide renamed the libgit2 subpackage to the SONAME-versioned libgit2_1.9-devel, which no longer provides libgit2-devel, breaking dependency resolution for COPR rawhide builds. Requiring pkgconfig(libgit2) instead resolves on both the new versioned package and the plain libgit2-devel still shipped by older Fedora releases, matching how CMake already locates the library via pkg-config.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
Fixes #4909 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
