### PR TITLE
BLE: fix read_characteristic() to wait for async response

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -947,7 +947,17 @@ dc_status_t BLEObject::read_characteristic(const QBluetoothUuid &uuid, char *res
 		}
 		report_info("Reading BLE characteristic %s", to_str(uuid).c_str());
 		s->readCharacteristic(ch);
-		QByteArray val = ch.value();
+		// AI-generated (Claude)
+		// readCharacteristic() is asynchronous: the value arrives via
+		// characteristicRead -> characteristcStateChanged -> receivedPackets.
+		// Wait for it and consume it here so it does not leak into the
+		// data-transfer queue used by subsequent dc_iostream_read calls.
+		WAITFOR(!receivedPackets.isEmpty(), timeout);
+		if (receivedPackets.isEmpty()) {
+			report_error("Timeout reading characteristic %s", to_str(uuid).c_str());
+			return DC_STATUS_TIMEOUT;
+		}
+		QByteArray val = receivedPackets.takeFirst();
 		if ((size_t)val.size() != size) {
 			report_error("Unexpected read characteristic size (%lld): expected %lld", (long long)val.size(), (long long)size);
 			return DC_STATUS_DATAFORMAT;


### PR DESCRIPTION
## Problem

`readCharacteristic()` is asynchronous — the characteristic value arrives via
the `characteristicRead` signal, which feeds into `characteristcStateChanged`
and then into `receivedPackets`. The old code called `ch.value()` immediately
after `readCharacteristic()`, reading stale or empty data before the response
had arrived.

## Fix

Replace the immediate `ch.value()` read with a `WAITFOR` on `receivedPackets`
and consume the result with `takeFirst()`. This prevents the value from leaking
into the data-transfer queue used by subsequent `dc_iostream_read` calls.

## Testing

Tested by a human on a Cressi Donatello with BT cradle.

## Notes

- AI-generated code (Claude), reviewed and tested by a human.