### PR TITLE
Fix inverted cloud detection when saving the dive log

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -1260,7 +1260,7 @@ int MainWindow::file_save()
 	if (existing_filename.empty())
 		return file_save_as();
 
-	is_cloud = (starts_with(existing_filename, "http") == 0);
+	is_cloud = starts_with(existing_filename, "http");
 	if (is_cloud && !saveToCloudOK())
 		return -1;
 


### PR DESCRIPTION
### Describe the pull request:
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:

`MainWindow::file_save()` decides whether the currently open log lives in cloud storage by testing whether its filename starts with `http`:

```cpp
is_cloud = (starts_with(existing_filename, "http") == 0);
```

Commit 41cb91606 ("core: turn existing_filename into std::string") replaced the original `strncmp()` call with the `starts_with()` helper but kept the `== 0` comparison:

```diff
-	is_cloud = (strncmp(existing_filename, "http", 4) == 0);
+	is_cloud = (starts_with(existing_filename, "http") == 0);
```

`strncmp()` returns 0 on a match, whereas `starts_with()` returns `true`:

```cpp
inline bool starts_with(std::string_view s, const char *s2)
{
	return s.rfind(s2, 0) == 0;
}
```

So `is_cloud` is now set for exactly the wrong files. This is the only `starts_with()` call site in the tree that compares the result against `0`; every other one uses it directly as a bool.

The flag does not select the save target -- `save_dives(existing_filename.c_str())` is called either way -- so nothing is written to the wrong place. It does gate two things:

1. `saveToCloudOK()`, which refuses to overwrite cloud storage with an empty log. That guard no longer runs on cloud saves, which is the only case it was written for.
2. The progress bar. A cloud save shows none during the network round-trip, while a local save shows one it does not need.

As a side effect, saving an empty log locally is rejected with the misleading message "Don't save an empty log to the cloud".

### Changes made:

1) In `MainWindow::file_save()`, use the `starts_with()` return value directly instead of comparing it against `0`.

### Related issues:

None.

### Additional information:

No dive log is needed to reproduce. With the current code:

- Open a local log file, then close all dives and press Ctrl+S. The save is refused with "Don't save an empty log to the cloud" even though the file is local.
- Open cloud storage and press Ctrl+S with dives loaded. No progress bar appears while the git push runs.

With this change, the empty-log guard and the progress bar both apply to cloud saves and neither applies to local ones.

### Documentation change:

No user-facing functionality changes. The only visible differences are that the progress bar now appears on cloud saves rather than local ones, and the "Don't save an empty log to the cloud" message no longer appears when saving a local file.

### Mentions:

---

Root-caused and prepared with [Claude Code](https://claude.com/claude-code).
