### PR TITLE
profile: show media thumbnails on manually added dives

### DIFF
--- a/profile-widget/divepixmapitem.cpp
+++ b/profile-widget/divepixmapitem.cpp
@@ -31,7 +31,8 @@ DivePictureItem::DivePictureItem(QGraphicsItem *parent): DivePixmapItem(parent),
 	canvas(new QGraphicsRectItem(this)),
 	shadow(new QGraphicsRectItem(this)),
 	button(new CloseButtonItem(this)),
-	baseZValue(0.0)
+	baseZValue(0.0),
+	allowRemove(true)
 {
 	setFlag(ItemIgnoresTransformations);
 	setAcceptHoverEvents(true);
@@ -83,9 +84,11 @@ void DivePictureItem::hoverEnterEvent(QGraphicsSceneHoverEvent*)
 	Animations::scaleTo(this, qPrefDisplay::animation_speed(), 1.0);
 	setZValue(baseZValue + 5.0);
 
-	button->setOpacity(0);
-	button->show();
-	Animations::show(button, qPrefDisplay::animation_speed());
+	if (allowRemove) {
+		button->setOpacity(0);
+		button->show();
+		Animations::show(button, qPrefDisplay::animation_speed());
+	}
 }
 
 void DivePictureItem::setFileUrl(const QString &s)
@@ -93,11 +96,19 @@ void DivePictureItem::setFileUrl(const QString &s)
 	fileUrl = s;
 }
 
+void DivePictureItem::setAllowRemove(bool on)
+{
+	allowRemove = on;
+	if (!on)
+		button->hide();
+}
+
 void DivePictureItem::hoverLeaveEvent(QGraphicsSceneHoverEvent*)
 {
 	Animations::scaleTo(this, qPrefDisplay::animation_speed(), 0.2);
 	setZValue(baseZValue);
-	Animations::hide(button, qPrefDisplay::animation_speed());
+	if (allowRemove)
+		Animations::hide(button, qPrefDisplay::animation_speed());
 }
 
 void DivePictureItem::mousePressEvent(QGraphicsSceneMouseEvent *event)

--- a/profile-widget/divepixmapitem.h
+++ b/profile-widget/divepixmapitem.h
@@ -33,6 +33,7 @@ public:
 	void setPixmap(const QPixmap& pix);
 	void setBaseZValue(double z);
 	void setFileUrl(const QString& s);
+	void setAllowRemove(bool allowRemove);
 signals:
 	void removePicture(const QString &fileUrl);
 public slots:
@@ -46,6 +47,7 @@ private:
 	QGraphicsRectItem *shadow;
 	CloseButtonItem *button;
 	double baseZValue;
+	bool allowRemove;
 };
 
 #endif // DIVEPIXMAPITEM_H

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -179,6 +179,11 @@ void ProfileWidget2::replot()
 	plotDive(d, dc);
 }
 
+void ProfileWidget2::replotPreservePictures()
+{
+	plotDive(d, dc, RenderFlags::DontRecreatePictures);
+}
+
 void ProfileWidget2::setupSceneAndFlags()
 {
 	setScene(profileScene.get());
@@ -234,7 +239,7 @@ void ProfileWidget2::plotDive(const struct dive *dIn, int dcIn, int flags)
 	}
 
 	// On zoom / pan don't recreate the picture thumbnails, only change their position.
-	if (flags & RenderFlags::DontRecalculatePlotInfo)
+	if (flags & (RenderFlags::DontRecalculatePlotInfo | RenderFlags::DontRecreatePictures))
 		updateThumbnails();
 	else
 		plotPicturesInternal(d, flags & RenderFlags::Instant);
@@ -316,7 +321,7 @@ void ProfileWidget2::divePlannerHandlerReleased()
 	if (currentState == EDIT)
 		emit stopMoved(1);
 	shouldCalculateMax = true;
-	replot();
+	replotPreservePictures();
 }
 
 void ProfileWidget2::mouseReleaseEvent(QMouseEvent *event)
@@ -328,7 +333,7 @@ void ProfileWidget2::mouseReleaseEvent(QMouseEvent *event)
 	}
 	if (currentState == PLAN || currentState == EDIT) {
 		shouldCalculateMax = true;
-		replot();
+		replotPreservePictures();
 	}
 }
 #endif
@@ -841,8 +846,8 @@ void ProfileWidget2::editName(DiveEventItem *item)
 
 void ProfileWidget2::connectPlannerModel()
 {
-	connect(plannerModel, &DivePlannerPointsModel::dataChanged, this, &ProfileWidget2::replot);
-	connect(plannerModel, &DivePlannerPointsModel::cylinderModelEdited, this, &ProfileWidget2::replot);
+	connect(plannerModel, &DivePlannerPointsModel::dataChanged, this, &ProfileWidget2::replotPreservePictures);
+	connect(plannerModel, &DivePlannerPointsModel::cylinderModelEdited, this, &ProfileWidget2::replotPreservePictures);
 	connect(plannerModel, &DivePlannerPointsModel::modelReset, this, &ProfileWidget2::pointsReset);
 	connect(plannerModel, &DivePlannerPointsModel::rowsInserted, this, &ProfileWidget2::pointInserted);
 	connect(plannerModel, &DivePlannerPointsModel::rowsRemoved, this, &ProfileWidget2::pointsRemoved);
@@ -854,8 +859,8 @@ void ProfileWidget2::disconnectPlannerModel()
 {
 #if defined(SUBSURFACE_DESKTOP)
 	if (plannerModel) {
-		disconnect(plannerModel, &DivePlannerPointsModel::dataChanged, this, &ProfileWidget2::replot);
-		disconnect(plannerModel, &DivePlannerPointsModel::cylinderModelEdited, this, &ProfileWidget2::replot);
+		disconnect(plannerModel, &DivePlannerPointsModel::dataChanged, this, &ProfileWidget2::replotPreservePictures);
+		disconnect(plannerModel, &DivePlannerPointsModel::cylinderModelEdited, this, &ProfileWidget2::replotPreservePictures);
 
 		disconnect(plannerModel, &DivePlannerPointsModel::modelReset, this, &ProfileWidget2::pointsReset);
 		disconnect(plannerModel, &DivePlannerPointsModel::rowsInserted, this, &ProfileWidget2::pointInserted);
@@ -1160,7 +1165,11 @@ ProfileWidget2::PictureEntry::PictureEntry(offset_t offsetIn, const std::string 
 	QImage img = Thumbnailer::instance()->fetchThumbnail(QString::fromStdString(filename), synchronous).scaled(size, size, Qt::KeepAspectRatio);
 	thumbnail->setPixmap(QPixmap::fromImage(img));
 	thumbnail->setFileUrl(QString::fromStdString(filename));
-	connect(thumbnail.get(), &DivePictureItem::removePicture, profile, &ProfileWidget2::removePicture);
+	// Profile edit mode plots a copy of the dive; don't delete media from it.
+	if (profile->currentState == EDIT)
+		thumbnail->setAllowRemove(false);
+	else
+		connect(thumbnail.get(), &DivePictureItem::removePicture, profile, &ProfileWidget2::removePicture);
 }
 
 // Define a default sort order for picture-entries: sort lexicographically by timestamp and filename.
@@ -1249,7 +1258,9 @@ void ProfileWidget2::plotPictures()
 void ProfileWidget2::plotPicturesInternal(const struct dive *d, bool synchronous)
 {
 	pictures.clear();
-	if (currentState == EDIT || currentState == PLAN)
+	// The planner has no media. Keep pictures in EDIT: manual dives auto-enter that mode
+	// so hiding them here made media vanish from those profiles after the first replot
+	if (currentState == PLAN)
 		return;
 
 	if (!d)
@@ -1331,6 +1342,10 @@ void ProfileWidget2::profileChanged(dive *dive)
 void ProfileWidget2::dropEvent(QDropEvent *event)
 {
 #if defined(SUBSURFACE_DESKTOP)
+	if (currentState == EDIT || currentState == PLAN) {
+		event->ignore();
+		return;
+	}
 	if (event->mimeData()->hasFormat("application/x-subsurfaceimagedrop") && d) {
 		QByteArray itemData = event->mimeData()->data("application/x-subsurfaceimagedrop");
 		QDataStream dataStream(&itemData, QIODevice::ReadOnly);
@@ -1426,6 +1441,10 @@ void ProfileWidget2::pictureOffsetChanged(dive *dIn, QString filenameIn, offset_
 
 void ProfileWidget2::dragEnterEvent(QDragEnterEvent *event)
 {
+	if (currentState == EDIT || currentState == PLAN) {
+		event->ignore();
+		return;
+	}
 	if (event->mimeData()->hasFormat("application/x-subsurfaceimagedrop")) {
 		if (event->source() == this) {
 			event->setDropAction(Qt::MoveAction);
@@ -1440,6 +1459,10 @@ void ProfileWidget2::dragEnterEvent(QDragEnterEvent *event)
 
 void ProfileWidget2::dragMoveEvent(QDragMoveEvent *event)
 {
+	if (currentState == EDIT || currentState == PLAN) {
+		event->ignore();
+		return;
+	}
 	if (event->mimeData()->hasFormat("application/x-subsurfaceimagedrop")) {
 		if (event->source() == this) {
 			event->setDropAction(Qt::MoveAction);

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -45,6 +45,7 @@ public:
 		static constexpr int None = 0;
 		static constexpr int Instant = 1 << 0;
 		static constexpr int DontRecalculatePlotInfo = 1 << 1;
+		static constexpr int DontRecreatePictures = 1 << 2;
 	};
 
 	// Pass null as plannerModel if no support for planning required
@@ -111,6 +112,7 @@ private:
 	void dragMoveEvent(QDragMoveEvent *event) override;
 
 	void replot();
+	void replotPreservePictures();
 	void diveComputerEdited(dive &dive, divecomputer &dc);
 	void setZoom(int level);
 	void addGasSwitch(int tank, int seconds);


### PR DESCRIPTION

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
Manually added dives auto-enter profile edit mode, which skipped drawing pictures after first replot. thumbnails kept visible there, allow hover and click-to-open, and leave delete/retime to the Media tab so they do not mutate the edit copy. Avoid rebuilding thumbnails while dragging profile handles (will blink otherwise)

### Changes made:
1. Draw media thumbnails on the profile in EDIT mode; still skip them in PLAN.
2. In EDIT, keep hover and click-to-open; disable thumbnail delete and drag-to-retime so those stay on the Media tab.
3. Do not recreate thumbnails while dragging profile handles only update their position.

### Related issues:
Fixes #3976

### Additional information:
add photos to a manually added dive, switch to another dive and back or enable and disable photos with buttons to the left (humbnails should stay on the profile graph as expected)

hover and click to view image work as expected

dragging waypoints should not make thumbnails blink 

computer-logged dives still allow delete/dragging from the graph

### Documentation change:

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
