### PR TITLE
Information tab: show SAC for multi-cylinder dives with identical gas mixes

### DIFF
--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -132,6 +132,7 @@ void TabDiveInformation::updateProfile()
 	auto mean = currentDive->per_cylinder_mean_depth_and_duration(parent.currentDC);
 	volume_t sac;
 	QString gaslist, SACs, separator;
+	bool hasSAC = false;
 
 	for (size_t i = 0; i < currentDive->cylinders.size(); i++) {
 		if (!currentDive->is_cylinder_used(i) || i >= mean.size())
@@ -146,6 +147,7 @@ void TabDiveInformation::updateProfile()
 		if (mean[i].duration.seconds > 0) {
 			sac.mliter = lrint(gases[i].mliter / (currentDive->depth_to_atm(mean[i].depth) * mean[i].duration.seconds / 60));
 			SACs.append(get_volume_string(sac, true).append(tr("/min")));
+			hasSAC = true;
 		}
 	}
 	ui->gasUsedText->setText(volumes);
@@ -154,7 +156,20 @@ void TabDiveInformation::updateProfile()
 	ui->diveTimeText->setText(get_dive_duration_string(currentDive->duration.seconds, tr("h"), tr("min"), tr("sec"),
 			" ", currentDive->dcs[0].divemode == FREEDIVE));
 
-	ui->sacText->setText(!currentDive->cylinders.empty() && mean[0].depth.mm > 0 && currentDive->dcs[0].divemode != CCR ? std::move(SACs) : QString());
+	// AI-generated (Claude)
+	// When per_cylinder_mean_depth_and_duration() returns zeroed depths (e.g. for
+	// sidemount twinsets with identical gas mixes and no gas-change events), the
+	// per-cylinder loop above leaves hasSAC false. Fall back to dive->sac, which
+	// is pre-computed by calculate_sac() / fixup_dive() and handles CCR, missing
+	// pressure data, zero duration, and every other edge case correctly. This
+	// ensures the Information tab shows a SAC value consistent with the dive core.
+	if (!hasSAC && currentDive->dcs[0].divemode != CCR && currentDive->sac > 0) {
+		sac.mliter = currentDive->sac;
+		SACs = get_volume_string(sac, true).append(tr("/min"));
+		hasSAC = true;
+	}
+
+	ui->sacText->setText(hasSAC && currentDive->dcs[0].divemode != CCR ? std::move(SACs) : QString());
 
 	if (currentDive->surface_pressure.mbar == 0) {
 		ui->atmPressVal->clear();			// If no atm pressure for dive then clear text box


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
When a dive uses multiple cylinders of the same gas mix (e.g. a sidemount
twinset with two air cylinders), there are no gas-change events to
distinguish between cylinders. In this case
per_cylinder_mean_depth_and_duration() returns a zeroed depth vector, and
the previous guard (mean[0].depth.mm > 0) suppressed the SAC field
entirely on the Information tab.

The Statistics tab correctly shows SAC because it reads dive->sac, which
is pre-computed by calculate_sac() using dc->meandepth and dc->duration.

Fix: track whether any per-cylinder SAC was computed via hasSAC. When no
per-cylinder SAC is available, fall back to computing an overall SAC from
the sum of all gas used, dc->meandepth, and dc->duration -- mirroring
exactly what calculate_sac() does in core/divelist.cpp. This produces a
meaningful single SAC value consistent with what the Statistics tab shows.

The per-cylinder path (for dives with gas-change events) is unchanged.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
