### PR TITLE
Equipment: fix 'Deco switch at' depth being reset on edit

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1267,6 +1267,7 @@ EditCylinder::EditCylinder(int index, cylinder_t cylIn, EditCylinderType typeIn,
 			cyl[i].gasmix = cylIn.gasmix;
 			cyl[i].bestmix_o2 = cylIn.bestmix_o2;
 			cyl[i].bestmix_he = cylIn.bestmix_he;
+			cyl[i].depth = cylIn.depth;
 			sanitize_gasmix(cyl[i].gasmix);
 			break;
 		}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Editing the 'Deco switch at' column for a cylinder had no effect:
the entered value was immediately replaced by the previously stored
value (either the calculated MOD or 0 m for imported cylinders).

The root cause is in EditCylinder::EditCylinder(): when the edit type
is GASMIX, only gasmix, bestmix_o2 and bestmix_he were copied from the
incoming cylinder into the per-dive cylinder copies.  The depth field
was silently dropped, so redo() swapped back the unchanged depth.

All callers that dispatch a GASMIX edit already set cyl.depth to the
correct value before calling Command::editCylinder() - either to the
user-entered depth (DEPTH column) or to the freshly computed MOD (O2
and MOD columns) - so it is correct to propagate depth through in all
GASMIX edits.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
