### PR TITLE
git: keep an empty dive site that is still referenced by a dive

### DIFF
--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -14,6 +14,7 @@
 #include <fcntl.h>
 #include <git2.h>
 #include <memory>
+#include <unordered_set>
 
 #include "commands/command.h"
 #include "dive.h"
@@ -847,11 +848,18 @@ static void save_divesites(git_repository *repo, struct dir *tree)
 {
 	struct dir *subdir;
 	membuffer dirname;
+	// AI-generated (Claude): An empty site still carries referential data when a dive uses its UUID.
+	std::unordered_set<const dive_site *> referenced_sites;
+	for (const auto &dive: divelog.dives) {
+		if (dive->dive_site)
+			referenced_sites.insert(dive->dive_site);
+	}
 	put_format(&dirname, "01-Divesites");
 	subdir = new_directory(repo, tree, &dirname);
 
-	divelog.sites.purge_empty();
 	for (const auto &ds: divelog.sites) {
+		if (ds->is_empty() && !referenced_sites.count(ds.get()))
+			continue;
 		membuffer b;
 		membuffer site_file_name;
 		put_format(&site_file_name, "Site-%08x", ds->uuid);
@@ -941,14 +949,13 @@ static void save_filter_presets(git_repository *repo, struct dir *tree)
 
 static int create_git_tree(git_repository *repo, struct dir *root, bool select_only, bool cached_ok)
 {
+	// AI-generated (Claude): Track serialized trips locally so failed saves do not mutate the log.
+	std::unordered_set<const dive_trip *> saved_trips;
 	git_storage_update_progress(translate("gettextFromC", "Start saving data"));
 	save_settings(repo, root);
 
 	save_divesites(repo, root);
 	save_filter_presets(repo, root);
-
-	for (auto &trip: divelog.trips)
-		trip->saved = false;
 
 	/* save the dives */
 	git_storage_update_progress(translate("gettextFromC", "Start saving dives"));
@@ -972,9 +979,9 @@ static int create_git_tree(git_repository *repo, struct dir *root, bool select_o
 
 		if (trip) {
 			/* Did we already save this trip? */
-			if (trip->saved)
+			if (saved_trips.count(trip))
 				continue;
-			trip->saved = 1;
+			saved_trips.insert(trip);
 
 			/* Pass that new subdirectory in for save-trip */
 			save_one_trip(repo, tree, trip, &tm, cached_ok);

--- a/tests/testgitstorage.cpp
+++ b/tests/testgitstorage.cpp
@@ -6,6 +6,7 @@
 #include "core/dive.h"
 #include "core/divelist.h"
 #include "core/divelog.h"
+#include "core/divesite.h"
 #include "core/errorhelper.h"
 #include "core/file.h"
 #include "core/subsurface-string.h"
@@ -391,6 +392,44 @@ void TestGitStorage::testGitSaveClassify()
 	QVERIFY(QDir(QString::fromStdString(deletedCache)).removeRecursively());
 	QVERIFY(classifyGitSave(deletedCacheTarget) == git_save_kind::normal);
 }
+
+// AI-generated (Claude): Empty sites referenced by dives must survive git
+// serialization, while genuinely unused empty sites remain omitted.
+void TestGitStorage::testGitStorageReferencedEmptyDiveSite()
+{
+	QTemporaryDir destinationDir;
+	QVERIFY(destinationDir.isValid());
+	std::string destination = destinationDir.path().toStdString();
+	std::string target = destination + "[main]";
+	git_repository *repo = nullptr;
+	QCOMPARE(git_repository_init(&repo, destination.c_str(), false), 0);
+	git_repository_free(repo);
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test10.xml", &divelog), 0);
+	QVERIFY(!divelog.dives.empty());
+
+	dive_site *referenced = divelog.dives.front()->dive_site;
+	QVERIFY(referenced);
+	referenced->name.clear();
+	referenced->description.clear();
+	referenced->notes.clear();
+	referenced->location = {};
+	referenced->taxonomy.clear();
+	uint32_t referencedUuid = referenced->uuid;
+	dive_site *unreferenced = divelog.sites.create(std::string());
+	uint32_t unreferencedUuid = unreferenced->uuid;
+	QCOMPARE(save_dives(target.c_str()), 0);
+
+	clear_dive_file_data();
+	QCOMPARE(parse_file(target.c_str(), &divelog), 0);
+	QVERIFY(!divelog.dives.empty());
+	QVERIFY(divelog.dives.front()->dive_site);
+	QCOMPARE(divelog.dives.front()->dive_site->uuid, referencedUuid);
+	bool foundUnreferenced = false;
+	for (const auto &site: divelog.sites)
+		foundUnreferenced |= site->uuid == unreferencedUuid;
+	QVERIFY(!foundUnreferenced);
+}
+
 void TestGitStorage::testGitStorageCloud()
 {
 	// test writing and reading back from cloud storage

--- a/tests/testgitstorage.h
+++ b/tests/testgitstorage.h
@@ -14,6 +14,7 @@ private slots:
 	void testGitStorageLocal_data();
 	void testGitStorageLocal();
 	void testGitSaveClassify();
+	void testGitStorageReferencedEmptyDiveSite();
 	void testGitStorageCloud();
 	void testGitStorageCloudOfflineSync();
 	void testGitStorageCloudMerge();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
When serialising to git storage, an empty dive site was skipped even if
a dive still referenced it by UUID, leaving a dangling divesiteid on
load. Keep any site referenced by a dive while still skipping truly
unreferenced empty sites.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
