### PR TITLE
Planner: display calculated deco switch depths

### DIFF
--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -456,6 +456,12 @@ ImportDives::ImportDives(struct divelog *log, int flags, const QString &source)
 {
 	setText(Command::Base::tr("import %n dive(s) from %1", "", log->dives.size()).arg(source));
 
+	// AI-generated (Claude)
+	// Normalise only dives accepted through the external-import command. Native
+	// log loading does not pass through this path and retains legacy zero depths.
+	for (auto &dive: log->dives)
+		normalize_imported_cylinder_depths(dive.get());
+
 	// this only matters if undoit were called before redoit
 	currentDive = nullptr;
 

--- a/core/equipment.cpp
+++ b/core/equipment.cpp
@@ -314,15 +314,29 @@ void weightsystem_table::set(int idx, weightsystem_t ws)
 	(*this)[idx] = std::move(ws);
 }
 
+// AI-generated (Claude)
+depth_t calculate_deco_switch_depth(const struct dive *dive, struct gasmix gasmix)
+{
+	pressure_t decopo2 = { .mbar = prefs.decopo2 };
+	return dive->gas_mod(gasmix, decopo2, m_or_ft(3, 10));
+}
+
+// AI-generated (Claude)
+void normalize_imported_cylinder_depths(struct dive *dive)
+{
+	for (cylinder_t &cyl: dive->cylinders) {
+		if (cyl.depth.mm == 0)
+			cyl.depth = calculate_deco_switch_depth(dive, cyl.gasmix);
+	}
+}
+
 /* when planning a dive we need to make sure that all cylinders have a sane depth assigned
  * and if we are tracking gas consumption the pressures need to be reset to start = end = workingpressure */
 void reset_cylinders(struct dive *dive, bool track_gas)
 {
-	pressure_t decopo2 = {.mbar = prefs.decopo2};
-
 	for (cylinder_t &cyl: dive->cylinders) {
 		if (cyl.depth.mm == 0) /* if the gas doesn't give a mod, calculate based on prefs */
-			cyl.depth = dive->gas_mod(cyl.gasmix, decopo2, m_or_ft(3, 10));
+			cyl.depth = calculate_deco_switch_depth(dive, cyl.gasmix);
 		if (track_gas)
 			cyl.start.mbar = cyl.end.mbar = cyl.type.workingpressure.mbar;
 		cyl.gas_used = 0_l;

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -92,6 +92,8 @@ struct weightsystem_table : public std::vector<weightsystem_t> {
 extern enum cylinderuse cylinderuse_from_text(const char *text);
 extern void copy_cylinder_types(const struct dive *s, struct dive *d);
 extern void remove_cylinder(struct dive *dive, int idx);
+extern depth_t calculate_deco_switch_depth(const struct dive *dive, struct gasmix gasmix);
+extern void normalize_imported_cylinder_depths(struct dive *dive);
 extern void reset_cylinders(struct dive *dive, bool track_gas);
 extern int find_best_gasmix_match(struct gasmix mix, const struct cylinder_table &cylinders, const enum cylinderuse *use);
 extern void fill_default_cylinder(const struct dive *dive, cylinder_t *cyl); /* dive is needed to fill out MOD, which depends on salinity. */

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -313,6 +313,10 @@ static dc_status_t parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_
 			 * dive computer, fill in the default tank information (if set) */
 			fill_default_cylinder(dive, &cyl);
 		}
+		// AI-generated (Claude)
+		// libdivecomputer does not supply switch depths. Apply the deco pO2
+		// depth after default-cylinder metadata, which may have set a bottom MOD.
+		cyl.depth = calculate_deco_switch_depth(dive, cyl.gasmix);
 		/* whatever happens, make sure there is a name for the cylinder */
 		if (cyl.type.description.empty())
 			cyl.type.description = translate("gettextFromC", "unknown");

--- a/dives/Freedom_MIX2_header_v2_00000007.dlf.xml
+++ b/dives/Freedom_MIX2_header_v2_00000007.dlf.xml
@@ -5,8 +5,8 @@
 </divesites>
 <dives>
 <dive otu='23' cns='8%' date='2023-08-13' time='10:36:41' duration='67:44 min'>
-  <cylinder size='12.0 l' workpressure='200.0 bar' description='unknown' />
-  <cylinder size='12.0 l' workpressure='200.0 bar' description='unknown' o2='50.0%' />
+  <cylinder size='12.0 l' workpressure='200.0 bar' description='unknown' depth='66.0 m' />
+  <cylinder size='12.0 l' workpressure='200.0 bar' description='unknown' o2='50.0%' depth='21.0 m' />
   <divecomputer model='Divesoft Freedom (Imported from file)'>
   <depth max='18.98 m' mean='7.93 m' />
   <temperature water='10.3 C' />

--- a/dives/Freedom_MIX2_header_v2_factory_test_00000001.dlf.xml
+++ b/dives/Freedom_MIX2_header_v2_factory_test_00000001.dlf.xml
@@ -5,7 +5,7 @@
 </divesites>
 <dives>
 <dive otu='15' date='2023-08-01' time='13:36:15' duration='3:36 min'>
-  <cylinder size='12.0 l' workpressure='200.0 bar' description='unknown' />
+  <cylinder size='12.0 l' workpressure='200.0 bar' description='unknown' depth='66.0 m' />
   <divecomputer model='Divesoft [unknown model, factory test dive] (Imported from file)'>
   <depth max='350.75 m' mean='154.299 m' />
   <temperature water='23.1 C' />

--- a/dives/Freedom_MIX_header_v1_00000115.dlf.xml
+++ b/dives/Freedom_MIX_header_v1_00000115.dlf.xml
@@ -5,8 +5,8 @@
 </divesites>
 <dives>
 <dive otu='26' cns='9%' date='2019-02-10' time='10:09:13' duration='55:01 min'>
-  <cylinder description='unknown' />
-  <cylinder description='unknown' o2='50.0%' />
+  <cylinder description='unknown' depth='66.0 m' />
+  <cylinder description='unknown' o2='50.0%' depth='21.0 m' />
   <divecomputer model='Divesoft [unknown model, V1 log] (Imported from file)'>
   <depth max='31.56 m' mean='15.932 m' />
   <temperature water='3.9 C' />

--- a/dives/Freedom_MIX_header_v2_00000003.dlf.xml
+++ b/dives/Freedom_MIX_header_v2_00000003.dlf.xml
@@ -5,9 +5,9 @@
 </divesites>
 <dives>
 <dive date='2023-06-30' time='10:27:49' duration='72:46 min'>
-  <cylinder size='12.0 l' workpressure='200.0 bar' description='unknown' />
-  <cylinder description='unknown' o2='100.0%' use='oxygen' />
-  <cylinder description='unknown' o2='14.0%' he='32.0%' use='diluent' />
+  <cylinder size='12.0 l' workpressure='200.0 bar' description='unknown' depth='66.0 m' />
+  <cylinder description='unknown' o2='100.0%' use='oxygen' depth='6.0 m' />
+  <cylinder description='unknown' o2='14.0%' he='32.0%' use='diluent' depth='105.0 m' />
   <divecomputer model='Divesoft Freedom (Imported from file)' dctype='CCR'>
   <depth max='53.64 m' mean='19.602 m' />
   <temperature water='5.1 C' />

--- a/dives/Liberty_CCR_header_v1_00000011.dlf.xml
+++ b/dives/Liberty_CCR_header_v1_00000011.dlf.xml
@@ -7,12 +7,12 @@
 </divesites>
 <dives>
 <dive otu='34' cns='13%' divesiteid='da2f213e' date='2021-06-12' time='09:47:24' duration='76:32 min'>
-  <cylinder description='unknown' />
-  <cylinder description='unknown' o2='50.0%' />
-  <cylinder description='unknown' o2='100.0%' />
-  <cylinder description='unknown' o2='30.0%' he='34.0%' />
-  <cylinder description='unknown' o2='100.0%' use='oxygen' />
-  <cylinder description='unknown' use='diluent' />
+  <cylinder description='unknown' depth='66.0 m' />
+  <cylinder description='unknown' o2='50.0%' depth='21.0 m' />
+  <cylinder description='unknown' o2='100.0%' depth='6.0 m' />
+  <cylinder description='unknown' o2='30.0%' he='34.0%' depth='42.0 m' />
+  <cylinder description='unknown' o2='100.0%' use='oxygen' depth='6.0 m' />
+  <cylinder description='unknown' use='diluent' depth='66.0 m' />
   <divecomputer model='Divesoft [unknown model, V1 log] (Imported from file)' dctype='CCR' no_o2sensors='4'>
   <depth max='29.22 m' mean='11.924 m' />
   <temperature water='5.6 C' />

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -433,10 +433,16 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 		cyl.bestmix_he = false;
 		type = Command::EditCylinderType::GASMIX;
 		break;
-	case DEPTH:
-		cyl.depth = string_to_depth(qPrintable(vString));
+	case DEPTH: {
+		// AI-generated (Claude)
+		// Clearing the editor requests a calculated value. A parsed zero is an
+		// explicit legacy value and must remain distinguishable from empty input.
+		cyl.depth = vString.trimmed().isEmpty()
+			? calculate_deco_switch_depth(d, cyl.gasmix)
+			: string_to_depth(qPrintable(vString));
 		type = Command::EditCylinderType::GASMIX;
 		break;
+	}
 	case MOD: {
 			if (QString::compare(qPrintable(vString), "*") == 0) {
 				cyl.bestmix_o2 = true;

--- a/tests/testdiveplannermodel.cpp
+++ b/tests/testdiveplannermodel.cpp
@@ -5,6 +5,7 @@
 #include "commands/command.h"
 #include "core/divelog.h"
 #include "core/pref.h"
+#include "core/string-format.h"
 #include "core/units.h"
 #include <QSignalSpy>
 #include <memory>
@@ -127,6 +128,95 @@ void TestDivePlannerModel::testSurfaceAirCylinderDataAccess()
 	QCOMPARE(gas.toString(), QStringLiteral("AIR"));
 
 	model->resetPlanState();
+}
+
+// AI-generated (Claude)
+void TestDivePlannerModel::testImportMissingCylinderDepth()
+{
+	prefs = default_prefs;
+	dive importedDive;
+	cylinder_t cylinder;
+	cylinder.gasmix.o2 = 50_percent;
+	importedDive.cylinders.push_back(cylinder);
+	depth_t expected = calculate_deco_switch_depth(&importedDive, cylinder.gasmix);
+
+	normalize_imported_cylinder_depths(&importedDive);
+
+	QVERIFY(expected.mm != 0);
+	QCOMPARE(importedDive.cylinders[0].depth.mm, expected.mm);
+	prefs = default_prefs;
+}
+
+// AI-generated (Claude)
+void TestDivePlannerModel::testImportedCylinderDepthPreserved()
+{
+	prefs = default_prefs;
+	dive importedDive;
+	cylinder_t cylinder;
+	cylinder.gasmix.o2 = 50_percent;
+	cylinder.depth = 12_m;
+	importedDive.cylinders.push_back(cylinder);
+
+	normalize_imported_cylinder_depths(&importedDive);
+
+	QCOMPARE(importedDive.cylinders[0].depth.mm, 12000);
+	prefs = default_prefs;
+}
+
+// AI-generated (Claude)
+void TestDivePlannerModel::testCylinderDepthInput()
+{
+	DivePlannerPointsModel *model = DivePlannerPointsModel::instance();
+	dive plannedDive;
+	prefs = default_prefs;
+	prefs.unit_system = METRIC;
+	prefs.units = SI_units;
+	model->setPlanMode(DivePlannerPointsModel::PLAN);
+	model->createSimpleDive(&plannedDive);
+
+	CylindersModel *cylinders = model->cylindersModel();
+	QModelIndex depthIndex = cylinders->index(0, CylindersModel::DEPTH);
+	cylinder_t *cylinder = plannedDive.get_cylinder(0);
+	depth_t calculatedDepth = calculate_deco_switch_depth(&plannedDive, cylinder->gasmix);
+
+	QVERIFY(cylinders->setData(depthIndex, QStringLiteral("12 m")));
+	QCOMPARE(cylinder->depth.mm, 12000);
+
+	QVERIFY(cylinders->setData(depthIndex, QString()));
+	QCOMPARE(cylinder->depth.mm, calculatedDepth.mm);
+
+	QVERIFY(cylinders->setData(depthIndex, QStringLiteral("12 m")));
+	QVERIFY(cylinders->setData(depthIndex, QStringLiteral("  \t")));
+	QCOMPARE(cylinder->depth.mm, calculatedDepth.mm);
+
+	QVERIFY(cylinders->setData(depthIndex, QStringLiteral("12 m")));
+	QVERIFY(cylinders->setData(depthIndex, QStringLiteral("0")));
+	QCOMPARE(cylinder->depth.mm, 0);
+	QCOMPARE(cylinders->data(depthIndex, Qt::DisplayRole).toString(), get_depth_string(0_m, true));
+
+	model->resetPlanState();
+	prefs = default_prefs;
+}
+
+// AI-generated (Claude)
+void TestDivePlannerModel::testStoredZeroCylinderDepthDisplay()
+{
+	DivePlannerPointsModel *model = DivePlannerPointsModel::instance();
+	dive plannedDive;
+	prefs = default_prefs;
+	prefs.unit_system = METRIC;
+	prefs.units = SI_units;
+	model->setPlanMode(DivePlannerPointsModel::PLAN);
+	model->createSimpleDive(&plannedDive);
+
+	CylindersModel *cylinders = model->cylindersModel();
+	QModelIndex depthIndex = cylinders->index(0, CylindersModel::DEPTH);
+	plannedDive.cylinders[0].depth = 0_m;
+
+	QCOMPARE(cylinders->data(depthIndex, Qt::DisplayRole).toString(), get_depth_string(0_m, true));
+
+	model->resetPlanState();
+	prefs = default_prefs;
 }
 
 // AI-generated (Claude)

--- a/tests/testdiveplannermodel.h
+++ b/tests/testdiveplannermodel.h
@@ -14,6 +14,10 @@ private slots:
 	void testInvalidRowIndex();
 	void testNothingModeDataAccess();
 	void testSurfaceAirCylinderDataAccess();
+	void testImportMissingCylinderDepth();
+	void testImportedCylinderDepthPreserved();
+	void testCylinderDepthInput();
+	void testStoredZeroCylinderDepthDisplay();
 	// AI-generated (Claude)
 	void testRecreationalPlanSaveAllowed();
 };


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
When importing a dive, if the deco switch depth is not imported, set it
to the calculated deco switch depth for the gasmix, instead of setting
it to 0.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
