### PR TITLE
ui: display true count of dives in titlebar

### DIFF
--- a/core/divefilter.cpp
+++ b/core/divefilter.cpp
@@ -192,10 +192,20 @@ bool DiveFilter::diveSiteMode() const
 QString DiveFilter::shownText() const
 {
 	size_t num = divelog.dives.size();
-	if (diveSiteMode() || filterData.validFilter())
+
+	if (diveSiteMode() || filterData.validFilter()) {
 		return gettextFromC::tr("%L1/%L2 shown").arg(shown_dives).arg(num);
-	else
-		return gettextFromC::tr("%L1 dives").arg(num);
+	} else {
+		size_t invalid = 0;
+		if (!prefs.display_invalid_dives)
+			invalid = invalidDives().size();
+
+		if (invalid) {
+			return gettextFromC::tr("%L1 dives)(%L2 shown").arg(num).arg(num-invalid);
+		} else {
+			return gettextFromC::tr("%L1 dives").arg(num);
+		}
+	}
 }
 
 int DiveFilter::shownDives() const
@@ -219,6 +229,17 @@ std::vector<dive *> DiveFilter::visibleDives() const
 
 	for (auto &d: divelog.dives) {
 		if (!d->hidden_by_filter)
+			res.push_back(d.get());
+	}
+	return res;
+}
+
+std::vector<dive *> DiveFilter::invalidDives() const
+{
+	std::vector<dive *> res;
+
+	for (auto &d: divelog.dives) {
+		if (d->invalid)
 			res.push_back(d.get());
 	}
 	return res;

--- a/core/divefilter.h
+++ b/core/divefilter.h
@@ -44,6 +44,7 @@ public:
 	int shownDives() const;
 	bool diveSiteMode() const; // returns true if we're filtering on dive site (on mobile always returns false)
 	std::vector<dive *> visibleDives() const;
+	std::vector<dive *> invalidDives() const;
 #ifndef SUBSURFACE_MOBILE
 	const std::vector<dive_site *> &filteredDiveSites() const;
 	void startFilterDiveSites(std::vector<dive_site *> ds);


### PR DESCRIPTION
## Problem

When the "hide invalid dives" option is selected, the number of dives
shown in the dive list and the number shown in the window title do not
match. For example, with 23 total dives and one marked invalid, the
list shows 22 entries but the title bar shows 23.

## Fix

Introduced `DiveFilter::invalidDives()` helper and reworked the title
composing methods to account for invalid dives, displaying total and
shown dive counts in the title bar analogically to how they are
displayed for trip dives.

## Testing

Any dive log with dives marked as invalid reproduces the issue.
Tested with 23 total dives / 1 invalid — title bar now correctly
shows the filtered count.

## Related

Originally submitted as zazolabs/subsurface#1.