### PR TITLE
uddf-export: fix duplicate waypoints when events coincide with samples

### DIFF
--- a/dives/test-uddf-export-events.uddf
+++ b/dives/test-uddf-export-events.uddf
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uddf xmlns="http://www.streit.cc/uddf/3.2/" version="3.2.0">
+  <generator>
+    <name>Subsurface Divelog</name>
+    <manufacturer id="subsurface">
+      <name>Subsurface Team</name>
+      <contact>
+        <homepage>http://subsurface-divelog.org/</homepage>
+      </contact>
+    </manufacturer>
+    <version>3</version>
+  </generator>
+  <mediadata/>
+  <diver>
+    <owner id="owner">
+      <personal>
+        <firstname/>
+        <lastname/>
+      </personal>
+      <equipment>
+        <divecomputer id="test-device">
+          <name>Test computer</name>
+          <model>Test computer</model>
+        </divecomputer>
+      </equipment>
+    </owner>
+  </diver>
+  <divesite>
+    <divebase id="allbase">
+      <name>Subsurface Divebase</name>
+    </divebase>
+  </divesite>
+  <gasdefinitions>
+    <mix id="mix(21/0)">
+      <name>air</name>
+      <o2>0.21</o2>
+      <he>0.00</he>
+    </mix>
+    <mix id="mix(32/0)">
+      <name>EANx 32</name>
+      <o2>0.32</o2>
+      <he>0.00</he>
+    </mix>
+  </gasdefinitions>
+  <profiledata>
+    <repetitiongroup id="testid2">
+      <dive id="testid3">
+        <informationbeforedive>
+          <link ref=""/>
+          <divenumber>1</divenumber>
+          <datetime>2026-08-23T12:00:00</datetime>
+          <equipmentused>
+            <leadquantity>0</leadquantity>
+          </equipmentused>
+        </informationbeforedive>
+        <tankdata>
+          <link ref="mix(21/0)"/>
+          <tankvolume>0.012</tankvolume>
+        </tankdata>
+        <tankdata>
+          <link ref="mix(32/0)"/>
+          <tankvolume>0.012</tankvolume>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <alarm>ascent</alarm>
+            <depth>10</depth>
+            <divetime>30</divetime>
+          </waypoint>
+          <waypoint>
+            <depth>10</depth>
+            <divetime>60</divetime>
+          </waypoint>
+          <waypoint>
+            <depth>15</depth>
+            <divetime>90</divetime>
+            <heading>45</heading>
+          </waypoint>
+          <waypoint>
+            <alarm>ascent</alarm>
+            <depth>20</depth>
+            <divetime>120</divetime>
+            <heading>90</heading>
+            <switchmix ref="mix(32/0)"/>
+          </waypoint>
+          <waypoint>
+            <alarm>error</alarm>
+            <depth>30</depth>
+            <divetime>180</divetime>
+            <heading>180</heading>
+            <switchmix ref="mix(21/0)"/>
+          </waypoint>
+          <waypoint>
+            <alarm>error</alarm>
+            <depth>30</depth>
+            <divetime>240</divetime>
+          </waypoint>
+        </samples>
+        <informationafterdive>
+          <diveduration>240</diveduration>
+          <notes>
+            <para/>
+          </notes>
+        </informationafterdive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+  <divetrip/>
+</uddf>

--- a/dives/test-uddf-export-events.xml
+++ b/dives/test-uddf-export-events.xml
@@ -1,0 +1,24 @@
+<!-- AI-generated (Claude) -->
+<divelog program='subsurface' version='3'>
+  <settings/>
+  <dives>
+    <dive number='1' date='2026-08-23' time='12:00:00' duration='4:00 min'>
+      <cylinder o2='21.0%' size='12.0 l' workpressure='200.0 bar'/>
+      <cylinder o2='32.0%' size='12.0 l' workpressure='200.0 bar'/>
+      <divecomputer model='Test computer' deviceid='test-device'>
+        <event time='0:30 min' name='ascent'/>
+        <sample time='1:00 min' depth='10.0 m'/>
+        <event time='1:30 min' name='heading' value='45'/>
+        <sample time='2:00 min' depth='20.0 m'/>
+        <event time='2:00 min' name='ascent'/>
+        <event time='2:00 min' name='heading' value='90'/>
+        <event time='2:00 min' name='gaschange' o2='32.0%'/>
+        <event time='3:00 min' name='ceiling'/>
+        <event time='3:00 min' name='heading' value='180'/>
+        <event time='3:00 min' name='gaschange' o2='21.0%'/>
+        <sample time='3:00 min' depth='30.0 m'/>
+        <event time='4:00 min' name='ceiling'/>
+      </divecomputer>
+    </dive>
+  </dives>
+</divelog>

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -9,9 +9,13 @@
 #include "core/import-csv.h"
 #include "core/parse.h"
 #include "core/pref.h"
+#include "core/qthelper.h"
 #include "core/subsurface-string.h"
 #include "core/trip.h"
 #include "core/xmlparams.h"
+#include <libxml/parser.h>
+#include <libxslt/transform.h>
+#include <libxslt/xsltutils.h>
 #include <QTextStream>
 #include <QXmlStreamReader>
 
@@ -451,6 +455,27 @@ void TestParse::exportUDDF()
 
 	export_dives_xslt("testuddfexport.uddf", 0, 1, "uddf-export.xslt", false);
 	FILE_COMPARE("testuddfexport.uddf", SUBSURFACE_TEST_DATA "/dives/test42.uddf");
+}
+
+// AI-generated (Claude): Regression coverage for interleaved UDDF events and samples.
+void TestParse::exportUDDFEvents()
+{
+	xmlDoc *input = xmlReadFile(SUBSURFACE_TEST_DATA "/dives/test-uddf-export-events.xml", NULL, XML_PARSE_HUGE);
+	QVERIFY(input);
+	xsltStylesheetPtr stylesheet = get_stylesheet("uddf-export.xslt");
+	QVERIFY(stylesheet);
+	const char *params[] = { "units", "'1'", NULL };
+	xmlDoc *output = xsltApplyStylesheet(stylesheet, input, params);
+	QVERIFY(output);
+	QVERIFY(xsltSaveResultToFilename("testuddfevents.uddf", output, stylesheet, 0) > 0);
+	xmlFreeDoc(output);
+	xsltFreeStylesheet(stylesheet);
+	xmlFreeDoc(input);
+	QFile expected(SUBSURFACE_TEST_DATA "/dives/test-uddf-export-events.uddf");
+	QVERIFY(expected.open(QFile::ReadOnly));
+	QFile actual("testuddfevents.uddf");
+	QVERIFY(actual.open(QFile::ReadOnly));
+	QCOMPARE(actual.readAll(), expected.readAll());
 }
 
 static std::vector<const dive_site *> allDiveSites()

--- a/tests/testparse.h
+++ b/tests/testparse.h
@@ -36,6 +36,7 @@ private slots:
 	int parseCSVprofile(int, std::string);
 	void exportCSVDiveProfile();
 	void exportUDDF();
+	void exportUDDFEvents();
 	void exportDiveSitesXML();
 	void exportKML();
 	void importUDDF();

--- a/xslt/uddf-export.xslt
+++ b/xslt/uddf-export.xslt
@@ -436,14 +436,19 @@
               <!-- Suppress this event waypoint when a sample exists at the
                    same @time — the sample's waypoint already carries all
                    data for that timestamp (gas-change / heading are merged
-                   in by the sample branch via preceding-sibling::event).
+                   in by the sample branch regardless of document order).
                    Using a direct @time string comparison avoids the broken
                    position() arithmetic that was here before: after an
                    xsl:sort, position() reflects the sorted order while
                    preceding-sibling:: axes still walk the original document
                    tree, making the old "$position - $events" index wrong
-                   whenever events and samples are interleaved. -->
+                   whenever events and samples are interleaved. Check this
+                   before calculating interpolation so suppressed events do
+                   not scan the samples four times. -->
               <xsl:variable name="evtime" select="@time"/>
+              <xsl:choose>
+                <xsl:when test="../sample[@time = $evtime]"/>
+                <xsl:otherwise>
               <xsl:variable name="time">
                 <xsl:value-of select="substring-before(@time, ':') * 60 + substring-before(substring-after(@time, ':'), ' ')"/>
               </xsl:variable>
@@ -512,7 +517,6 @@
                 </xsl:for-each>
               </xsl:variable>
 
-              <xsl:if test="not(../sample[@time = $evtime])">
                 <waypoint>
                   <xsl:variable name="name">
                     <xsl:value-of select="@name"/>
@@ -582,7 +586,8 @@
                   </xsl:if>
 
                 </waypoint>
-              </xsl:if>
+                </xsl:otherwise>
+              </xsl:choose>
             </xsl:when>
             <xsl:otherwise>
 
@@ -593,7 +598,7 @@
                   <xsl:value-of select="@time"/>
                 </xsl:variable>
 
-                <xsl:for-each select="preceding-sibling::event[@time = $time]">
+                <xsl:for-each select="../event[@time = $time]">
                   <xsl:variable name="name">
                     <xsl:value-of select="@name"/>
                   </xsl:variable>
@@ -616,13 +621,13 @@
                   </xsl:call-template>
                 </divetime>
 
-                <xsl:for-each select="preceding-sibling::event[@time = $time and @name='heading']/@value">
+                <xsl:for-each select="../event[@time = $time and @name='heading']/@value">
                   <heading>
                     <xsl:value-of select="."/>
                   </heading>
                 </xsl:for-each>
 
-                <xsl:for-each select="preceding-sibling::event[@time = $time and @name='gaschange']">
+                <xsl:for-each select="../event[@time = $time and @name='gaschange']">
                   <xsl:variable name="o2">
                     <xsl:choose>
                       <xsl:when test="@o2 != ''">
@@ -773,7 +778,19 @@
   <xsl:param name="depthsecond"/>
   <xsl:param name="timeevent"/>
 
-  <xsl:value-of select="format-number((($timeevent - $timefirst) div ($timesecond - $timefirst) * ($depthsecond - $depthfirst) + $depthfirst) div 1000, '#.##')"/>
+  <xsl:choose>
+    <xsl:when test="string-length(normalize-space($depthfirst)) &gt; 0 and string-length(normalize-space($depthsecond)) &gt; 0 and $timefirst != $timesecond">
+      <xsl:value-of select="format-number((($timeevent - $timefirst) div ($timesecond - $timefirst) * ($depthsecond - $depthfirst) + $depthfirst) div 1000, '#.##')"/>
+    </xsl:when>
+    <!-- Events outside the sampled interval use the nearest sample depth. -->
+    <xsl:when test="string-length(normalize-space($depthfirst)) &gt; 0">
+      <xsl:value-of select="format-number($depthfirst div 1000, '#.##')"/>
+    </xsl:when>
+    <xsl:when test="string-length(normalize-space($depthsecond)) &gt; 0">
+      <xsl:value-of select="format-number($depthsecond div 1000, '#.##')"/>
+    </xsl:when>
+    <xsl:otherwise>0</xsl:otherwise>
+  </xsl:choose>
 
 </xsl:template>
 

--- a/xslt/uddf-export.xslt
+++ b/xslt/uddf-export.xslt
@@ -430,82 +430,89 @@
         <xsl:for-each select="divecomputer[1]/event | divecomputer[1]/sample">
           <xsl:sort select="substring-before(@time, ':') * 60 + substring-before(substring-after(@time, ':'), ' ')" data-type="number" order="ascending"/>
 
-        <xsl:variable name="events">
-          <xsl:value-of select="count(preceding-sibling::event)"/>
-        </xsl:variable>
-
           <xsl:choose>
             <xsl:when test="name() = 'event'">
 
-              <xsl:variable name="position">
-                <xsl:value-of select="position()"/>
-              </xsl:variable>
-
-              <!-- Times of surrounding waypoints -->
-              <xsl:variable name="timefirst">
-                <xsl:choose>
-                  <xsl:when test="../sample[position() = $position - 1 - $events]/@time != ''">
-                    <xsl:call-template name="time2sec">
-                      <xsl:with-param name="time">
-                        <xsl:value-of select="../sample[position() = $position - 1 - $events]/@time"/>
-                      </xsl:with-param>
-                    </xsl:call-template>
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <xsl:value-of select="0"/>
-                  </xsl:otherwise>
-                </xsl:choose>
-              </xsl:variable>
-              <xsl:variable name="timesecond">
-                <xsl:choose>
-                  <xsl:when test="../sample[position() = $position - $events]/@time != ''">
-                    <xsl:call-template name="time2sec">
-                      <xsl:with-param name="time">
-                        <xsl:value-of select="../sample[position() = $position - $events]/@time"/>
-                      </xsl:with-param>
-                    </xsl:call-template>
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <xsl:value-of select="0"/>
-                  </xsl:otherwise>
-                </xsl:choose>
-              </xsl:variable>
-
-              <!-- Depths of surrounding waypoints -->
-              <xsl:variable name="depthfirst">
-                <xsl:choose>
-                  <xsl:when test="../sample[position() = $position - 1 - $events]/@depth != ''">
-                    <xsl:call-template name="depth2mm">
-                      <xsl:with-param name="depth">
-                        <xsl:value-of select="../sample[position() = $position - 1 - $events]/@depth"/>
-                      </xsl:with-param>
-                    </xsl:call-template>
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <xsl:value-of select="0"/>
-                  </xsl:otherwise>
-                </xsl:choose>
-              </xsl:variable>
-              <xsl:variable name="depthsecond">
-                <xsl:choose>
-                  <xsl:when test="../sample[position() = $position - $events]/@depth != ''">
-                    <xsl:call-template name="depth2mm">
-                      <xsl:with-param name="depth">
-                        <xsl:value-of select="../sample[position() = $position - $events]/@depth"/>
-                      </xsl:with-param>
-                    </xsl:call-template>
-                  </xsl:when>
-                  <xsl:otherwise>
-                    <xsl:value-of select="0"/>
-                  </xsl:otherwise>
-                </xsl:choose>
-              </xsl:variable>
-
+              <!-- Suppress this event waypoint when a sample exists at the
+                   same @time — the sample's waypoint already carries all
+                   data for that timestamp (gas-change / heading are merged
+                   in by the sample branch via preceding-sibling::event).
+                   Using a direct @time string comparison avoids the broken
+                   position() arithmetic that was here before: after an
+                   xsl:sort, position() reflects the sorted order while
+                   preceding-sibling:: axes still walk the original document
+                   tree, making the old "$position - $events" index wrong
+                   whenever events and samples are interleaved. -->
+              <xsl:variable name="evtime" select="@time"/>
               <xsl:variable name="time">
                 <xsl:value-of select="substring-before(@time, ':') * 60 + substring-before(substring-after(@time, ':'), ' ')"/>
               </xsl:variable>
 
-              <xsl:if test="$timesecond != $time">
+              <!-- Find the nearest sample at or before the event time (for
+                   depth interpolation). Filter to samples with time_s <=
+                   event time_s, sort descending, take position()=1.
+                   The time is compared using the same arithmetic as the
+                   sort key: MM*60+SS. -->
+              <xsl:variable name="timefirst">
+                <xsl:for-each select="../sample[
+                    (substring-before(@time, ':') * 60 +
+                     substring-before(substring-after(@time, ':'), ' '))
+                    &lt;= $time]">
+                  <xsl:sort select="substring-before(@time, ':') * 60 + substring-before(substring-after(@time, ':'), ' ')" data-type="number" order="descending"/>
+                  <xsl:if test="position() = 1">
+                    <xsl:call-template name="time2sec">
+                      <xsl:with-param name="time" select="@time"/>
+                    </xsl:call-template>
+                  </xsl:if>
+                </xsl:for-each>
+              </xsl:variable>
+
+              <!-- Nearest sample at or after the event time -->
+              <xsl:variable name="timesecond">
+                <xsl:for-each select="../sample[
+                    (substring-before(@time, ':') * 60 +
+                     substring-before(substring-after(@time, ':'), ' '))
+                    &gt;= $time]">
+                  <xsl:sort select="substring-before(@time, ':') * 60 + substring-before(substring-after(@time, ':'), ' ')" data-type="number" order="ascending"/>
+                  <xsl:if test="position() = 1">
+                    <xsl:call-template name="time2sec">
+                      <xsl:with-param name="time" select="@time"/>
+                    </xsl:call-template>
+                  </xsl:if>
+                </xsl:for-each>
+              </xsl:variable>
+
+              <xsl:variable name="depthfirst">
+                <xsl:for-each select="../sample[
+                    @depth != '' and
+                    (substring-before(@time, ':') * 60 +
+                     substring-before(substring-after(@time, ':'), ' '))
+                    &lt;= $time]">
+                  <xsl:sort select="substring-before(@time, ':') * 60 + substring-before(substring-after(@time, ':'), ' ')" data-type="number" order="descending"/>
+                  <xsl:if test="position() = 1">
+                    <xsl:call-template name="depth2mm">
+                      <xsl:with-param name="depth" select="@depth"/>
+                    </xsl:call-template>
+                  </xsl:if>
+                </xsl:for-each>
+              </xsl:variable>
+
+              <xsl:variable name="depthsecond">
+                <xsl:for-each select="../sample[
+                    @depth != '' and
+                    (substring-before(@time, ':') * 60 +
+                     substring-before(substring-after(@time, ':'), ' '))
+                    &gt;= $time]">
+                  <xsl:sort select="substring-before(@time, ':') * 60 + substring-before(substring-after(@time, ':'), ' ')" data-type="number" order="ascending"/>
+                  <xsl:if test="position() = 1">
+                    <xsl:call-template name="depth2mm">
+                      <xsl:with-param name="depth" select="@depth"/>
+                    </xsl:call-template>
+                  </xsl:if>
+                </xsl:for-each>
+              </xsl:variable>
+
+              <xsl:if test="not(../sample[@time = $evtime])">
                 <waypoint>
                   <xsl:variable name="name">
                     <xsl:value-of select="@name"/>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
The event branch in the for-each loop used position() arithmetic combined
with preceding-sibling::event counts to locate the surrounding samples for
depth interpolation and to decide whether to suppress the event's waypoint
when a sample already exists at the same time.

After xsl:sort, position() reflects the sorted order but preceding-sibling::
axes still walk the original document tree order.  The resulting
"$position - $events" index therefore points at the wrong sample whenever
events and samples are interleaved, causing the coincidence check
($timesecond != $time) to mis-fire and emit a duplicate waypoint for
every event that falls at the same timestamp as a sample.

Fix the coincidence guard with a direct @time string comparison:

  not(../sample[@time = $evtime])

Fix the surrounding-sample lookups for depth interpolation by filtering the
sample node-set with an inline predicate (time_s <= event_time_s or
time_s >= event_time_s) before sorting and taking position()=1, which is
correct under XSLT 1.0 regardless of document order.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Reported-by: K4pisa (Maxime) in https://groups.google.com/g/subsurface-divelog/c/CkeizSm0yXE/m/WJGcp1YSDgAJ
