### PR TITLE
Mobile: Add configurable date and time formats to mobile settings

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -352,10 +352,6 @@ static std::vector<std::string> get_languages(const QLocale &loc)
  */
 void initUiLanguage()
 {
-	QString shortDateFormat;
-	QString dateFormat;
-	QString timeFormat;
-
 	// set loc as system language or selected language
 	loc = QLocale(qPrefLanguage::lang_locale());
 	if (qPrefLanguage::use_system_language() && !QLocale().uiLanguages().isEmpty()) {
@@ -392,30 +388,7 @@ void initUiLanguage()
 
 	prefs.locale.lang_locale = uiLang;
 
-	if (!prefs.date_format_override || prefs.date_format.empty()) {
-		// derive our standard date format from what the locale gives us
-		// the long format uses long weekday and month names, so replace those with the short ones
-		// for time we don't want the time zone designator and don't want leading zeroes on the hours
-		dateFormat = loc.dateFormat(QLocale::LongFormat);
-		dateFormat.replace("dddd,", "ddd").replace("dddd", "ddd").replace("MMMM", "MMM");
-		// special hack for Swedish as our switching from long weekday names to short weekday names
-		// messes things up there
-		dateFormat.replace("'en' 'den' d:'e'", " d");
-		prefs.date_format = dateFormat.toStdString();
-	}
-
-	if (!prefs.date_format_override || prefs.date_format_short.empty()) {
-		// derive our standard date format from what the locale gives us
-		shortDateFormat = loc.dateFormat(QLocale::ShortFormat);
-		prefs.date_format_short = shortDateFormat.toStdString();
-	}
-
-	if (!prefs.time_format_override || prefs.time_format.empty()) {
-		timeFormat = loc.timeFormat();
-		timeFormat.replace("(t)", "").replace(" t", "").replace("t", "").replace("hh", "h").replace("HH", "H").replace("'kl'.", "");
-		timeFormat.replace(".ss", "").replace(":ss", "").replace("ss", "");
-		prefs.time_format = timeFormat.toStdString();
-	}
+	qPrefLanguage::applyLocaleDefaults(loc);
 }
 
 QLocale getLocale()

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -2,7 +2,14 @@
 #include "qPrefLanguage.h"
 #include "qPrefPrivate.h"
 
+#include <QDate>
+#include <QTime>
+#include <QVariantMap>
+
 static const QString group = QStringLiteral("Language");
+
+static const QDate previewDate(2000, 12, 31);
+static const QTime previewTime(13, 45);
 
 qPrefLanguage *qPrefLanguage::instance()
 {
@@ -22,18 +29,276 @@ void qPrefLanguage::loadSync(bool doSync)
 	disk_use_system_language(doSync);
 }
 
-HANDLE_PREFERENCE_TXT(Language, "date_format", date_format);
+DISK_LOADSYNC_TXT(Language, "date_format", date_format);
 
-HANDLE_PREFERENCE_BOOL(Language,"date_format_override", date_format_override);
+DISK_LOADSYNC_BOOL(Language,"date_format_override", date_format_override);
 
-HANDLE_PREFERENCE_TXT(Language, "date_format_short", date_format_short);
+DISK_LOADSYNC_TXT(Language, "date_format_short", date_format_short);
 
 HANDLE_PREFERENCE_TXT_EXT(Language, "UiLanguage", language, locale.);
 
-HANDLE_PREFERENCE_TXT_EXT(Language, "UiLangLocale", lang_locale, locale.);
+DISK_LOADSYNC_TXT_EXT(Language, "UiLangLocale", lang_locale, locale.);
 
-HANDLE_PREFERENCE_TXT(Language, "time_format", time_format);
+DISK_LOADSYNC_TXT(Language, "time_format", time_format);
 
-HANDLE_PREFERENCE_BOOL(Language, "time_format_override", time_format_override);
+DISK_LOADSYNC_BOOL(Language, "time_format_override", time_format_override);
 
-HANDLE_PREFERENCE_BOOL_EXT(Language, "UseSystemLanguage", use_system_language, locale.);
+DISK_LOADSYNC_BOOL_EXT(Language, "UseSystemLanguage", use_system_language, locale.);
+
+// AI-generated (Claude): Keep legacy keys while applying related formats as one state change.
+QLocale qPrefLanguage::preferenceLocale()
+{
+	if (use_system_language() && !QLocale().uiLanguages().isEmpty())
+		return QLocale(QLocale().uiLanguages().first());
+	return QLocale(lang_locale());
+}
+
+QString qPrefLanguage::defaultDateFormat(const QLocale &locale)
+{
+	QString format = locale.dateFormat(QLocale::LongFormat);
+	format.replace("dddd,", "ddd").replace("dddd", "ddd").replace("MMMM", "MMM");
+	format.replace("'en' 'den' d:'e'", " d");
+	return format;
+}
+
+QString qPrefLanguage::defaultShortDateFormat(const QLocale &locale)
+{
+	return locale.dateFormat(QLocale::ShortFormat);
+}
+
+QString qPrefLanguage::defaultTimeFormat(const QLocale &locale)
+{
+	QString format = locale.timeFormat();
+	format.replace("(t)", "").replace(" t", "").replace("t", "").replace("hh", "h").replace("HH", "H").replace("'kl'.", "");
+	format.replace(".ss", "").replace(":ss", "").replace("ss", "");
+	return format;
+}
+
+QString qPrefLanguage::effectiveDateFormat()
+{
+	return date_format_override() && !date_format().isEmpty() ? date_format() : defaultDateFormat(preferenceLocale());
+}
+
+QString qPrefLanguage::effectiveDateFormatShort()
+{
+	return date_format_override() && !date_format_short().isEmpty() ? date_format_short() : defaultShortDateFormat(preferenceLocale());
+}
+
+QString qPrefLanguage::effectiveTimeFormat()
+{
+	return time_format_override() && !time_format().isEmpty() ? time_format() : defaultTimeFormat(preferenceLocale());
+}
+
+QString qPrefLanguage::longDatePreview()
+{
+	return preferenceLocale().toString(previewDate, effectiveDateFormat());
+}
+
+QString qPrefLanguage::shortDatePreview()
+{
+	return preferenceLocale().toString(previewDate, effectiveDateFormatShort());
+}
+
+QString qPrefLanguage::timePreview()
+{
+	return preferenceLocale().toString(previewTime, effectiveTimeFormat());
+}
+
+QVariantList qPrefLanguage::dateFormatPresets()
+{
+	const QLocale locale = preferenceLocale();
+	const QVariantList presets = {
+		QVariantMap{ { "id", "system" }, { "name", tr("System default") },
+			     { "longFormat", defaultDateFormat(locale) }, { "shortFormat", defaultShortDateFormat(locale) } },
+		QVariantMap{ { "id", "day-first" }, { "name", tr("Day first") },
+			     { "longFormat", "dd.MM.yyyy" }, { "shortFormat", "d.M.yy" } },
+		QVariantMap{ { "id", "month-first" }, { "name", tr("Month first") },
+			     { "longFormat", "MM/dd/yyyy" }, { "shortFormat", "M/d/yy" } },
+		QVariantMap{ { "id", "iso" }, { "name", tr("ISO") },
+			     { "longFormat", "yyyy-MM-dd" }, { "shortFormat", "yy-M-d" } }
+	};
+	QVariantList result;
+	for (const QVariant &entry: presets) {
+		QVariantMap preset = entry.toMap();
+		preset["preview"] = locale.toString(previewDate, preset["longFormat"].toString()) +
+			QStringLiteral(" / ") + locale.toString(previewDate, preset["shortFormat"].toString());
+		result.append(preset);
+	}
+	return result;
+}
+
+QVariantList qPrefLanguage::timeFormatPresets()
+{
+	const QLocale locale = preferenceLocale();
+	const QVariantList presets = {
+		QVariantMap{ { "id", "system" }, { "name", tr("System default") }, { "format", defaultTimeFormat(locale) } },
+		QVariantMap{ { "id", "24-hour" }, { "name", tr("24-hour") }, { "format", "hh:mm" } },
+		QVariantMap{ { "id", "12-hour" }, { "name", tr("12-hour") }, { "format", "h:mm AP" } }
+	};
+	QVariantList result;
+	for (const QVariant &entry: presets) {
+		QVariantMap preset = entry.toMap();
+		preset["preview"] = locale.toString(previewTime, preset["format"].toString());
+		result.append(preset);
+	}
+	return result;
+}
+
+void qPrefLanguage::applyFormats(const QString &longDateFormat, const QString &shortDateFormat,
+				 const QString &timeFormat, bool overrideDate, bool overrideTime)
+{
+	const QString effectiveLongDate = overrideDate && !longDateFormat.isEmpty() ? longDateFormat : defaultDateFormat(preferenceLocale());
+	const QString effectiveShortDate = overrideDate && !shortDateFormat.isEmpty() ? shortDateFormat : defaultShortDateFormat(preferenceLocale());
+	const QString effectiveTime = overrideTime && !timeFormat.isEmpty() ? timeFormat : defaultTimeFormat(preferenceLocale());
+	storeFormats(effectiveLongDate, effectiveShortDate, effectiveTime, overrideDate, overrideTime);
+}
+
+void qPrefLanguage::storeFormats(const QString &longDateFormat, const QString &shortDateFormat,
+				 const QString &timeFormat, bool overrideDate, bool overrideTime)
+{
+	const bool dateChanged = date_format() != longDateFormat;
+	const bool shortDateChanged = date_format_short() != shortDateFormat;
+	const bool dateOverrideChanged = date_format_override() != overrideDate;
+	const bool timeChanged = time_format() != timeFormat;
+	const bool timeOverrideChanged = time_format_override() != overrideTime;
+
+	if (!dateChanged && !shortDateChanged && !dateOverrideChanged && !timeChanged && !timeOverrideChanged)
+		return;
+
+	prefs.date_format = longDateFormat.toStdString();
+	prefs.date_format_short = shortDateFormat.toStdString();
+	prefs.date_format_override = overrideDate;
+	prefs.time_format = timeFormat.toStdString();
+	prefs.time_format_override = overrideTime;
+	disk_date_format(true);
+	disk_date_format_short(true);
+	disk_date_format_override(true);
+	disk_time_format(true);
+	disk_time_format_override(true);
+
+	qPrefLanguage *language = instance();
+	if (dateChanged)
+		emit language->date_formatChanged(longDateFormat);
+	if (shortDateChanged)
+		emit language->date_format_shortChanged(shortDateFormat);
+	if (dateOverrideChanged)
+		emit language->date_format_overrideChanged(overrideDate);
+	if (timeChanged)
+		emit language->time_formatChanged(timeFormat);
+	if (timeOverrideChanged)
+		emit language->time_format_overrideChanged(overrideTime);
+	emit language->dateTimeFormatsChanged();
+}
+
+void qPrefLanguage::applyDateTimeFormats(const QString &longDateFormat, const QString &shortDateFormat,
+					 const QString &timeFormat, bool overrideDate, bool overrideTime)
+{
+	applyFormats(longDateFormat, shortDateFormat, timeFormat, overrideDate, overrideTime);
+}
+
+void qPrefLanguage::applyDatePreset(const QString &preset)
+{
+	for (const QVariant &entry: dateFormatPresets()) {
+		const QVariantMap values = entry.toMap();
+		if (values["id"].toString() == preset) {
+			applyFormats(values["longFormat"].toString(), values["shortFormat"].toString(),
+				     effectiveTimeFormat(), preset != QStringLiteral("system"), time_format_override());
+			return;
+		}
+	}
+}
+
+void qPrefLanguage::applyTimePreset(const QString &preset)
+{
+	for (const QVariant &entry: timeFormatPresets()) {
+		const QVariantMap values = entry.toMap();
+		if (values["id"].toString() == preset) {
+			applyFormats(effectiveDateFormat(), effectiveDateFormatShort(), values["format"].toString(),
+				     date_format_override(), preset != QStringLiteral("system"));
+			return;
+		}
+	}
+}
+
+void qPrefLanguage::restoreDateTimeDefaults()
+{
+	applyFormats(QString(), QString(), QString(), false, false);
+}
+
+void qPrefLanguage::applyLocaleDefaults(const QLocale &locale)
+{
+	const QString longDate = date_format_override() && !date_format().isEmpty() ? date_format() : defaultDateFormat(locale);
+	const QString shortDate = date_format_override() && !date_format_short().isEmpty() ? date_format_short() : defaultShortDateFormat(locale);
+	const QString time = time_format_override() && !time_format().isEmpty() ? time_format() : defaultTimeFormat(locale);
+	storeFormats(longDate, shortDate, time, date_format_override(), time_format_override());
+}
+
+void qPrefLanguage::set_date_format(const QString &value)
+{
+	if (value == date_format())
+		return;
+	prefs.date_format = value.toStdString();
+	disk_date_format(true);
+	emit instance()->date_formatChanged(value);
+	emit instance()->dateTimeFormatsChanged();
+}
+
+void qPrefLanguage::set_date_format_override(bool value)
+{
+	if (value == date_format_override())
+		return;
+	prefs.date_format_override = value;
+	disk_date_format_override(true);
+	emit instance()->date_format_overrideChanged(value);
+	emit instance()->dateTimeFormatsChanged();
+}
+
+void qPrefLanguage::set_date_format_short(const QString &value)
+{
+	if (value == date_format_short())
+		return;
+	prefs.date_format_short = value.toStdString();
+	disk_date_format_short(true);
+	emit instance()->date_format_shortChanged(value);
+	emit instance()->dateTimeFormatsChanged();
+}
+
+void qPrefLanguage::set_time_format(const QString &value)
+{
+	if (value == time_format())
+		return;
+	prefs.time_format = value.toStdString();
+	disk_time_format(true);
+	emit instance()->time_formatChanged(value);
+	emit instance()->dateTimeFormatsChanged();
+}
+
+void qPrefLanguage::set_time_format_override(bool value)
+{
+	if (value == time_format_override())
+		return;
+	prefs.time_format_override = value;
+	disk_time_format_override(true);
+	emit instance()->time_format_overrideChanged(value);
+	emit instance()->dateTimeFormatsChanged();
+}
+
+void qPrefLanguage::set_lang_locale(const QString &value)
+{
+	if (value == lang_locale())
+		return;
+	prefs.locale.lang_locale = value.toStdString();
+	disk_lang_locale(true);
+	emit instance()->lang_localeChanged(value);
+	emit instance()->dateTimeFormatsChanged();
+}
+
+void qPrefLanguage::set_use_system_language(bool value)
+{
+	if (value == use_system_language())
+		return;
+	prefs.locale.use_system_language = value;
+	disk_use_system_language(true);
+	emit instance()->use_system_languageChanged(value);
+	emit instance()->dateTimeFormatsChanged();
+}

--- a/core/settings/qPrefLanguage.h
+++ b/core/settings/qPrefLanguage.h
@@ -3,7 +3,9 @@
 #define QPREFLANGUAGE_H
 #include "core/pref.h"
 
+#include <QLocale>
 #include <QObject>
+#include <QVariantList>
 
 class qPrefLanguage : public QObject {
 	Q_OBJECT
@@ -15,6 +17,14 @@ class qPrefLanguage : public QObject {
 	Q_PROPERTY(QString time_format READ time_format WRITE set_time_format NOTIFY time_formatChanged)
 	Q_PROPERTY(bool time_format_override READ time_format_override WRITE set_time_format_override NOTIFY time_format_overrideChanged)
 	Q_PROPERTY(bool use_system_language READ use_system_language WRITE set_use_system_language NOTIFY use_system_languageChanged)
+	Q_PROPERTY(QString effectiveDateFormat READ effectiveDateFormat NOTIFY dateTimeFormatsChanged)
+	Q_PROPERTY(QString effectiveDateFormatShort READ effectiveDateFormatShort NOTIFY dateTimeFormatsChanged)
+	Q_PROPERTY(QString effectiveTimeFormat READ effectiveTimeFormat NOTIFY dateTimeFormatsChanged)
+	Q_PROPERTY(QString longDatePreview READ longDatePreview NOTIFY dateTimeFormatsChanged)
+	Q_PROPERTY(QString shortDatePreview READ shortDatePreview NOTIFY dateTimeFormatsChanged)
+	Q_PROPERTY(QString timePreview READ timePreview NOTIFY dateTimeFormatsChanged)
+	Q_PROPERTY(QVariantList dateFormatPresets READ dateFormatPresets NOTIFY dateTimeFormatsChanged)
+	Q_PROPERTY(QVariantList timeFormatPresets READ timeFormatPresets NOTIFY dateTimeFormatsChanged)
 
 public:
 	static qPrefLanguage *instance();
@@ -33,6 +43,25 @@ public:
 	static const QString time_format() { return QString::fromStdString(prefs.time_format); }
 	static bool time_format_override() { return prefs.time_format_override; }
 	static bool use_system_language() { return prefs.locale.use_system_language; }
+
+	// AI-generated (Claude): Shared date/time preference API for all Qt frontends.
+	static QString effectiveDateFormat();
+	static QString effectiveDateFormatShort();
+	static QString effectiveTimeFormat();
+	static QString longDatePreview();
+	static QString shortDatePreview();
+	static QString timePreview();
+	static QVariantList dateFormatPresets();
+	static QVariantList timeFormatPresets();
+
+	Q_INVOKABLE void applyDateTimeFormats(const QString &longDateFormat, const QString &shortDateFormat,
+				      const QString &timeFormat, bool overrideDate, bool overrideTime);
+	Q_INVOKABLE void applyDatePreset(const QString &preset);
+	Q_INVOKABLE void applyTimePreset(const QString &preset);
+	Q_INVOKABLE void restoreDateTimeDefaults();
+
+	// Apply selected-locale defaults during UI locale initialization.
+	static void applyLocaleDefaults(const QLocale &locale);
 
 public slots:
 	static void set_date_format(const QString& value);
@@ -53,9 +82,19 @@ signals:
 	void time_formatChanged(const QString& value);
 	void time_format_overrideChanged(bool value);
 	void use_system_languageChanged(bool value);
+	void dateTimeFormatsChanged();
 
 private:
 	qPrefLanguage() {}
+
+	static QLocale preferenceLocale();
+	static QString defaultDateFormat(const QLocale &locale);
+	static QString defaultShortDateFormat(const QLocale &locale);
+	static QString defaultTimeFormat(const QLocale &locale);
+	static void applyFormats(const QString &longDateFormat, const QString &shortDateFormat,
+				 const QString &timeFormat, bool overrideDate, bool overrideTime);
+	static void storeFormats(const QString &longDateFormat, const QString &shortDateFormat,
+				 const QString &timeFormat, bool overrideDate, bool overrideTime);
 
 	static void disk_date_format(bool doSync);
 	static void disk_date_format_override(bool doSync);

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -466,6 +466,8 @@ TemplatePage {
 					Layout.fillWidth: true
 					model: datePresetLabels
 					currentIndex: datePresetIndex()
+					// AI-generated (Claude): Unknown persisted formats remain visible without becoming presets.
+					displayText: currentIndex >= 0 ? currentText : qsTr("Custom")
 					onActivated: function(index) {
 						PrefLanguage.applyDatePreset(datePresetIds[index])
 					}
@@ -484,6 +486,8 @@ TemplatePage {
 					Layout.fillWidth: true
 					model: timePresetLabels
 					currentIndex: timePresetIndex()
+					// AI-generated (Claude): Unknown persisted formats remain visible without becoming presets.
+					displayText: currentIndex >= 0 ? currentText : qsTr("Custom")
 					onActivated: function(index) {
 						PrefLanguage.applyTimePreset(timePresetIds[index])
 					}

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -13,11 +13,6 @@ TemplatePage {
 	property alias defaultCylinderIndex: defaultCylinderBox.currentIndex
 	property real contentColumeWidth: width - 2 * Kirigami.Units.gridUnit
 	// AI-generated (Claude): Present the shared date/time presets without exposing Qt format strings.
-	property var datePresetIds: ["system", "day-first", "month-first", "iso"]
-	property var datePresetLabels: [qsTr("System default"), qsTr("Day-month-year"),
-		qsTr("Month-day-year"), qsTr("Year-month-day (ISO)")]
-	property var timePresetIds: ["system", "24-hour", "12-hour"]
-	property var timePresetLabels: [qsTr("System default"), qsTr("24-hour"), qsTr("12-hour")]
 	property var describe: [qsTr("Undefined"),
 		qsTr("Incorrect username/password combination"),
 		qsTr("Credentials need to be verified"),
@@ -45,6 +40,25 @@ TemplatePage {
 				return i
 		}
 		return -1
+	}
+
+	function datePresetLabel(preset) {
+		switch (preset.id) {
+		case "system": return qsTr("System default")
+		case "day-first": return qsTr("Day-month-year")
+		case "month-first": return qsTr("Month-day-year")
+		case "iso": return qsTr("Year-month-day (ISO)")
+		default: return preset.name
+		}
+	}
+
+	function timePresetLabel(preset) {
+		switch (preset.id) {
+		case "system": return qsTr("System default")
+		case "24-hour": return qsTr("24-hour")
+		case "12-hour": return qsTr("12-hour")
+		default: return preset.name
+		}
 	}
 
 	function datePresetPreview() {
@@ -464,12 +478,12 @@ TemplatePage {
 				TemplateComboBox {
 					id: dateFormatBox
 					Layout.fillWidth: true
-					model: datePresetLabels
+					model: PrefLanguage.dateFormatPresets.map(datePresetLabel)
 					currentIndex: datePresetIndex()
 					// AI-generated (Claude): Unknown persisted formats remain visible without becoming presets.
 					displayText: currentIndex >= 0 ? currentText : qsTr("Custom")
 					onActivated: function(index) {
-						PrefLanguage.applyDatePreset(datePresetIds[index])
+						PrefLanguage.applyDatePreset(PrefLanguage.dateFormatPresets[index].id)
 					}
 				}
 				TemplateLabel {
@@ -484,12 +498,12 @@ TemplatePage {
 				TemplateComboBox {
 					id: timeFormatBox
 					Layout.fillWidth: true
-					model: timePresetLabels
+					model: PrefLanguage.timeFormatPresets.map(timePresetLabel)
 					currentIndex: timePresetIndex()
 					// AI-generated (Claude): Unknown persisted formats remain visible without becoming presets.
 					displayText: currentIndex >= 0 ? currentText : qsTr("Custom")
 					onActivated: function(index) {
-						PrefLanguage.applyTimePreset(timePresetIds[index])
+						PrefLanguage.applyTimePreset(PrefLanguage.timeFormatPresets[index].id)
 					}
 				}
 				TemplateLabel {

--- a/mobile-widgets/qml/Settings.qml
+++ b/mobile-widgets/qml/Settings.qml
@@ -12,11 +12,51 @@ TemplatePage {
 	property alias defaultCylinderModel: defaultCylinderBox.model
 	property alias defaultCylinderIndex: defaultCylinderBox.currentIndex
 	property real contentColumeWidth: width - 2 * Kirigami.Units.gridUnit
+	// AI-generated (Claude): Present the shared date/time presets without exposing Qt format strings.
+	property var datePresetIds: ["system", "day-first", "month-first", "iso"]
+	property var datePresetLabels: [qsTr("System default"), qsTr("Day-month-year"),
+		qsTr("Month-day-year"), qsTr("Year-month-day (ISO)")]
+	property var timePresetIds: ["system", "24-hour", "12-hour"]
+	property var timePresetLabels: [qsTr("System default"), qsTr("24-hour"), qsTr("12-hour")]
 	property var describe: [qsTr("Undefined"),
 		qsTr("Incorrect username/password combination"),
 		qsTr("Credentials need to be verified"),
 		qsTr("Credentials verified"),
 		qsTr("No cloud mode")]
+
+	function datePresetIndex() {
+		if (!PrefLanguage.date_format_override)
+			return 0
+		var presets = PrefLanguage.dateFormatPresets
+		for (var i = 1; i < presets.length; ++i) {
+			if (presets[i].longFormat === PrefLanguage.date_format &&
+			    presets[i].shortFormat === PrefLanguage.date_format_short)
+				return i
+		}
+		return -1
+	}
+
+	function timePresetIndex() {
+		if (!PrefLanguage.time_format_override)
+			return 0
+		var presets = PrefLanguage.timeFormatPresets
+		for (var i = 1; i < presets.length; ++i) {
+			if (presets[i].format === PrefLanguage.time_format)
+				return i
+		}
+		return -1
+	}
+
+	function datePresetPreview() {
+		var index = datePresetIndex()
+		return index >= 0 ? PrefLanguage.dateFormatPresets[index].preview :
+			PrefLanguage.longDatePreview + " / " + PrefLanguage.shortDatePreview
+	}
+
+	function timePresetPreview() {
+		var index = timePresetIndex()
+		return index >= 0 ? PrefLanguage.timeFormatPresets[index].preview : PrefLanguage.timePreview
+	}
 	Column {
 		width: contentColumeWidth
 		TemplateSection {
@@ -407,6 +447,56 @@ TemplatePage {
 			id: sectionUnits
 			title: qsTr("Units")
 			width: parent.width
+			ColumnLayout {
+				visible: sectionUnits.isExpanded
+				width: parent.width
+				spacing: Kirigami.Units.smallSpacing
+
+				TemplateLabel {
+					text: qsTr("Date and time")
+					font.pointSize: subsurfaceTheme.headingPointSize
+					font.weight: Font.Light
+					Layout.topMargin: Kirigami.Units.largeSpacing
+				}
+				TemplateLabel {
+					text: qsTr("Date format")
+				}
+				TemplateComboBox {
+					id: dateFormatBox
+					Layout.fillWidth: true
+					model: datePresetLabels
+					currentIndex: datePresetIndex()
+					onActivated: function(index) {
+						PrefLanguage.applyDatePreset(datePresetIds[index])
+					}
+				}
+				TemplateLabel {
+					Layout.fillWidth: true
+					wrapMode: Text.Wrap
+					text: qsTr("Example: %1").arg(datePresetPreview())
+				}
+				TemplateLabel {
+					text: qsTr("Time format")
+					Layout.topMargin: Kirigami.Units.smallSpacing
+				}
+				TemplateComboBox {
+					id: timeFormatBox
+					Layout.fillWidth: true
+					model: timePresetLabels
+					currentIndex: timePresetIndex()
+					onActivated: function(index) {
+						PrefLanguage.applyTimePreset(timePresetIds[index])
+					}
+				}
+				TemplateLabel {
+					Layout.fillWidth: true
+					wrapMode: Text.Wrap
+					text: qsTr("Example: %1").arg(timePresetPreview())
+				}
+				TemplateLine {
+					Layout.topMargin: Kirigami.Units.largeSpacing
+				}
+			}
 			RowLayout {
 				visible: sectionUnits.isExpanded
 				width: parent.width

--- a/qt-models/mobilelistmodel.cpp
+++ b/qt-models/mobilelistmodel.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 #include "mobilelistmodel.h"
 #include "core/divefilter.h" // for shown_dives
+#include "core/settings/qPrefLanguage.h"
 
 MobileListModelBase::MobileListModelBase(DiveTripModelBase *sourceIn) : source(sourceIn)
 {
@@ -952,6 +953,10 @@ MobileModels::MobileModels() :
 	lm(&source),
 	sm(&source)
 {
+	// AI-generated (Claude): Date/time preferences only affect presentation, so refresh both
+	// mobile views without modifying dive data or scheduling a cloud save.
+	QObject::connect(qPrefLanguage::instance(), &qPrefLanguage::dateTimeFormatsChanged, &lm, &MobileListModel::invalidate);
+	QObject::connect(qPrefLanguage::instance(), &qPrefLanguage::dateTimeFormatsChanged, &sm, &MobileSwipeModel::invalidate);
 }
 
 MobileListModel *MobileModels::listModel()

--- a/tests/testqPrefLanguage.cpp
+++ b/tests/testqPrefLanguage.cpp
@@ -198,6 +198,52 @@ void TestQPrefLanguage::test_oldPreferences()
 	TEST(language->date_format_override(), true);
 	TEST(language->use_system_language(), true);
 
+	// AI-generated (Claude): Verify the shared API and stable preset values.
+	language->set_use_system_language(false);
+	language->set_lang_locale("en_US");
+	language->applyDateTimeFormats("ddd, d MMM yyyy", "d/M/yy", "HH:mm", true, true);
+	QCOMPARE(language->effectiveDateFormat(), QStringLiteral("ddd, d MMM yyyy"));
+	QCOMPARE(language->effectiveDateFormatShort(), QStringLiteral("d/M/yy"));
+	QCOMPARE(language->effectiveTimeFormat(), QStringLiteral("HH:mm"));
+	language->load();
+	QCOMPARE(language->date_format(), QStringLiteral("ddd, d MMM yyyy"));
+	QCOMPARE(language->date_format_short(), QStringLiteral("d/M/yy"));
+	QCOMPARE(language->time_format(), QStringLiteral("HH:mm"));
+
+	language->applyDatePreset("month-first");
+	QCOMPARE(language->date_format(), QStringLiteral("MM/dd/yyyy"));
+	QCOMPARE(language->date_format_short(), QStringLiteral("M/d/yy"));
+	language->applyDatePreset("day-first");
+	QCOMPARE(language->date_format(), QStringLiteral("dd.MM.yyyy"));
+	QCOMPARE(language->date_format_short(), QStringLiteral("d.M.yy"));
+	language->applyDatePreset("iso");
+	QCOMPARE(language->date_format(), QStringLiteral("yyyy-MM-dd"));
+	QCOMPARE(language->date_format_short(), QStringLiteral("yy-M-d"));
+	language->applyTimePreset("24-hour");
+	QCOMPARE(language->time_format(), QStringLiteral("hh:mm"));
+	language->applyTimePreset("12-hour");
+	QCOMPARE(language->time_format(), QStringLiteral("h:mm AP"));
+
+	QSignalSpy formatsSpy(language, &qPrefLanguage::dateTimeFormatsChanged);
+	language->restoreDateTimeDefaults();
+	QCOMPARE(language->date_format_override(), false);
+	QCOMPARE(language->time_format_override(), false);
+	const QString defaultLongDate = QLocale("en_US").dateFormat(QLocale::LongFormat).replace("dddd,", "ddd").replace("dddd", "ddd").replace("MMMM", "MMM");
+	const QString defaultShortDate = QLocale("en_US").dateFormat(QLocale::ShortFormat);
+	QCOMPARE(language->date_format(), defaultLongDate);
+	QCOMPARE(language->date_format_short(), defaultShortDate);
+	QCOMPARE(formatsSpy.count(), 1);
+	prefs.date_format = "error";
+	prefs.date_format_short = "error";
+	prefs.date_format_override = true;
+	prefs.time_format = "error";
+	prefs.time_format_override = true;
+	language->load();
+	QCOMPARE(language->date_format(), defaultLongDate);
+	QCOMPARE(language->date_format_short(), defaultShortDate);
+	QCOMPARE(language->date_format_override(), false);
+	QCOMPARE(language->time_format_override(), false);
+
 }
 
 void TestQPrefLanguage::test_signals()

--- a/tests/tst_qPrefLanguage.qml
+++ b/tests/tst_qPrefLanguage.qml
@@ -110,6 +110,22 @@ TestCase {
 		verify(PrefLanguage.time_format.length > 0)
 	}
 
+	// AI-generated (Claude): Reading preset data must not replace persisted custom formats.
+	function test_customFormatsRemainUntouched() {
+		PrefLanguage.applyDateTimeFormats("yyyy/MM/dd", "yy/M/d", "HH.mm", true, true)
+
+		compare(PrefLanguage.dateFormatPresets.length, 4)
+		compare(PrefLanguage.timeFormatPresets.length, 3)
+		verify(PrefLanguage.longDatePreview.length > 0)
+		verify(PrefLanguage.shortDatePreview.length > 0)
+		verify(PrefLanguage.timePreview.length > 0)
+		compare(PrefLanguage.date_format, "yyyy/MM/dd")
+		compare(PrefLanguage.date_format_short, "yy/M/d")
+		compare(PrefLanguage.time_format, "HH.mm")
+		compare(PrefLanguage.date_format_override, true)
+		compare(PrefLanguage.time_format_override, true)
+	}
+
 	function test_signals() {
 		PrefLanguage.date_format = "qml"
 		PrefLanguage.date_format_override = ! PrefLanguage.date_format_override

--- a/tests/tst_qPrefLanguage.qml
+++ b/tests/tst_qPrefLanguage.qml
@@ -36,6 +36,16 @@ TestCase {
 		var x8 = PrefLanguage.use_system_language
 		PrefLanguage.use_system_language = true
 		compare(PrefLanguage.use_system_language, true)
+
+		PrefLanguage.applyDateTimeFormats("yyyy/MM/dd", "yy/M/d", "HH:mm", true, true)
+		compare(PrefLanguage.effectiveDateFormat, "yyyy/MM/dd")
+		compare(PrefLanguage.effectiveDateFormatShort, "yy/M/d")
+		compare(PrefLanguage.effectiveTimeFormat, "HH:mm")
+		verify(PrefLanguage.longDatePreview.length > 0)
+		verify(PrefLanguage.shortDatePreview.length > 0)
+		verify(PrefLanguage.timePreview.length > 0)
+		compare(PrefLanguage.dateFormatPresets.length, 4)
+		compare(PrefLanguage.timeFormatPresets.length, 3)
 	}
 
 	Item {

--- a/tests/tst_qPrefLanguage.qml
+++ b/tests/tst_qPrefLanguage.qml
@@ -59,6 +59,7 @@ TestCase {
 		property bool spy6 : false
 		property bool spy7 : false
 		property bool spy8 : false
+		property int formatRefreshCount: 0
 
 		Connections {
 			target: PrefLanguage
@@ -70,7 +71,43 @@ TestCase {
 			onTime_formatChanged: {spyCatcher.spy6 = true }
 			onTime_format_overrideChanged: {spyCatcher.spy7 = true }
 			onUse_system_languageChanged: {spyCatcher.spy8 = true }
+			function onDateTimeFormatsChanged() { ++spyCatcher.formatRefreshCount }
 		}
+	}
+
+	// AI-generated (Claude): Exercise the mobile preset choices through the public QML API.
+	function test_mobilePresets() {
+		PrefLanguage.use_system_language = false
+		PrefLanguage.lang_locale = "en_US"
+		PrefLanguage.applyDatePreset("system")
+
+		var refreshCount = spyCatcher.formatRefreshCount
+		PrefLanguage.applyDatePreset("day-first")
+		compare(PrefLanguage.date_format, "dd.MM.yyyy")
+		compare(PrefLanguage.date_format_short, "d.M.yy")
+		compare(PrefLanguage.date_format_override, true)
+		compare(spyCatcher.formatRefreshCount, refreshCount + 1)
+
+		PrefLanguage.applyDatePreset("iso")
+		compare(PrefLanguage.date_format, "yyyy-MM-dd")
+		compare(PrefLanguage.date_format_short, "yy-M-d")
+		PrefLanguage.applyDatePreset("month-first")
+		compare(PrefLanguage.date_format, "MM/dd/yyyy")
+		compare(PrefLanguage.date_format_short, "M/d/yy")
+
+		PrefLanguage.applyTimePreset("24-hour")
+		compare(PrefLanguage.time_format, "hh:mm")
+		compare(PrefLanguage.time_format_override, true)
+		PrefLanguage.applyTimePreset("12-hour")
+		compare(PrefLanguage.time_format, "h:mm AP")
+
+		PrefLanguage.applyDatePreset("system")
+		PrefLanguage.applyTimePreset("system")
+		compare(PrefLanguage.date_format_override, false)
+		compare(PrefLanguage.time_format_override, false)
+		verify(PrefLanguage.date_format.length > 0)
+		verify(PrefLanguage.date_format_short.length > 0)
+		verify(PrefLanguage.time_format.length > 0)
 	}
 
 	function test_signals() {


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
## Summary

- add a shared preference API for date and time formats while retaining the existing settings keys
- add preset-based date and time selectors with examples to the mobile Units settings
- support system defaults, day-first, month-first, ISO, 24-hour, and 12-hour formats
- refresh affected mobile displays immediately when formats change
- use shared Qt/QML code for Android and iOS without platform-specific implementations

The existing desktop preference layout and custom date/time format controls remain unchanged.

## Testing

- Qt 6 desktop build and test suite: 33/33 passed
- date/time preference tests: 9/9 passed
- QML lint checks passed
- Android arm64-v8a build and APK packaging passed

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #445.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
