### PR TITLE
profile: replace oversized empty-state logo

### DIFF
--- a/desktop-widgets/profilewidget.cpp
+++ b/desktop-widgets/profilewidget.cpp
@@ -3,7 +3,6 @@
 #include "profilewidget.h"
 #include "profile-widget/profilewidget2.h"
 #include "commands/command.h"
-#include "core/color.h"
 #include "core/event.h"
 #include "core/sample.h"
 #include "core/selection.h"
@@ -14,44 +13,34 @@
 
 #include <QToolBar>
 #include <QHBoxLayout>
+#include <QVBoxLayout>
 #include <QStackedWidget>
 #include <QLabel>
+#include <QIcon>
 
-// A resizing display of the Subsurface logo when no dive is shown
-class EmptyView : public QLabel {
+//  small display of Subsurface logo when no dive is shown + a helpful hint
+class EmptyView : public QWidget {
 public:
 	EmptyView(QWidget *parent = nullptr);
-	~EmptyView();
-private:
-	QPixmap logo;
-	void update();
-	void resizeEvent(QResizeEvent *) override;
 };
 
-EmptyView::EmptyView(QWidget *parent) : QLabel(parent),
-	logo(":poster-icon")
+EmptyView::EmptyView(QWidget *parent) : QWidget(parent)
 {
-	QPalette pal;
-	pal.setColor(QPalette::Window, getColor(::BACKGROUND));
 	setAutoFillBackground(true);
-	setPalette(pal);
-	setMinimumSize(1,1);
-	setAlignment(Qt::AlignHCenter);
-	update();
-}
 
-EmptyView::~EmptyView()
-{
-}
+	QLabel *icon = new QLabel;
+	icon->setAlignment(Qt::AlignHCenter);
+	icon->setPixmap(QIcon(":poster-icon").pixmap(QSize(64, 64)));
 
-void EmptyView::update()
-{
-	setPixmap(logo.scaled(size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
-}
+	QLabel *message = new QLabel(ProfileWidget::tr("Welcome! Select a dive to show information here"));
+	message->setAlignment(Qt::AlignHCenter);
+	message->setWordWrap(true);
 
-void EmptyView::resizeEvent(QResizeEvent *)
-{
-	update();
+	QVBoxLayout *layout = new QVBoxLayout(this);
+	layout->addStretch();
+	layout->addWidget(icon);
+	layout->addWidget(message);
+	layout->addStretch();
 }
 
 ProfileWidget::ProfileWidget() : d(nullptr), dc(0), placingCommand(false)


### PR DESCRIPTION
When no dive is selected the profile pane scaled the logo to fill the
widget, which looked oversized + ignored application theme. Instead,
show a small icon and a short message to user on what to do

uses widget palette

this looks a bit more modern and polished

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
When no dive is selected the profile pane scaled the logo to fill the
widget, which looked oversized and ignored the application theme.
Instead, show a small icon and a short message to the user on what to
do. This uses the widget palette so the empty state follows light and
dark themes, and looks a bit more modern and polished.

Previously:
<img width="476" height="505" alt="image" src="https://github.com/user-attachments/assets/830438b7-66a1-4eb3-adf3-8ba9bcc15d8f" />


New look:
<img width="418" height="450" alt="image" src="https://github.com/user-attachments/assets/5773676d-6de5-49ed-9fd4-f34558116957" />

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Replace the empty profile view that scaled the poster to the pane size with a 64px icon and the hint "Welcome! Select a dive to show information here".
2) Drop the hardcoded profile-plot background color so the placeholder uses the normal widget palett

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Start with no dive selected (or deselect the current dive, ctrl+click it). The profile pane should show a small icon plus the hint instead of a huge stretched logo. Select a dive to confirm the profile still plots

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->