### PR TITLE
ui: draw unused rating stars smaller and gray

### DIFF
--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -67,11 +67,13 @@ void StarWidgetsDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
 	const QPixmap active = QPixmap::fromImage(StarWidget::starActive());
 	const QPixmap inactive = QPixmap::fromImage(StarWidget::starInactive());
 	const IconMetrics &metrics = defaultIconMetrics();
+	int inactiveDeltaX = (metrics.sz_small - inactive.width()) / 2;
+	int inactiveDeltaY = option.rect.height() / 2 - inactive.height() / 2;
 
 	for (int i = 0; i < rating; i++)
 		painter->drawPixmap(option.rect.x() + i * metrics.sz_small + metrics.spacing, option.rect.y() + deltaY, active);
 	for (int i = rating; i < TOTALSTARS; i++)
-		painter->drawPixmap(option.rect.x() + i * metrics.sz_small + metrics.spacing, option.rect.y() + deltaY, inactive);
+		painter->drawPixmap(option.rect.x() + i * metrics.sz_small + metrics.spacing + inactiveDeltaX, option.rect.y() + inactiveDeltaY, inactive);
 	painter->restore();
 }
 

--- a/desktop-widgets/starwidget.cpp
+++ b/desktop-widgets/starwidget.cpp
@@ -18,24 +18,6 @@ const QImage& StarWidget::starInactive()
 	return inactiveStar;
 }
 
-QImage focusedImage(const QImage& coloredImg)
-{
-	QImage img = coloredImg;
-	for (int i = 0; i < img.width(); ++i) {
-		for (int j = 0; j < img.height(); ++j) {
-			QRgb rgb = img.pixel(i, j);
-			if (!rgb)
-				continue;
-
-			QColor c(rgb);
-			c = c.darker();
-			img.setPixel(i, j, c.rgb());
-		}
-	}
-
-	return img;
-}
-
 int StarWidget::currentStars() const
 {
 	return current;
@@ -67,17 +49,17 @@ void StarWidget::mouseReleaseEvent(QMouseEvent *event)
 void StarWidget::paintEvent(QPaintEvent*)
 {
 	QPainter p(this);
-	QImage star = hasFocus() ? focusedImage(starActive()) : starActive();
-	QPixmap selected = QPixmap::fromImage(star);
+	QPixmap selected = QPixmap::fromImage(starActive());
 	QPixmap inactive = QPixmap::fromImage(starInactive());
 	const IconMetrics& metrics = defaultIconMetrics();
-
+	int dx = (metrics.sz_small - inactive.width()) / 2;
+	int dy = (metrics.sz_small - inactive.height()) / 2;
 
 	for (int i = 0; i < current; i++)
 		p.drawPixmap(i * metrics.sz_small + metrics.spacing, 0, selected);
 
 	for (int i = current; i < TOTALSTARS; i++)
-		p.drawPixmap(i * metrics.sz_small + metrics.spacing, 0, inactive);
+		p.drawPixmap(i * metrics.sz_small + metrics.spacing + dx, dy, inactive);
 
 	if (hasFocus()) {
 		QStyleOptionFocusRect option;
@@ -103,8 +85,7 @@ static QImage grayImage(const QImage &coloredImg)
 			if (!rgb)
 				continue;
 
-			QColor c(rgb);
-			int gray = 204 + (c.red() + c.green() + c.blue()) / 15;
+			int gray = qGray(rgb) * 2 / 5 + 40;
 			img.setPixel(i, j, qRgb(gray, gray, gray));
 		}
 	}
@@ -128,9 +109,8 @@ StarWidget::StarWidget(QWidget *parent) : QWidget(parent, QFlag(0)),
 		render.render(&painter, QRectF(0, 0, dim, dim));
 		activeStar = renderedStar.toImage();
 	}
-	if (inactiveStar.isNull()) {
-		inactiveStar = grayImage(activeStar);
-	}
+	if (inactiveStar.isNull())
+		inactiveStar = grayImage(activeStar.scaled(dim / 2, dim / 2, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	setFocusPolicy(Qt::StrongFocus);
 }
 


### PR DESCRIPTION
unselected stars were big and white, making it cluttered and hard to read. Instead draw them at half size and grayed out. Gives a cleaner look to the app

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Unselected rating stars were the same size as selected ones and almost white, which made the control cluttered and hard to read. Draw unused stars at half size and grayed out, keep selected stars yellow (including while the control has focus), and center the smaller stars in each slot.

Previously:
<img width="178" height="171" alt="image" src="https://github.com/user-attachments/assets/0e8ff55f-20ee-49a4-a0c9-eb2c62f04bed" />

New look:
<img width="181" height="182" alt="image" src="https://github.com/user-attachments/assets/0289e006-6b47-4375-9137-b3ae280999b0" />

This applies everywhere `StarWidget` is used Notes rating, Information tab (visibility, current)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Scale unused stars to half size and render them gray instead of white
2) Stop darkening selected stars while the widget has focus.
3) Center the smaller unused stars in the Notes/Information widgets and in the dive-list rating column

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Open any dive, check Notes rating and the Information tab star ratings, and the rating column in the dive list

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
No documentation change. Unused stars are visually smaller and gray rating values and how you set them are unchanged

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->