### PR TITLE
Android: Preserve unsigned local build artifacts

### DIFF
--- a/packaging/android/in-container-build.sh
+++ b/packaging/android/in-container-build.sh
@@ -303,13 +303,21 @@ mkdir -p "${OUTPUT_DIR}"
 OUTPUT_APK="${OUTPUT_DIR}/Subsurface-mobile-${VERSION}.apk"
 
 echo "=== Collecting artifacts ==="
-# Use the APK that androiddeployqt produced (during cmake --build).
-APK="${BUILDROOT}/build-android/android-build/subsurface-mobile.apk"
+# AI-generated (Claude): androiddeployqt may apply its debug key even without release credentials.
+if [ -z "${KS_ALIAS}" ]; then
+	APK="${BUILDROOT}/build-android/android-build/build/outputs/apk/release/android-build-release-unsigned.apk"
+else
+	APK="${BUILDROOT}/build-android/android-build/subsurface-mobile.apk"
+fi
 if [ ! -f "${APK}" ]; then
 	echo "Error: Unable to locate APK at ${APK}"
 	exit 1
 fi
-cp "${APK}" "${OUTPUT_APK}"
+if [ -z "${KS_ALIAS}" ]; then
+	"${ANDROID_SDK_ROOT}/build-tools/${SDK_VERSION}/zipalign" -f -P 16 4 "${APK}" "${OUTPUT_APK}"
+else
+	cp "${APK}" "${OUTPUT_APK}"
+fi
 
 if [ "${BUILD_AAB}" = "1" ]; then
 	AAB=$(find "${BUILDROOT}/build-android/android-build" -name '*.aab' | head -1)
@@ -347,4 +355,3 @@ fi
 if [ -n "${HOST_UID}" ] && [ -n "${HOST_GID}" ]; then
 	chown "${HOST_UID}:${HOST_GID}" "${OUTPUT_DIR}"/*
 fi
-

--- a/packaging/android/local-build.sh
+++ b/packaging/android/local-build.sh
@@ -167,8 +167,10 @@ fi
 # Start the container (no-op if already running).
 ${CONTAINER_RT} start "${CONTAINER_NAME}" >/dev/null
 
-# Copy the keystore into the running container.
-${CONTAINER_RT} cp "${KEYSTORE_FILE}" "${CONTAINER_NAME}:/tmp/keystore"
+# AI-generated (Claude): unsigned builds do not have a keystore to copy.
+if [ -n "${ANDROID_KEYSTORE_BASE64}" ]; then
+	${CONTAINER_RT} cp "${KEYSTORE_FILE}" "${CONTAINER_NAME}:/tmp/keystore"
+fi
 
 # --- Run the build ---
 # All build logic (compile, strip, gradle, collect artifacts, sign, chown)


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
## Summary

- skip copying a keystore into the build container when no signing credentials are provided
- collect Gradle's unsigned release APK for unsigned local builds
- align the unsigned APK before copying it to the output directory
- retain the existing signing path when release credentials are available

This allows the documented no-secrets workflow to work with both Podman and Docker without attempting to copy `/dev/null` as a keystore.

## Testing

- ran an unsigned Android arm64-v8a container build using Podman
- C++ compilation and `androiddeployqt` packaging passed
- Gradle `assembleRelease` passed
- `apksigner verify --verbose` confirmed that the resulting APK contains no signature

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
