### PR TITLE
Validate planner deco switch depth edits

### DIFF
--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -14,7 +14,26 @@
 #include "core/subsurface-qt/divelistnotifier.h"
 #include "core/subsurface-string.h"
 #include "core/tanksensormapping.h"
+#include <cmath>
 #include <string>
+
+// AI-generated (Claude)
+static bool validDepthString(const QString &text)
+{
+	if (text.trimmed().isEmpty())
+		return true;
+
+	QByteArray bytes = text.toLocal8Bit();
+	const char *end;
+	double value = permissive_strtod(bytes.constData(), &end);
+	if (end == bytes.constData() || value < 0 || !std::isfinite(value))
+		return false;
+
+	QString rest = QString(end).trimmed();
+	QString localFt = gettextFromC::tr("ft");
+	QString localM = gettextFromC::tr("m");
+	return rest.isEmpty() || rest == "m" || rest == localM || rest == "ft" || rest == localFt;
+}
 
 CylindersModel::CylindersModel(bool planner, QObject *parent) : CleanerTableModel(parent),
 	d(nullptr),
@@ -434,6 +453,8 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 		type = Command::EditCylinderType::GASMIX;
 		break;
 	case DEPTH: {
+		if (!validDepthString(vString))
+			return false;
 		// AI-generated (Claude)
 		// Clearing the editor requests a calculated value. A parsed zero is an
 		// explicit legacy value and must remain distinguishable from empty input.

--- a/tests/testdiveplannermodel.cpp
+++ b/tests/testdiveplannermodel.cpp
@@ -8,6 +8,7 @@
 #include "core/string-format.h"
 #include "core/units.h"
 #include <QSignalSpy>
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -199,6 +200,53 @@ void TestDivePlannerModel::testCylinderDepthInput()
 }
 
 // AI-generated (Claude)
+void TestDivePlannerModel::testDecoSwitchDepthValidation()
+{
+	DivePlannerPointsModel *planner = DivePlannerPointsModel::instance();
+	dive plannedDive;
+
+	prefs = default_prefs;
+	prefs.unit_system = METRIC;
+	prefs.units = SI_units;
+	planner->setPlanMode(DivePlannerPointsModel::PLAN);
+	planner->createSimpleDive(&plannedDive);
+	CylindersModel *model = planner->cylindersModel();
+	QModelIndex depthIndex = model->index(0, CylindersModel::DEPTH);
+	cylinder_t *cylinder = plannedDive.get_cylinder(0);
+	QVERIFY(cylinder);
+	depth_t calculatedDepth = calculate_deco_switch_depth(&plannedDive, cylinder->gasmix);
+	QString zeroDepth = get_depth_string(0_m, true);
+
+	cylinder->depth = 15_m;
+	QVERIFY(model->setData(depthIndex, QString()));
+	QCOMPARE(cylinder->depth.mm, calculatedDepth.mm);
+
+	cylinder->depth = 15_m;
+	QVERIFY(model->setData(depthIndex, QStringLiteral("0")));
+	QCOMPARE(cylinder->depth.mm, 0);
+	QCOMPARE(model->data(depthIndex, Qt::DisplayRole).toString(), zeroDepth);
+
+	QVERIFY(model->setData(depthIndex, QStringLiteral("12,5 m")));
+	QCOMPARE(cylinder->depth.mm, 12500);
+	QVERIFY(model->setData(depthIndex, QStringLiteral("41 ft")));
+	QCOMPARE(cylinder->depth.mm, feet_to_mm(41.0));
+
+	QSignalSpy dataChangedSpy(model, &CylindersModel::dataChanged);
+	QVERIFY(!model->setData(depthIndex, QStringLiteral("invalid")));
+	QCOMPARE(cylinder->depth.mm, feet_to_mm(41.0));
+	QCOMPARE(dataChangedSpy.count(), 0);
+	QVERIFY(!model->setData(depthIndex, QStringLiteral("m")));
+	QCOMPARE(cylinder->depth.mm, feet_to_mm(41.0));
+	QCOMPARE(dataChangedSpy.count(), 0);
+	QVERIFY(!model->setData(depthIndex, QStringLiteral("-3 m")));
+	QCOMPARE(cylinder->depth.mm, feet_to_mm(41.0));
+	QCOMPARE(dataChangedSpy.count(), 0);
+
+	planner->resetPlanState();
+	prefs = default_prefs;
+}
+
+// AI-generated (Claude)
 void TestDivePlannerModel::testStoredZeroCylinderDepthDisplay()
 {
 	DivePlannerPointsModel *model = DivePlannerPointsModel::instance();
@@ -216,6 +264,53 @@ void TestDivePlannerModel::testStoredZeroCylinderDepthDisplay()
 	QCOMPARE(cylinders->data(depthIndex, Qt::DisplayRole).toString(), get_depth_string(0_m, true));
 
 	model->resetPlanState();
+	prefs = default_prefs;
+}
+
+// AI-generated (Claude)
+void TestDivePlannerModel::testZeroDepthExcludesDecoGas()
+{
+	DivePlannerPointsModel *planner = DivePlannerPointsModel::instance();
+	dive plannedDive;
+
+	prefs = default_prefs;
+	prefs.unit_system = METRIC;
+	prefs.units = SI_units;
+	planner->setPlanMode(DivePlannerPointsModel::PLAN);
+	planner->createSimpleDive(&plannedDive);
+	CylindersModel *model = planner->cylindersModel();
+	model->add();
+	QCOMPARE(plannedDive.cylinders.size(), size_t(2));
+	cylinder_t *decoCylinder = plannedDive.get_cylinder(1);
+	QVERIFY(decoCylinder);
+	decoCylinder->cylinder_use = OC_GAS;
+	decoCylinder->gasmix.o2 = make_fraction(500);
+	decoCylinder->depth = 21_m;
+	QModelIndex depthIndex = model->index(1, CylindersModel::DEPTH);
+
+	QVERIFY(model->setData(depthIndex, QStringLiteral("21 m")));
+	planner->emitDataChanged();
+	const diveplan &manualDepthPlan = planner->getDiveplan();
+	QVERIFY(std::any_of(manualDepthPlan.dp.begin(), manualDepthPlan.dp.end(), [](const divedatapoint &point) {
+		return point.time == 0 && !point.entered && point.cylinderid == 1 && point.depth.mm == 21000;
+	}));
+
+	QVERIFY(model->setData(depthIndex, QStringLiteral("0")));
+	planner->emitDataChanged();
+	const diveplan &zeroDepthPlan = planner->getDiveplan();
+	QVERIFY(std::none_of(zeroDepthPlan.dp.begin(), zeroDepthPlan.dp.end(), [](const divedatapoint &point) {
+		return point.time == 0 && !point.entered && point.cylinderid == 1;
+	}));
+
+	decoCylinder->cylinder_use = TRAVEL_OC;
+	decoCylinder->depth = 21_m;
+	planner->emitDataChanged();
+	const diveplan &travelGasPlan = planner->getDiveplan();
+	QVERIFY(std::none_of(travelGasPlan.dp.begin(), travelGasPlan.dp.end(), [](const divedatapoint &point) {
+		return point.time == 0 && !point.entered && point.cylinderid == 1;
+	}));
+
+	planner->resetPlanState();
 	prefs = default_prefs;
 }
 

--- a/tests/testdiveplannermodel.h
+++ b/tests/testdiveplannermodel.h
@@ -19,6 +19,10 @@ private slots:
 	void testCylinderDepthInput();
 	void testStoredZeroCylinderDepthDisplay();
 	// AI-generated (Claude)
+	void testDecoSwitchDepthValidation();
+	// AI-generated (Claude)
+	void testZeroDepthExcludesDecoGas();
+	// AI-generated (Claude)
 	void testRecreationalPlanSaveAllowed();
 };
 


### PR DESCRIPTION
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
The permissive depth parser maps malformed and negative input to zero, so invalid edits appeared successful and replaced the manual switch depth. Validate the complete value before applying it, while retaining empty and explicit zero as the calculated-depth fallback.
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
