### PR TITLE
BLE: skip MAC address check on macOS/iOS

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -673,8 +673,14 @@ dc_status_t qt_ble_open(void **io, dc_context_t *, const char *devaddr, device_d
 	//
 	// NOTE: this MAC-based fallback must NOT be used on macOS/iOS, where
 	// CoreBluetooth identifies peripherals by UUID rather than MAC address.
+	// On those platforms address() is always null -- only check isValid().
 	//
+	// AI-generated (Claude)
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+	if (!remoteDevice.isValid()) {
+#else
 	if (!remoteDevice.isValid() || remoteDevice.address().isNull()) {
+#endif
 #if defined(Q_OS_ANDROID)
 		QBluetoothAddress addr{QString(devaddr)};
 		if (addr.isNull()) {


### PR DESCRIPTION
## Problem

CoreBluetooth (macOS/iOS) identifies BLE peripherals by UUID, not MAC address.
`QBluetoothDeviceInfo::address()` therefore always returns a null address on
those platforms. The existing condition:

```cpp
if (!remoteDevice.isValid() || remoteDevice.address().isNull())
```

caused valid, UUID-based device infos to be discarded and the connection to
fail, because `address().isNull()` is always true on macOS/iOS.

## Fix

Add a platform guard so the MAC-address null check is skipped on macOS and iOS:

```cpp
#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
    if (!remoteDevice.isValid()) {
#else
    if (!remoteDevice.isValid() || remoteDevice.address().isNull()) {
#endif
```

## Testing

Tested by a human on a Cressi Donatello with BT cradle.

## Notes

AI-generated code (Claude), reviewed and tested by a human.