### PR TITLE
mobile: harden dive planner date/time and gas input for soft keyboards

### DIFF
--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -6,6 +6,7 @@
 #include <QDateTime>
 #include <QRegularExpression>
 #include <QTime>
+#include <QDebug>
 #include <QVariantMap>
 
 static const QString group = QStringLiteral("Language");
@@ -135,7 +136,12 @@ QString qPrefLanguage::effectiveDateFormatShort()
 
 QString qPrefLanguage::effectiveTimeFormat()
 {
-	return time_format_override() && !time_format().isEmpty() ? time_format() : defaultTimeFormat(preferenceLocale());
+	const QString result = time_format_override() && !time_format().isEmpty() ? time_format() : defaultTimeFormat(preferenceLocale());
+	qDebug() << "effectiveTimeFormat: override=" << time_format_override()
+	         << "stored=" << time_format()
+	         << "QLocale().timeFormat()=" << QLocale().timeFormat()
+	         << "result=" << result;
+	return result;
 }
 
 QString qPrefLanguage::longDatePreview()
@@ -196,10 +202,16 @@ QVariantList qPrefLanguage::timeFormatPresets()
 void qPrefLanguage::applyFormats(const QString &longDateFormat, const QString &shortDateFormat,
 				 const QString &timeFormat, bool overrideDate, bool overrideTime)
 {
-	const QString effectiveLongDate = overrideDate && !longDateFormat.isEmpty() ? longDateFormat : defaultDateFormat(preferenceLocale());
-	const QString effectiveShortDate = overrideDate && !shortDateFormat.isEmpty() ? shortDateFormat : defaultShortDateFormat(preferenceLocale());
-	const QString effectiveTime = overrideTime && !timeFormat.isEmpty() ? timeFormat : defaultTimeFormat(preferenceLocale());
-	storeFormats(effectiveLongDate, effectiveShortDate, effectiveTime, overrideDate, overrideTime);
+	// AI-generated (Claude): Store the resolved format only when an override is
+	// active; store empty string otherwise. This ensures that when "system default"
+	// is selected, prefs.time_format / date_format_short remain empty, and
+	// effectiveTimeFormat() / effectiveDateFormatShort() fall back to the system
+	// locale at call time — correctly picking up the iOS 12/24-hour device toggle
+	// rather than a format string baked in at settings-apply time.
+	const QString storedLongDate = overrideDate && !longDateFormat.isEmpty() ? longDateFormat : QString();
+	const QString storedShortDate = overrideDate && !shortDateFormat.isEmpty() ? shortDateFormat : QString();
+	const QString storedTime = overrideTime && !timeFormat.isEmpty() ? timeFormat : QString();
+	storeFormats(storedLongDate, storedShortDate, storedTime, overrideDate, overrideTime);
 }
 
 void qPrefLanguage::storeFormats(const QString &longDateFormat, const QString &shortDateFormat,
@@ -291,9 +303,15 @@ QString qPrefLanguage::timeDisplayText(const QString &editText) const
 QString qPrefLanguage::dateTimeEditText(const QString &displayText) const
 {
 	const QLocale locale = preferenceLocale();
-	const QString displayFormat = effectiveDateFormatShort() + QLatin1Char(' ') + effectiveTimeFormat();
+	const QString timeFormat = effectiveTimeFormat();
+	const QString displayFormat = effectiveDateFormatShort() + QLatin1Char(' ') + timeFormat;
 	const QDateTime dateTime = locale.toDateTime(displayText, displayFormat);
-	const QString editFormat = keypadDateFormat(effectiveDateFormatShort()) + QLatin1Char(' ') + keypadTimeFormat(effectiveTimeFormat());
+	const QString editFormat = keypadDateFormat(effectiveDateFormatShort()) + QLatin1Char(' ') + keypadTimeFormat(timeFormat);
+	qDebug() << "dateTimeEditText: input=" << displayText
+	         << "displayFormat=" << displayFormat
+	         << "parsed=" << dateTime
+	         << "editFormat=" << editFormat
+	         << "result=" << (dateTime.isValid() ? locale.toString(dateTime, editFormat) : QString("PARSE FAILED"));
 	return dateTime.isValid() ? locale.toString(dateTime, editFormat) : QString();
 }
 
@@ -331,9 +349,13 @@ QString qPrefLanguage::preferenceLocaleName() const
 
 void qPrefLanguage::applyLocaleDefaults(const QLocale &locale)
 {
-	const QString longDate = date_format_override() && !date_format().isEmpty() ? date_format() : defaultDateFormat(locale);
-	const QString shortDate = date_format_override() && !date_format_short().isEmpty() ? date_format_short() : defaultShortDateFormat(locale);
-	const QString time = time_format_override() && !time_format().isEmpty() ? time_format() : defaultTimeFormat(locale);
+	// AI-generated (Claude): When no override is active, store empty string so
+	// the effective* helpers resolve dynamically from the system locale at call
+	// time, rather than baking in a format string that may not reflect the iOS
+	// 12/24-hour device toggle.
+	const QString longDate = date_format_override() && !date_format().isEmpty() ? date_format() : QString();
+	const QString shortDate = date_format_override() && !date_format_short().isEmpty() ? date_format_short() : QString();
+	const QString time = time_format_override() && !time_format().isEmpty() ? time_format() : QString();
 	storeFormats(longDate, shortDate, time, date_format_override(), time_format_override());
 }
 

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -110,7 +110,14 @@ QString qPrefLanguage::defaultShortDateFormat(const QLocale &locale)
 
 QString qPrefLanguage::defaultTimeFormat(const QLocale &locale)
 {
-	QString format = locale.timeFormat();
+	// AI-generated (Claude): On iOS the 12/24-hour preference is a system
+	// setting independent of the UI language. QLocale() (no arguments) reads
+	// it correctly; a locale constructed from a language tag (e.g. "en") uses
+	// Qt's built-in default for that language and may disagree with the iOS
+	// toggle. Use the system locale for the time format pattern and the
+	// preference locale only for non-time formatting.
+	Q_UNUSED(locale)
+	QString format = QLocale().timeFormat();
 	format.replace("(t)", "").replace(" t", "").replace("t", "").replace("hh", "h").replace("HH", "H").replace("'kl'.", "");
 	format.replace(".ss", "").replace(":ss", "").replace("ss", "");
 	return format;

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -6,7 +6,6 @@
 #include <QDateTime>
 #include <QRegularExpression>
 #include <QTime>
-#include <QDebug>
 #include <QVariantMap>
 
 static const QString group = QStringLiteral("Language");
@@ -142,12 +141,7 @@ QString qPrefLanguage::effectiveDateFormatShort()
 
 QString qPrefLanguage::effectiveTimeFormat()
 {
-	const QString result = time_format_override() && !time_format().isEmpty() ? time_format() : defaultTimeFormat(preferenceLocale());
-	qDebug() << "effectiveTimeFormat: override=" << time_format_override()
-	         << "stored=" << time_format()
-	         << "QLocale().timeFormat()=" << QLocale().timeFormat()
-	         << "result=" << result;
-	return result;
+	return time_format_override() && !time_format().isEmpty() ? time_format() : defaultTimeFormat(preferenceLocale());
 }
 
 QString qPrefLanguage::longDatePreview()
@@ -309,15 +303,9 @@ QString qPrefLanguage::timeDisplayText(const QString &editText) const
 QString qPrefLanguage::dateTimeEditText(const QString &displayText) const
 {
 	const QLocale locale = preferenceLocale();
-	const QString timeFormat = effectiveTimeFormat();
-	const QString displayFormat = effectiveDateFormatShort() + QLatin1Char(' ') + timeFormat;
+	const QString displayFormat = effectiveDateFormatShort() + QLatin1Char(' ') + effectiveTimeFormat();
 	const QDateTime dateTime = locale.toDateTime(displayText, displayFormat);
-	const QString editFormat = keypadDateFormat(effectiveDateFormatShort()) + QLatin1Char(' ') + keypadTimeFormat(timeFormat);
-	qDebug() << "dateTimeEditText: input=" << displayText
-	         << "displayFormat=" << displayFormat
-	         << "parsed=" << dateTime
-	         << "editFormat=" << editFormat
-	         << "result=" << (dateTime.isValid() ? locale.toString(dateTime, editFormat) : QString("PARSE FAILED"));
+	const QString editFormat = keypadDateFormat(effectiveDateFormatShort()) + QLatin1Char(' ') + keypadTimeFormat(effectiveTimeFormat());
 	return dateTime.isValid() ? locale.toString(dateTime, editFormat) : QString();
 }
 

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -115,12 +115,18 @@ QString qPrefLanguage::defaultTimeFormat(const QLocale &locale)
 	// setting independent of the UI language. QLocale() (no arguments) reads
 	// it correctly; a locale constructed from a language tag (e.g. "en") uses
 	// Qt's built-in default for that language and may disagree with the iOS
-	// toggle. Use the system locale for the time format pattern and the
-	// preference locale only for non-time formatting.
+	// toggle. Use the system locale for the time format pattern.
+	//
+	// Qt on iOS returns "h:mm Ap" — mixed-case AM/PM token. Qt's C++ date/time
+	// formatting only recognises "AP" (uppercase) or "ap" (lowercase); "Ap" is
+	// treated as literals, causing toString() to produce 24-hour output and
+	// toDateTime() to fail to parse. Normalise any "Ap" or "aP" to "AP".
 	Q_UNUSED(locale)
 	QString format = QLocale().timeFormat();
 	format.replace("(t)", "").replace(" t", "").replace("t", "").replace("hh", "h").replace("HH", "H").replace("'kl'.", "");
 	format.replace(".ss", "").replace(":ss", "").replace("ss", "");
+	// Normalise mixed-case AM/PM token to uppercase "AP"
+	format.replace("Ap", "AP").replace("aP", "AP");
 	return format;
 }
 

--- a/core/settings/qPrefLanguage.cpp
+++ b/core/settings/qPrefLanguage.cpp
@@ -3,6 +3,8 @@
 #include "qPrefPrivate.h"
 
 #include <QDate>
+#include <QDateTime>
+#include <QRegularExpression>
 #include <QTime>
 #include <QVariantMap>
 
@@ -10,6 +12,46 @@ static const QString group = QStringLiteral("Language");
 
 static const QDate previewDate(2000, 12, 31);
 static const QTime previewTime(13, 45);
+
+// AI-generated (Claude): Replace display punctuation with separators available
+// on Android's specialised date and time keyboards, without reordering fields.
+static QString keypadDateFormat(const QString &format)
+{
+	QRegularExpression component(QStringLiteral("d+|M+|y+"));
+	QRegularExpressionMatchIterator matches = component.globalMatch(format);
+	QStringList result;
+	while (matches.hasNext()) {
+		QString value = matches.next().captured();
+		if (value.startsWith(QLatin1Char('d')) && value.size() > 2)
+			value = QStringLiteral("d");
+		else if (value.startsWith(QLatin1Char('M')) && value.size() > 2)
+			value = QStringLiteral("M");
+		result.append(value);
+	}
+	return result.join(QLatin1Char('/'));
+}
+
+static QString keypadTimeFormat(const QString &format)
+{
+	QRegularExpression component(QStringLiteral("AP|ap|h+|H+|m+|s+"));
+	QRegularExpressionMatchIterator matches = component.globalMatch(format);
+	QStringList timeComponents;
+	QString designator;
+	bool designatorFirst = false;
+	while (matches.hasNext()) {
+		const QString value = matches.next().captured();
+		if (value == QLatin1String("AP") || value == QLatin1String("ap")) {
+			designator = value;
+			designatorFirst = timeComponents.isEmpty();
+		} else {
+			timeComponents.append(value);
+		}
+	}
+	QString result = timeComponents.join(QLatin1Char(':'));
+	if (!designator.isEmpty())
+		result = designatorFirst ? designator + QLatin1Char(' ') + result : result + QLatin1Char(' ') + designator;
+	return result;
+}
 
 qPrefLanguage *qPrefLanguage::instance()
 {
@@ -223,6 +265,61 @@ void qPrefLanguage::applyTimePreset(const QString &preset)
 void qPrefLanguage::restoreDateTimeDefaults()
 {
 	applyFormats(QString(), QString(), QString(), false, false);
+}
+
+QString qPrefLanguage::timeEditText(const QString &displayText) const
+{
+	const QLocale locale = preferenceLocale();
+	const QTime time = locale.toTime(displayText, effectiveTimeFormat());
+	return time.isValid() ? locale.toString(time, keypadTimeFormat(effectiveTimeFormat())) : QString();
+}
+
+QString qPrefLanguage::timeDisplayText(const QString &editText) const
+{
+	const QLocale locale = preferenceLocale();
+	const QTime time = locale.toTime(editText, keypadTimeFormat(effectiveTimeFormat()));
+	return time.isValid() ? locale.toString(time, effectiveTimeFormat()) : QString();
+}
+
+QString qPrefLanguage::dateTimeEditText(const QString &displayText) const
+{
+	const QLocale locale = preferenceLocale();
+	const QString displayFormat = effectiveDateFormatShort() + QLatin1Char(' ') + effectiveTimeFormat();
+	const QDateTime dateTime = locale.toDateTime(displayText, displayFormat);
+	const QString editFormat = keypadDateFormat(effectiveDateFormatShort()) + QLatin1Char(' ') + keypadTimeFormat(effectiveTimeFormat());
+	return dateTime.isValid() ? locale.toString(dateTime, editFormat) : QString();
+}
+
+QString qPrefLanguage::dateTimeDisplayText(const QString &editText) const
+{
+	const QLocale locale = preferenceLocale();
+	const QString editFormat = keypadDateFormat(effectiveDateFormatShort()) + QLatin1Char(' ') + keypadTimeFormat(effectiveTimeFormat());
+	const QDateTime dateTime = locale.toDateTime(editText, editFormat);
+	const QString displayFormat = effectiveDateFormatShort() + QLatin1Char(' ') + effectiveTimeFormat();
+	return dateTime.isValid() ? locale.toString(dateTime, displayFormat) : QString();
+}
+
+QString qPrefLanguage::toggleMeridiem(const QString &editText, bool dateTime) const
+{
+	const QLocale locale = preferenceLocale();
+	const QString timeFormat = keypadTimeFormat(effectiveTimeFormat());
+	if (!timeFormat.contains(QLatin1String("AP")) && !timeFormat.contains(QLatin1String("ap")))
+		return editText;
+	if (dateTime) {
+		const QString format = keypadDateFormat(effectiveDateFormatShort()) + QLatin1Char(' ') + timeFormat;
+		QDateTime value = locale.toDateTime(editText, format);
+		if (!value.isValid())
+			return editText;
+		value.setTime(value.time().addSecs(12 * 60 * 60));
+		return locale.toString(value, format);
+	}
+	QTime value = locale.toTime(editText, timeFormat);
+	return value.isValid() ? locale.toString(value.addSecs(12 * 60 * 60), timeFormat) : editText;
+}
+
+QString qPrefLanguage::preferenceLocaleName() const
+{
+	return preferenceLocale().name();
 }
 
 void qPrefLanguage::applyLocaleDefaults(const QLocale &locale)

--- a/core/settings/qPrefLanguage.h
+++ b/core/settings/qPrefLanguage.h
@@ -59,6 +59,14 @@ public:
 	Q_INVOKABLE void applyDatePreset(const QString &preset);
 	Q_INVOKABLE void applyTimePreset(const QString &preset);
 	Q_INVOKABLE void restoreDateTimeDefaults();
+	// AI-generated (Claude): Canonical keypad formats keep mobile date/time fields editable.
+	Q_INVOKABLE QString timeEditText(const QString &displayText) const;
+	Q_INVOKABLE QString timeDisplayText(const QString &editText) const;
+	Q_INVOKABLE QString dateTimeEditText(const QString &displayText) const;
+	Q_INVOKABLE QString dateTimeDisplayText(const QString &editText) const;
+	Q_INVOKABLE QString toggleMeridiem(const QString &editText, bool dateTime) const;
+	// AI-generated (Claude): Expose the preference locale so QML parses edits with the same locale used for display.
+	Q_INVOKABLE QString preferenceLocaleName() const;
 
 	// Apply selected-locale defaults during UI locale initialization.
 	static void applyLocaleDefaults(const QLocale &locale);

--- a/core/string-format.cpp
+++ b/core/string-format.cpp
@@ -246,13 +246,16 @@ QString formatDiveGPS(const dive *d)
 QString formatDiveDate(const dive *d)
 {
 	QDateTime localTime = timestampToDateTime(d->when);
-	return localTime.date().toString(QString::fromStdString(prefs.date_format_short));
+	// AI-generated (Claude): use effective format so system-default (empty stored
+	// pref) resolves to the locale default rather than Qt's internal ISO format.
+	return QLocale().toString(localTime.date(), qPrefLanguage::effectiveDateFormatShort());
 }
 
 QString formatDiveTime(const dive *d)
 {
 	QDateTime localTime = timestampToDateTime(d->when);
-	return localTime.time().toString(QString::fromStdString(prefs.time_format));
+	// AI-generated (Claude): same rationale as formatDiveDate.
+	return QLocale().toString(localTime.time(), qPrefLanguage::effectiveTimeFormat());
 }
 
 QString formatDiveDateTime(const dive *d)

--- a/core/string-format.cpp
+++ b/core/string-format.cpp
@@ -1,5 +1,6 @@
 #include "string-format.h"
 #include "dive.h"
+#include "settings/qPrefLanguage.h"
 #include "divecomputer.h"
 #include "divelist.h"
 #include "divelog.h"
@@ -257,8 +258,17 @@ QString formatDiveTime(const dive *d)
 QString formatDiveDateTime(const dive *d)
 {
 	QDateTime localTime = timestampToDateTime(d->when);
-	return QStringLiteral("%1 %2").arg(localTime.date().toString(QString::fromStdString(prefs.date_format_short)),
-					   localTime.time().toString(QString::fromStdString(prefs.time_format)));
+	// AI-generated (Claude): Use effectiveTimeFormat/effectiveDateFormatShort
+	// rather than raw prefs values. prefs.time_format is empty when "system
+	// default" is selected with no override, so toString("") fell back to Qt's
+	// internal ISO 8601 24-hour format. The effective helpers resolve to the
+	// system-locale format, which correctly reflects the iOS 12/24-hour toggle.
+	// Use QLocale() for toString() so AM/PM strings match what the edit
+	// parsing functions produce.
+	const QLocale locale;
+	return QStringLiteral("%1 %2").arg(
+		locale.toString(localTime.date(), qPrefLanguage::effectiveDateFormatShort()),
+		locale.toString(localTime.time(), qPrefLanguage::effectiveTimeFormat()));
 }
 
 QString formatDiveGasString(const dive *d)

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -48,6 +48,13 @@ Item {
 	property int visibility
 	property var usedCyl: []
 
+	// AI-generated (Claude): iOS does not map the date and time hints to a
+	// specialised keyboard. Keep Android's specialised hints while requesting
+	// iOS's number-and-punctuation keyboard for fields with separators.
+	function punctuationInputMethodHints(platformName, androidHints) {
+		return platformName === "ios" ? Qt.ImhPreferNumbers : androidHints
+	}
+
 	// AI-generated (Claude)
 	function gasEditText(gasMix) {
 		if (gasMix === undefined || gasMix === null)
@@ -246,7 +253,7 @@ Item {
 					property string displayText: ""
 					property string initialEditText: ""
 					Layout.preferredWidth: effectiveGridUnit * 10
-					inputMethodHints: Qt.ImhDate | Qt.ImhTime
+					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhDate | Qt.ImhTime)
 					flickable: detailsEditFlickable
 					onActiveFocusChanged: {
 						if (activeFocus) {
@@ -305,7 +312,7 @@ Item {
 					Layout.preferredWidth: effectiveGridUnit * 3
 					sampleText: "200.0ft"
 					id: txtDepth
-					inputMethodHints: Qt.ImhFormattedNumbersOnly
+					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhFormattedNumbersOnly)
 					validator: RegularExpressionValidator { regularExpression: /[^-]*/ }
 					flickable: detailsEditFlickable
 					onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
@@ -325,7 +332,7 @@ Item {
 					Layout.preferredWidth: effectiveGridUnit * 3
 					sampleText: "0:00min"
 					id: txtDuration
-					inputMethodHints: Qt.ImhTime
+					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhTime)
 					validator: RegularExpressionValidator { regularExpression: /[^-]*/ }
 					flickable: detailsEditFlickable
 					onActiveFocusChanged: activeFocus ? beginNumericEdit(this, true) : finishDurationEdit(this)
@@ -344,7 +351,7 @@ Item {
 					property string initialEditText: ""
 					sampleText: "-10.0\u00B0F"
 					Layout.preferredWidth: effectiveGridUnit * 3
-					inputMethodHints: Qt.ImhFormattedNumbersOnly
+					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhFormattedNumbersOnly)
 					flickable: detailsEditFlickable
 					onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
 						Backend.temperature === Enums.CELSIUS ? "°" + qsTr("C") : "°" + qsTr("F"))
@@ -363,7 +370,7 @@ Item {
 					Layout.preferredWidth: effectiveGridUnit * 3
 					sampleText: "-10.0\u00B0F"
 					id: txtWaterTemp
-					inputMethodHints: Qt.ImhFormattedNumbersOnly
+					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhFormattedNumbersOnly)
 					flickable: detailsEditFlickable
 					onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
 						Backend.temperature === Enums.CELSIUS ? "°" + qsTr("C") : "°" + qsTr("F"))
@@ -475,7 +482,7 @@ Item {
 					property string initialEditText: ""
 					Layout.preferredWidth: effectiveGridUnit * 12
 					readOnly: text === "cannot edit multiple weight systems"
-					inputMethodHints: Qt.ImhFormattedNumbersOnly
+					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhFormattedNumbersOnly)
 					flickable: detailsEditFlickable
 					// AI-generated (Claude): A read-only field must not enter numeric-edit mode, which would overwrite the sentinel message.
 					onActiveFocusChanged: {
@@ -523,9 +530,9 @@ Item {
 						property string displayText: ""
 						property string initialEditText: ""
 						text: usedGas[0] !== undefined ? usedGas[0] : null
-						sampleText: "20/24"
+						sampleText: "18/45"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhDate
+						inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhDate)
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
 						onActiveFocusChanged: {
@@ -616,9 +623,9 @@ Item {
 						property string displayText: ""
 						property string initialEditText: ""
 						text: usedGas[1] !== undefined ? usedGas[1] : null
-						sampleText: "20/24"
+						sampleText: "18/45"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhDate
+						inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhDate)
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
 						onActiveFocusChanged: {
@@ -710,9 +717,9 @@ Item {
 						property string displayText: ""
 						property string initialEditText: ""
 						text: usedGas[2] !== undefined ? usedGas[2] : null
-						sampleText: "20/24"
+						sampleText: "18/45"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhDate
+						inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhDate)
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
 						onActiveFocusChanged: {
@@ -805,9 +812,9 @@ Item {
 						property string displayText: ""
 						property string initialEditText: ""
 						text: usedGas[3] !== undefined ? usedGas[3] : null
-						sampleText: "20/24"
+						sampleText: "18/45"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhDate
+						inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhDate)
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
 						onActiveFocusChanged: {
@@ -903,9 +910,9 @@ Item {
 						property string displayText: ""
 						property string initialEditText: ""
 						text: usedGas[4] !== undefined ? usedGas[4] : null
-						sampleText: "20/24"
+						sampleText: "18/45"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhDate
+						inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhDate)
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
 						onActiveFocusChanged: {

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -55,6 +55,14 @@ Item {
 		return platformName === "ios" ? Qt.ImhPreferNumbers : androidHints
 	}
 
+	// AI-generated (Claude): temporary debug label - remove before merge
+	TemplateLabel {
+		text: "FMT:[" + PrefLanguage.effectiveTimeFormat + "]\nSYS:[" + Qt.locale().timeFormat(Locale.ShortFormat) + "]"
+		color: "red"
+		wrapMode: Text.Wrap
+		z: 100
+	}
+
 	// AI-generated (Claude)
 	function gasEditText(gasMix) {
 		if (gasMix === undefined || gasMix === null)

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -48,6 +48,91 @@ Item {
 	property int visibility
 	property var usedCyl: []
 
+	// AI-generated (Claude)
+	function gasEditText(gasMix) {
+		if (gasMix === undefined || gasMix === null)
+			return "";
+		var value = gasMix.toString();
+		if (/^AIR$/i.test(value))
+			return "21";
+		var enrichedAir = /^EAN(\d{1,3})$/i.exec(value);
+		return enrichedAir ? enrichedAir[1] : value;
+	}
+
+	function gasDisplayText(text, originalDisplay, originalEdit) {
+		if (text === originalEdit)
+			return originalDisplay;
+		if (text.indexOf("/") !== -1 || text === "")
+			return text;
+		if (/^AIR$/i.test(text))
+			return "AIR";
+		var enrichedAir = /^EAN(\d{1,3})$/i.exec(text);
+		if (enrichedAir)
+			return "EAN" + Number(enrichedAir[1]);
+		var percent = Number(text);
+		// Guard against non-numeric input; never emit an "EANNaN" string.
+		if (isNaN(percent))
+			return text;
+		return percent === 21 ? "AIR" : "EAN" + percent;
+	}
+
+	function numericEditText(text) {
+		if (!text)
+			return "";
+		var match = text.match(/[-+]?\d[\d.,]*/);
+		return match ? match[0] : "";
+	}
+
+	function restoreUnitText(text, originalDisplay, originalEdit, fallbackUnit) {
+		if (text === originalEdit)
+			return originalDisplay;
+		if (text === "")
+			return "";
+		var suffix = originalDisplay.replace(/[-+]?\d[\d.,]*/, "").trim();
+		return text + (suffix !== "" ? suffix : fallbackUnit);
+	}
+
+	function durationEditText(text) {
+		var values = text.match(/\d+/g);
+		if (!values)
+			return "0:00";
+		var minutes = values.length > 1 ? Number(values[0]) * 60 + Number(values[1]) : Number(values[0]);
+		var remainder = minutes % 60;
+		return Math.floor(minutes / 60) + ":" + (remainder < 10 ? "0" : "") + remainder;
+	}
+
+	function durationDisplayText(text) {
+		var match = /^(\d+):([0-5]\d)$/.exec(text);
+		if (!match)
+			return "";
+		var minutes = Number(match[1]) * 60 + Number(match[2]);
+		if (Backend.duration_units === Enums.ALWAYS_HOURS ||
+		    (Backend.duration_units === Enums.MIXED && minutes >= 60)) {
+			var remainder = minutes % 60;
+			return Math.floor(minutes / 60) + ":" + (remainder < 10 ? "0" : "") + remainder + qsTr("h");
+		}
+		return minutes + qsTr("min");
+	}
+
+	function beginNumericEdit(field, duration) {
+		field.displayText = field.text;
+		field.initialEditText = duration ? durationEditText(field.text) : numericEditText(field.text);
+		field.text = field.initialEditText;
+	}
+
+	function finishNumericEdit(field, fallbackUnit) {
+		field.text = restoreUnitText(field.text, field.displayText, field.initialEditText, fallbackUnit);
+	}
+
+	function finishDurationEdit(field) {
+		if (field.text === field.initialEditText) {
+			field.text = field.displayText;
+			return;
+		}
+		var display = durationDisplayText(field.text);
+		field.text = display !== "" ? display : field.displayText;
+	}
+
 	function focusReset() {
 		// set the focus explicitlt (to steal from any other field), then unset
 		editArea.focus = true
@@ -155,11 +240,36 @@ Item {
 					horizontalAlignment: Text.AlignRight
 					text: qsTr("Date/Time:")
 				}
+				// AI-generated (Claude): Edit with keypad separators and validate before restoring display format.
 				SsrfTextField {
 					id: txtDate;
+					property string displayText: ""
+					property string initialEditText: ""
 					Layout.preferredWidth: effectiveGridUnit * 10
-					inputMethodHints: Qt.ImhPreferNumbers
+					inputMethodHints: Qt.ImhDate | Qt.ImhTime
 					flickable: detailsEditFlickable
+					onActiveFocusChanged: {
+						if (activeFocus) {
+							displayText = text;
+							var editText = PrefLanguage.dateTimeEditText(text);
+							initialEditText = editText !== "" ? editText : text;
+							text = initialEditText;
+						} else if (text === initialEditText) {
+							text = displayText;
+						} else {
+							var display = PrefLanguage.dateTimeDisplayText(text);
+							text = display !== "" ? display : displayText;
+						}
+					}
+				}
+				TemplateButton {
+					text: qsTr("A/P")
+					visible: txtDate.activeFocus && /AP|ap/.test(PrefLanguage.time_format)
+					fontSize: subsurfaceTheme.smallPointSize
+					padding: 0
+					Layout.alignment: Qt.AlignVCenter
+					focusPolicy: Qt.NoFocus
+					onClicked: txtDate.text = PrefLanguage.toggleMeridiem(txtDate.text, true)
 				}
 			}
 			RowLayout {
@@ -190,12 +300,16 @@ Item {
 					text: qsTr("Depth:")
 				}
 				SsrfTextField {
+					property string displayText: ""
+					property string initialEditText: ""
 					Layout.preferredWidth: effectiveGridUnit * 3
 					sampleText: "200.0ft"
 					id: txtDepth
-					inputMethodHints: Qt.ImhPreferNumbers
+					inputMethodHints: Qt.ImhFormattedNumbersOnly
 					validator: RegularExpressionValidator { regularExpression: /[^-]*/ }
 					flickable: detailsEditFlickable
+					onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+						Backend.length === Enums.METERS ? qsTr("m") : qsTr("ft"))
 				}
 			}
 			RowLayout {
@@ -204,13 +318,17 @@ Item {
 					horizontalAlignment: Text.AlignRight
 					text: qsTr("Duration:")
 				}
+				// AI-generated (Claude): Duration editing always uses the time keypad's h:mm form.
 				SsrfTextField {
+					property string displayText: ""
+					property string initialEditText: ""
 					Layout.preferredWidth: effectiveGridUnit * 3
-					sampleText: "00:00min"
+					sampleText: "0:00min"
 					id: txtDuration
-					inputMethodHints: Qt.ImhPreferNumbers
+					inputMethodHints: Qt.ImhTime
 					validator: RegularExpressionValidator { regularExpression: /[^-]*/ }
 					flickable: detailsEditFlickable
+					onActiveFocusChanged: activeFocus ? beginNumericEdit(this, true) : finishDurationEdit(this)
 				}
 
 			}
@@ -222,10 +340,14 @@ Item {
 				}
 				SsrfTextField {
 					id: txtAirTemp
+					property string displayText: ""
+					property string initialEditText: ""
 					sampleText: "-10.0\u00B0F"
 					Layout.preferredWidth: effectiveGridUnit * 3
-					inputMethodHints: Qt.ImhPreferNumbers
+					inputMethodHints: Qt.ImhFormattedNumbersOnly
 					flickable: detailsEditFlickable
+					onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+						Backend.temperature === Enums.CELSIUS ? "°" + qsTr("C") : "°" + qsTr("F"))
 				}
 
 			}
@@ -236,11 +358,15 @@ Item {
 					text: qsTr("Water Temp:")
 				}
 				SsrfTextField {
+					property string displayText: ""
+					property string initialEditText: ""
 					Layout.preferredWidth: effectiveGridUnit * 3
 					sampleText: "-10.0\u00B0F"
 					id: txtWaterTemp
-					inputMethodHints: Qt.ImhPreferNumbers
+					inputMethodHints: Qt.ImhFormattedNumbersOnly
 					flickable: detailsEditFlickable
+					onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+						Backend.temperature === Enums.CELSIUS ? "°" + qsTr("C") : "°" + qsTr("F"))
 				}
 			}
 			RowLayout {
@@ -277,7 +403,6 @@ Item {
 				SsrfTextField {
 					Layout.preferredWidth: effectiveGridUnit * 16
 					id: txtGps
-					inputMethodHints: Qt.ImhPreferNumbers
 					flickable: detailsEditFlickable
 				}
 			}
@@ -346,10 +471,21 @@ Item {
 				}
 				SsrfTextField {
 					id: txtWeight
+					property string displayText: ""
+					property string initialEditText: ""
 					Layout.preferredWidth: effectiveGridUnit * 12
 					readOnly: text === "cannot edit multiple weight systems"
-					inputMethodHints: Qt.ImhPreferNumbers
+					inputMethodHints: Qt.ImhFormattedNumbersOnly
 					flickable: detailsEditFlickable
+					// AI-generated (Claude): A read-only field must not enter numeric-edit mode, which would overwrite the sentinel message.
+					onActiveFocusChanged: {
+						if (readOnly)
+							return;
+						if (activeFocus)
+							beginNumericEdit(this, false);
+						else
+							finishNumericEdit(this, Backend.weight === Enums.KG ? qsTr("kg") : qsTr("lbs"));
+					}
 				}
 			}
 
@@ -384,12 +520,23 @@ Item {
 					}
 					SsrfTextField {
 						id: txtGasMix0
+						property string displayText: ""
+						property string initialEditText: ""
 						text: usedGas[0] !== undefined ? usedGas[0] : null
-						sampleText: "EAN100"
+						sampleText: "20/24"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDate
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: {
+							if (activeFocus) {
+								displayText = text;
+								initialEditText = gasEditText(text);
+								text = initialEditText;
+							} else {
+								text = gasDisplayText(text, displayText, initialEditText);
+							}
+						}
 					}
 				}
 				RowLayout {
@@ -402,11 +549,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtStartPressure0
+						property string displayText: ""
+						property string initialEditText: ""
 						text: startpressure[0] !== undefined ? startpressure[0] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 				}
 				RowLayout {
@@ -419,11 +570,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtEndPressure0
+						property string displayText: ""
+						property string initialEditText: ""
 						text: endpressure[0] !== undefined ? endpressure[0] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 				}
 			}
@@ -458,12 +613,23 @@ Item {
 					}
 					SsrfTextField {
 						id: txtGasMix1
+						property string displayText: ""
+						property string initialEditText: ""
 						text: usedGas[1] !== undefined ? usedGas[1] : null
-						sampleText: "EAN100"
+						sampleText: "20/24"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDate
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: {
+							if (activeFocus) {
+								displayText = text;
+								initialEditText = gasEditText(text);
+								text = initialEditText;
+							} else {
+								text = gasDisplayText(text, displayText, initialEditText);
+							}
+						}
 					}
 				}
 				RowLayout {
@@ -476,11 +642,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtStartPressure1
+						property string displayText: ""
+						property string initialEditText: ""
 						text: startpressure[1] !== undefined ? startpressure[1] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 				}
 				RowLayout {
@@ -493,11 +663,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtEndPressure1
+						property string displayText: ""
+						property string initialEditText: ""
 						text: endpressure[1] !== undefined ? endpressure[1] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 				}
 			}
@@ -533,12 +707,23 @@ Item {
 					}
 					SsrfTextField {
 						id: txtGasMix2
+						property string displayText: ""
+						property string initialEditText: ""
 						text: usedGas[2] !== undefined ? usedGas[2] : null
-						sampleText: "EAN100"
+						sampleText: "20/24"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDate
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: {
+							if (activeFocus) {
+								displayText = text;
+								initialEditText = gasEditText(text);
+								text = initialEditText;
+							} else {
+								text = gasDisplayText(text, displayText, initialEditText);
+							}
+						}
 					}
 				}
 				RowLayout {
@@ -551,11 +736,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtStartPressure2
+						property string displayText: ""
+						property string initialEditText: ""
 						text: startpressure[2] !== undefined ? startpressure[2] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 				}
 				RowLayout {
@@ -568,11 +757,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtEndPressure2
+						property string displayText: ""
+						property string initialEditText: ""
 						text: endpressure[2] !== undefined ? endpressure[2] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 				}
 			}
@@ -609,12 +802,23 @@ Item {
 					}
 					SsrfTextField {
 						id: txtGasMix3
+						property string displayText: ""
+						property string initialEditText: ""
 						text: usedGas[3] !== undefined ? usedGas[3] : null
-						sampleText: "EAN100"
+						sampleText: "20/24"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDate
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: {
+							if (activeFocus) {
+								displayText = text;
+								initialEditText = gasEditText(text);
+								text = initialEditText;
+							} else {
+								text = gasDisplayText(text, displayText, initialEditText);
+							}
+						}
 					}
 
 				}
@@ -628,11 +832,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtStartPressure3
+						property string displayText: ""
+						property string initialEditText: ""
 						text: startpressure[3] !== undefined ? startpressure[3] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 
 				}
@@ -646,11 +854,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtEndPressure3
+						property string displayText: ""
+						property string initialEditText: ""
 						text: endpressure[3] !== undefined ? endpressure[3] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 				}
 			}
@@ -688,12 +900,23 @@ Item {
 					}
 					SsrfTextField {
 						id: txtGasMix4
+						property string displayText: ""
+						property string initialEditText: ""
 						text: usedGas[4] !== undefined ? usedGas[4] : null
-						sampleText: "EAN100"
+						sampleText: "20/24"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDate
 						validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{1,2}|\d{1,2}\/\d{1,2})/i }
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: {
+							if (activeFocus) {
+								displayText = text;
+								initialEditText = gasEditText(text);
+								text = initialEditText;
+							} else {
+								text = gasDisplayText(text, displayText, initialEditText);
+							}
+						}
 					}
 
 				}
@@ -707,11 +930,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtStartPressure4
+						property string displayText: ""
+						property string initialEditText: ""
 						text: startpressure[4] !== undefined ? startpressure[4] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 
 				}
@@ -725,11 +952,15 @@ Item {
 					}
 					SsrfTextField {
 						id: txtEndPressure4
+						property string displayText: ""
+						property string initialEditText: ""
 						text: endpressure[4] !== undefined ? endpressure[4] : null
 						sampleText: "3000psi"
 						Layout.fillWidth: true
-						inputMethodHints: Qt.ImhPreferNumbers
+						inputMethodHints: Qt.ImhDigitsOnly
 						flickable: detailsEditFlickable
+						onActiveFocusChanged: activeFocus ? beginNumericEdit(this, false) : finishNumericEdit(this,
+							Backend.pressure === Enums.BAR ? qsTr("bar") : qsTr("psi"))
 					}
 				}
 			}

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -271,7 +271,7 @@ Item {
 				}
 				TemplateButton {
 					text: qsTr("A/P")
-					visible: txtDate.activeFocus && /AP|ap/.test(PrefLanguage.time_format)
+					visible: txtDate.activeFocus && /AP|ap/.test(PrefLanguage.effectiveTimeFormat)
 					fontSize: subsurfaceTheme.smallPointSize
 					padding: 0
 					Layout.alignment: Qt.AlignVCenter

--- a/mobile-widgets/qml/DiveDetailsEdit.qml
+++ b/mobile-widgets/qml/DiveDetailsEdit.qml
@@ -55,13 +55,6 @@ Item {
 		return platformName === "ios" ? Qt.ImhPreferNumbers : androidHints
 	}
 
-	// AI-generated (Claude): temporary debug label - remove before merge
-	TemplateLabel {
-		text: "FMT:[" + PrefLanguage.effectiveTimeFormat + "]\nSYS:[" + Qt.locale().timeFormat(Locale.ShortFormat) + "]"
-		color: "red"
-		wrapMode: Text.Wrap
-		z: 100
-	}
 
 	// AI-generated (Claude)
 	function gasEditText(gasMix) {

--- a/mobile-widgets/qml/DivePlannerEdit.qml
+++ b/mobile-widgets/qml/DivePlannerEdit.qml
@@ -60,7 +60,7 @@ TemplatePage {
 		if (!planDate.activeFocus)
 			planDate.text = Qt.formatDate(planDateTime, PrefLanguage.date_format_short);
 		if (!planTime.activeFocus)
-			planTime.text = Qt.formatTime(planDateTime, PrefLanguage.time_format);
+			planTime.text = Qt.formatTime(planDateTime, PrefLanguage.effectiveTimeFormat);
 	}
 
 	function applyDateInput(text, format) {
@@ -322,10 +322,10 @@ TemplatePage {
 					Layout.fillWidth: true
 					sampleText: "00:00 PM"
 					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhTime)
-					text: Qt.formatTime(planDateTime, PrefLanguage.time_format)
+					text: Qt.formatTime(planDateTime, PrefLanguage.effectiveTimeFormat)
 					onActiveFocusChanged: {
 						if (activeFocus) {
-							editFormat = PrefLanguage.time_format;
+							editFormat = PrefLanguage.effectiveTimeFormat;
 							var editText = PrefLanguage.timeEditText(text);
 							initialEditText = editText !== "" ? editText : text;
 							text = initialEditText;
@@ -338,7 +338,7 @@ TemplatePage {
 				}
 				TemplateButton {
 					text: qsTr("A/P")
-					visible: planTime.activeFocus && /AP|ap/.test(PrefLanguage.time_format)
+					visible: planTime.activeFocus && /AP|ap/.test(PrefLanguage.effectiveTimeFormat)
 					fontSize: subsurfaceTheme.smallPointSize
 					padding: 0
 					Layout.alignment: Qt.AlignVCenter

--- a/mobile-widgets/qml/DivePlannerEdit.qml
+++ b/mobile-widgets/qml/DivePlannerEdit.qml
@@ -15,6 +15,7 @@ TemplatePage {
 
 	property string planNotes: ""
 	property var profileData: []
+	property date planDateTime: new Date()
 	// AI-generated (Claude)
 	property bool exceedsNDL: false
 
@@ -32,6 +33,84 @@ TemplatePage {
 			newList.push(qsTr("Gas %1").arg(i + 1));
 		}
 		gasNumberModel = newList;
+	}
+
+	// AI-generated (Claude)
+	function dateInputFormat(format) {
+		var components = format.match(/d+|M+|y+/g);
+		if (!components)
+			return format;
+		for (var i = 0; i < components.length; ++i) {
+			if (components[i].indexOf("d") === 0 && components[i].length > 2)
+				components[i] = "d";
+			if (components[i].indexOf("M") === 0 && components[i].length > 2)
+				components[i] = "M";
+		}
+		return components.join("/");
+	}
+
+	function updateDateTimeDisplay() {
+		if (!planDate.activeFocus)
+			planDate.text = Qt.formatDate(planDateTime, PrefLanguage.date_format_short);
+		if (!planTime.activeFocus)
+			planTime.text = Qt.formatTime(planDateTime, PrefLanguage.time_format);
+	}
+
+	function applyDateInput(text, format) {
+		var loc = Qt.locale(PrefLanguage.preferenceLocaleName());
+		var parsed = Date.fromLocaleDateString(loc, text, dateInputFormat(format));
+		if (isNaN(parsed.getTime()))
+			return false;
+		var yearToken = format.match(/y+/);
+		if (yearToken && yearToken[0].length <= 2) {
+			var century = Math.floor(planDateTime.getFullYear() / 100) * 100;
+			parsed.setFullYear(century + parsed.getFullYear() % 100);
+		}
+		var updated = new Date(planDateTime.getTime());
+		updated.setFullYear(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
+		if (updated.getFullYear() !== parsed.getFullYear() || updated.getMonth() !== parsed.getMonth() ||
+		    updated.getDate() !== parsed.getDate())
+			return false;
+		planDateTime = updated;
+		return true;
+	}
+
+	function applyTimeInput(text, format) {
+		var displayText = PrefLanguage.timeDisplayText(text);
+		if (displayText === "")
+			return false;
+		var loc = Qt.locale(PrefLanguage.preferenceLocaleName());
+		var parsed = Date.fromLocaleTimeString(loc, displayText, format);
+		if (isNaN(parsed.getTime()))
+			return false;
+		var updated = new Date(planDateTime.getTime());
+		updated.setHours(parsed.getHours(), parsed.getMinutes(), parsed.getSeconds(), 0);
+		planDateTime = updated;
+		return true;
+	}
+
+	function gasEditText(text) {
+		if (/^AIR$/i.test(text))
+			return "21";
+		var enrichedAir = /^EAN(\d{1,3})$/i.exec(text);
+		return enrichedAir ? enrichedAir[1] : text;
+	}
+
+	function gasDisplayText(text, originalDisplay, originalEdit) {
+		if (text === originalEdit)
+			return originalDisplay;
+		if (text.indexOf("/") !== -1 || text === "")
+			return text;
+		if (/^AIR$/i.test(text))
+			return "AIR";
+		var enrichedAir = /^EAN(\d{1,3})$/i.exec(text);
+		if (enrichedAir)
+			return "EAN" + Number(enrichedAir[1]);
+		var percent = Number(text);
+		// Guard against non-numeric input; never emit an "EANNaN" string.
+		if (isNaN(percent))
+			return text;
+		return percent === 21 ? "AIR" : "EAN" + percent;
 	}
 
 	function generatePlan(savePlan = false) {
@@ -96,9 +175,12 @@ TemplatePage {
 			}
 
 			var planResult = Backend.divePlannerPointsModel.calculatePlan(
-				cylinderData, segmentData, planDate.text, planTime.text,
+				cylinderData, segmentData,
+				Qt.formatDate(planDateTime, "yyyy-MM-dd"), Qt.formatTime(planDateTime, "hh:mm:ss"),
 				overallDivemode.currentIndex, salinity, savePlan
 			)
+			if (planResult.dateTimeValid === false)
+				return;
 			// AI-generated (Claude)
 			// Always update the preview so that a refused save still explains why
 			// the recreational plan is invalid.
@@ -139,7 +221,7 @@ TemplatePage {
 		Backend.planner_gfhigh = PrefTechnicalDetails.gfhigh;
 		cylinderListModel.append({
 			"type": PrefEquipment.default_cylinder ? PrefEquipment.default_cylinder : "AL80",
-			"mix": "21/0",
+			"mix": "AIR",
 			"pressure": (Backend.pressure === Enums.BAR) ? 200 : 3000,
 			"use": 0 // Default to OC_GAS
 		});
@@ -175,6 +257,11 @@ TemplatePage {
 		}
 	}
 
+	Connections {
+		target: PrefLanguage
+		function onDateTimeFormatsChanged() { updateDateTimeDisplay(); }
+	}
+
 	ColumnLayout {
 		width: parent.width
 		spacing: Kirigami.Units.gridUnit
@@ -200,19 +287,57 @@ TemplatePage {
 			}
 			SsrfTextField {
 				id: planDate
+				property string initialEditText: ""
+				property string editFormat: ""
 				Layout.fillWidth: true
 				sampleText: "0000-00-00"
-				// prefer a numeric keyboard on mobile while still allowing the date separators
-				inputMethodHints: Qt.ImhPreferNumbers
-				text: Qt.formatDate(new Date(), "yyyy-MM-dd")
+				inputMethodHints: Qt.ImhDate
+				text: Qt.formatDate(planDateTime, PrefLanguage.date_format_short)
+				onActiveFocusChanged: {
+					if (activeFocus) {
+						editFormat = PrefLanguage.date_format_short;
+						initialEditText = Qt.formatDate(planDateTime, dateInputFormat(editFormat));
+						text = initialEditText;
+					} else {
+						if (text !== initialEditText)
+							applyDateInput(text, editFormat);
+						updateDateTimeDisplay();
+					}
+				}
 			}
-			SsrfTextField {
-				id: planTime
+			// AI-generated (Claude): Keep the time keypad while exposing meridiem selection.
+			RowLayout {
 				Layout.fillWidth: true
-				sampleText: "00:00:00"
-				// prefer a numeric keyboard on mobile while still allowing the time separators
-				inputMethodHints: Qt.ImhPreferNumbers
-				text: Qt.formatTime(new Date(), "hh:mm:ss")
+				SsrfTextField {
+					id: planTime
+					property string initialEditText: ""
+					property string editFormat: ""
+					Layout.fillWidth: true
+					sampleText: "00:00 PM"
+					inputMethodHints: Qt.ImhTime
+					text: Qt.formatTime(planDateTime, PrefLanguage.time_format)
+					onActiveFocusChanged: {
+						if (activeFocus) {
+							editFormat = PrefLanguage.time_format;
+							var editText = PrefLanguage.timeEditText(text);
+							initialEditText = editText !== "" ? editText : text;
+							text = initialEditText;
+						} else {
+							if (text !== initialEditText)
+								applyTimeInput(text, editFormat);
+							updateDateTimeDisplay();
+						}
+					}
+				}
+				TemplateButton {
+					text: qsTr("A/P")
+					visible: planTime.activeFocus && /AP|ap/.test(PrefLanguage.time_format)
+					fontSize: subsurfaceTheme.smallPointSize
+					padding: 0
+					Layout.alignment: Qt.AlignVCenter
+					focusPolicy: Qt.NoFocus
+					onClicked: planTime.text = PrefLanguage.toggleMeridiem(planTime.text, false)
+				}
 			}
 			TemplateLabel {
 				text: qsTr("Dive Mode")
@@ -265,7 +390,7 @@ TemplatePage {
 					onClicked: {
 						cylinderListModel.append({
 							"type": PrefEquipment.default_cylinder ? PrefEquipment.default_cylinder : "AL80",
-							"mix": "21/0",
+							"mix": "AIR",
 							"pressure": (Backend.pressure === Enums.BAR) ? 200 : 3000,
 							"use": 0 // Default to OC_GAS
 						});
@@ -334,11 +459,11 @@ TemplatePage {
 				}
 				SsrfTextField {
 					id: mixField
+					property string displayText: ""
+					property string initialEditText: ""
 					Layout.preferredWidth: Kirigami.Units.gridUnit * 2.5
-					sampleText: "32/68"
-					// prefer a numeric keyboard on mobile; not digits-only because
-					// values like "EAN50", "AIR" and the "/" separator must remain typeable
-					inputMethodHints: Qt.ImhPreferNumbers
+					sampleText: "18/45"
+					inputMethodHints: Qt.ImhDate
 					text: mix
 					onTextChanged: {
 						if (text !== mix) {
@@ -365,7 +490,16 @@ TemplatePage {
 						}
 					}
 					validator: RegularExpressionValidator { regularExpression: /(EAN100|EAN\d\d|AIR|100|\d{0,2}|\d{0,2}\/\d{0,2})/i }
-					onActiveFocusChanged: cylinderListView.interactive = !activeFocus
+					onActiveFocusChanged: {
+						cylinderListView.interactive = !activeFocus;
+						if (activeFocus) {
+							displayText = text;
+							initialEditText = gasEditText(text);
+							text = initialEditText;
+						} else {
+							text = gasDisplayText(text, displayText, initialEditText);
+						}
+					}
 				}
 				TemplateCheckBox {
 					Layout.preferredWidth: Kirigami.Units.gridUnit * 1.5

--- a/mobile-widgets/qml/DivePlannerEdit.qml
+++ b/mobile-widgets/qml/DivePlannerEdit.qml
@@ -58,7 +58,7 @@ TemplatePage {
 
 	function updateDateTimeDisplay() {
 		if (!planDate.activeFocus)
-			planDate.text = Qt.formatDate(planDateTime, PrefLanguage.date_format_short);
+			planDate.text = Qt.formatDate(planDateTime, PrefLanguage.effectiveDateFormatShort);
 		if (!planTime.activeFocus)
 			planTime.text = Qt.formatTime(planDateTime, PrefLanguage.effectiveTimeFormat);
 	}
@@ -299,10 +299,10 @@ TemplatePage {
 				Layout.fillWidth: true
 				sampleText: "0000-00-00"
 				inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhDate)
-				text: Qt.formatDate(planDateTime, PrefLanguage.date_format_short)
+				text: Qt.formatDate(planDateTime, PrefLanguage.effectiveDateFormatShort)
 				onActiveFocusChanged: {
 					if (activeFocus) {
-						editFormat = PrefLanguage.date_format_short;
+						editFormat = PrefLanguage.effectiveDateFormatShort;
 						initialEditText = Qt.formatDate(planDateTime, dateInputFormat(editFormat));
 						text = initialEditText;
 					} else {

--- a/mobile-widgets/qml/DivePlannerEdit.qml
+++ b/mobile-widgets/qml/DivePlannerEdit.qml
@@ -19,6 +19,13 @@ TemplatePage {
 	// AI-generated (Claude)
 	property bool exceedsNDL: false
 
+	// AI-generated (Claude): iOS does not map the date and time hints to a
+	// specialised keyboard. Keep Android's specialised hints while requesting
+	// iOS's number-and-punctuation keyboard for fields with separators.
+	function punctuationInputMethodHints(platformName, androidHints) {
+		return platformName === "ios" ? Qt.ImhPreferNumbers : androidHints
+	}
+
 	// --- Data Models ---
 	ListModel { id: cylinderListModel }
 	ListModel { id: segmentListModel }
@@ -291,7 +298,7 @@ TemplatePage {
 				property string editFormat: ""
 				Layout.fillWidth: true
 				sampleText: "0000-00-00"
-				inputMethodHints: Qt.ImhDate
+				inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhDate)
 				text: Qt.formatDate(planDateTime, PrefLanguage.date_format_short)
 				onActiveFocusChanged: {
 					if (activeFocus) {
@@ -314,7 +321,7 @@ TemplatePage {
 					property string editFormat: ""
 					Layout.fillWidth: true
 					sampleText: "00:00 PM"
-					inputMethodHints: Qt.ImhTime
+					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhTime)
 					text: Qt.formatTime(planDateTime, PrefLanguage.time_format)
 					onActiveFocusChanged: {
 						if (activeFocus) {
@@ -463,7 +470,7 @@ TemplatePage {
 					property string initialEditText: ""
 					Layout.preferredWidth: Kirigami.Units.gridUnit * 2.5
 					sampleText: "18/45"
-					inputMethodHints: Qt.ImhDate
+					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhDate)
 					text: mix
 					onTextChanged: {
 						if (text !== mix) {
@@ -662,7 +669,7 @@ TemplatePage {
 					sampleText: "00.00"
 					text: cylinderListModel.get(gas) && cylinderListModel.get(gas).use === 1 ? (setpoint / 1000.0).toFixed(2) : ""
 					// request a numeric keyboard on mobile; ImhFormattedNumbersOnly allows the decimal separator
-					inputMethodHints: Qt.ImhFormattedNumbersOnly
+					inputMethodHints: punctuationInputMethodHints(Qt.platform.os, Qt.ImhFormattedNumbersOnly)
 					validator: DoubleValidator {
 						bottom: 0.16;
 						top: 2.0;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1137,18 +1137,19 @@ bool QMLManager::checkLocation(DiveSiteChange &res, struct dive *d, QString loca
 bool QMLManager::checkDuration(struct dive *d, QString duration)
 {
 	if (formatDiveDuration(d) != duration) {
+		// AI-generated (Claude): Reject incomplete input rather than interpreting missing fields as zero.
 		int h = 0, m = 0, s = 0;
-		QRegularExpression r1(QStringLiteral("(\\d*)\\s*%1[\\s,:]*(\\d*)\\s*%2[\\s,:]*(\\d*)\\s*%3").arg(tr("h")).arg(tr("min")).arg(tr("sec")), QRegularExpression::CaseInsensitiveOption);
+		QRegularExpression r1(QStringLiteral("^(\\d+)\\s*%1[\\s,:]*(\\d+)\\s*%2[\\s,:]*(\\d+)\\s*%3$").arg(QRegularExpression::escape(tr("h"))).arg(QRegularExpression::escape(tr("min"))).arg(QRegularExpression::escape(tr("sec"))), QRegularExpression::CaseInsensitiveOption);
 		QRegularExpressionMatch m1 = r1.match(duration);
-		QRegularExpression r2(QStringLiteral("(\\d*)\\s*%1[\\s,:]*(\\d*)\\s*%2").arg(tr("h")).arg(tr("min")), QRegularExpression::CaseInsensitiveOption);
+		QRegularExpression r2(QStringLiteral("^(\\d+)\\s*%1[\\s,:]*(\\d+)\\s*%2$").arg(QRegularExpression::escape(tr("h"))).arg(QRegularExpression::escape(tr("min"))), QRegularExpression::CaseInsensitiveOption);
 		QRegularExpressionMatch m2 = r2.match(duration);
-		QRegularExpression r3(QStringLiteral("(\\d*)\\s*%1").arg(tr("min")), QRegularExpression::CaseInsensitiveOption);
+		QRegularExpression r3(QStringLiteral("^(\\d+)\\s*%1$").arg(QRegularExpression::escape(tr("min"))), QRegularExpression::CaseInsensitiveOption);
 		QRegularExpressionMatch m3 = r3.match(duration);
-		QRegularExpression r4(QStringLiteral("(\\d*):(\\d*):(\\d*)"));
+		QRegularExpression r4(QStringLiteral("^(\\d+):(\\d{1,2}):(\\d{1,2})$"));
 		QRegularExpressionMatch m4 = r4.match(duration);
-		QRegularExpression r5(QStringLiteral("(\\d*):(\\d*)"));
+		QRegularExpression r5(QStringLiteral("^(\\d+):(\\d{2})\\s*(?:%1)?$").arg(QRegularExpression::escape(tr("h"))), QRegularExpression::CaseInsensitiveOption);
 		QRegularExpressionMatch m5 = r5.match(duration);
-		QRegularExpression r6(QStringLiteral("(\\d*)"));
+		QRegularExpression r6(QStringLiteral("^(\\d+)$"));
 		QRegularExpressionMatch m6 = r6.match(duration);
 		if (m1.hasMatch()) {
 			h = m1.captured(1).toInt();
@@ -1168,7 +1169,11 @@ bool QMLManager::checkDuration(struct dive *d, QString duration)
 			m = m5.captured(2).toInt();
 		} else if (m6.hasMatch()) {
 			m = m6.captured(1).toInt();
+		} else {
+			return false;
 		}
+		if ((m >= 60 && (m4.hasMatch() || m5.hasMatch())) || s >= 60)
+			return false;
 		d->dcs[0].duration = d->duration = duration_t { .seconds = h * 3600 + m * 60 + s };
 		if (is_dc_manually_added_dive(&d->dcs[0]))
 			d->dcs[0].samples.clear();

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -1491,6 +1491,15 @@ void DivePlannerPointsModel::createPlan(bool saveAsNew)
 
 QVariantMap DivePlannerPointsModel::calculatePlan(const QVariantList &cylindersData, const QVariantList &segmentsData, const QString &date, const QString &time, int diveMode, int waterType, bool shouldSave)
 {
+	// AI-generated (Claude): Reject malformed UI input before replacing the last valid plan state.
+	QDateTime plannedDateTime = QDateTime::fromString(date + " " + time, "yyyy-MM-dd hh:mm:ss");
+	if (!plannedDateTime.isValid()) {
+		return {
+			{ QStringLiteral("dateTimeValid"), false },
+			{ QStringLiteral("newDiveId"), -1 }
+		};
+	}
+
 	if (d) {
 		delete d;
 	}
@@ -1505,8 +1514,6 @@ QVariantMap DivePlannerPointsModel::calculatePlan(const QVariantList &cylindersD
 	make_planner_dc(&d->dcs[dcNr]);
 
 	// Set Date, Time, and Dive Mode from parameters
-	QString dateTimeString = date + " " + time;
-	QDateTime plannedDateTime = QDateTime::fromString(dateTimeString, "yyyy-MM-dd hh:mm:ss");
 #if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
 	plannedDateTime = QDateTime(plannedDateTime.date(), plannedDateTime.time(), QTimeZone(QTimeZone::UTC));
 #else
@@ -1598,6 +1605,7 @@ QVariantMap DivePlannerPointsModel::calculatePlan(const QVariantList &cylindersD
 	d->notes = notes_qstr.toStdString();
 	// Build the results map
 	QVariantMap results;
+	results["dateTimeValid"] = true;
 	results["notes"] = QString::fromStdString(d->notes);
 	results["maxDepth"] = get_depth_string(d->maxdepth, true);
 	results["duration"] = QString::number(d->duration.seconds / 60) + " min";

--- a/tests/testqPrefLanguage.cpp
+++ b/tests/testqPrefLanguage.cpp
@@ -228,10 +228,13 @@ void TestQPrefLanguage::test_oldPreferences()
 	language->restoreDateTimeDefaults();
 	QCOMPARE(language->date_format_override(), false);
 	QCOMPARE(language->time_format_override(), false);
-	const QString defaultLongDate = QLocale("en_US").dateFormat(QLocale::LongFormat).replace("dddd,", "ddd").replace("dddd", "ddd").replace("MMMM", "MMM");
-	const QString defaultShortDate = QLocale("en_US").dateFormat(QLocale::ShortFormat);
-	QCOMPARE(language->date_format(), defaultLongDate);
-	QCOMPARE(language->date_format_short(), defaultShortDate);
+	// When no override is active, the stored format is empty; the effective
+	// format is resolved dynamically from the system locale at call time.
+	// AI-generated (Claude): updated to match new behaviour where prefs store
+	// empty string for system-default formats.
+	QCOMPARE(language->date_format(), QString());
+	QCOMPARE(language->date_format_short(), QString());
+	QCOMPARE(language->time_format(), QString());
 	QCOMPARE(formatsSpy.count(), 1);
 	prefs.date_format = "error";
 	prefs.date_format_short = "error";
@@ -239,8 +242,8 @@ void TestQPrefLanguage::test_oldPreferences()
 	prefs.time_format = "error";
 	prefs.time_format_override = true;
 	language->load();
-	QCOMPARE(language->date_format(), defaultLongDate);
-	QCOMPARE(language->date_format_short(), defaultShortDate);
+	QCOMPARE(language->date_format(), QString());
+	QCOMPARE(language->date_format_short(), QString());
 	QCOMPARE(language->date_format_override(), false);
 	QCOMPARE(language->time_format_override(), false);
 

--- a/tests/tst_qPrefLanguage.qml
+++ b/tests/tst_qPrefLanguage.qml
@@ -3,6 +3,9 @@ import QtQuick 2.6
 import QtTest 1.2
 TestCase {
 	name: "qPrefLanguage"
+	property date plannerDateTime: new Date(2026, 7, 26, 13, 5, 0)
+	property string plannerDateDisplay: Qt.formatDate(plannerDateTime, PrefLanguage.date_format_short)
+	property string plannerTimeDisplay: Qt.formatTime(plannerDateTime, PrefLanguage.time_format)
 
 	function test_variables() {
 		var x1 = PrefLanguage.date_format
@@ -108,6 +111,51 @@ TestCase {
 		verify(PrefLanguage.date_format.length > 0)
 		verify(PrefLanguage.date_format_short.length > 0)
 		verify(PrefLanguage.time_format.length > 0)
+	}
+
+	// AI-generated (Claude): The planner binds to these preferences while it remains instantiated.
+	function test_plannerDateTimeDisplayFormats() {
+		PrefLanguage.use_system_language = false
+		PrefLanguage.lang_locale = "en_US"
+
+		PrefLanguage.applyDatePreset("day-first")
+		compare(plannerDateDisplay, "26.8.26")
+		PrefLanguage.applyDatePreset("month-first")
+		compare(plannerDateDisplay, "8/26/26")
+		PrefLanguage.applyDatePreset("iso")
+		compare(plannerDateDisplay, "26-8-26")
+		PrefLanguage.applyDateTimeFormats("yyyy-MM-dd", "yyyy-MM-dd", "HH:mm", true, true)
+		compare(plannerDateDisplay, "2026-08-26")
+		compare(plannerTimeDisplay, "13:05")
+
+		PrefLanguage.applyTimePreset("12-hour")
+		compare(plannerTimeDisplay, "1:05 PM")
+		// The time input fields drop the digits-only IME hint when the format
+		// carries a meridiem token, so AM/PM letters stay reachable on Android.
+		verify(/AP|ap/.test(PrefLanguage.time_format))
+		PrefLanguage.applyTimePreset("24-hour")
+		compare(plannerTimeDisplay, "13:05")
+		verify(!/AP|ap/.test(PrefLanguage.time_format))
+	}
+
+	// AI-generated (Claude): Exercise keypad conversion, meridiem changes and safe rejection.
+	function test_mobileDateTimeKeypadRoundTrips() {
+		PrefLanguage.use_system_language = false
+		PrefLanguage.lang_locale = "en_US"
+		PrefLanguage.applyDateTimeFormats("MM/dd/yyyy", "M/d/yy", "h:mm AP", true, true)
+
+		compare(PrefLanguage.timeEditText("1:05 PM"), "1:05 PM")
+		compare(PrefLanguage.toggleMeridiem("1:05 PM", false), "1:05 AM")
+		compare(PrefLanguage.timeDisplayText("1:05 AM"), "1:05 AM")
+		compare(PrefLanguage.dateTimeEditText("8/26/26 1:05 PM"), "8/26/26 1:05 PM")
+		compare(PrefLanguage.toggleMeridiem("8/26/26 1:05 PM", true), "8/26/26 1:05 AM")
+		compare(PrefLanguage.dateTimeDisplayText("8/26/26 1:05 AM"), "8/26/26 1:05 AM")
+
+		PrefLanguage.applyDateTimeFormats("dd.MM.yyyy", "d.M.yy", "HH.mm", true, true)
+		compare(PrefLanguage.dateTimeEditText("26.8.26 13.05"), "26/8/26 13:05")
+		compare(PrefLanguage.dateTimeDisplayText("26/8/26 13:05"), "26.8.26 13.05")
+		compare(PrefLanguage.dateTimeDisplayText("31/2/26 13:05"), "")
+		compare(PrefLanguage.toggleMeridiem("incomplete", false), "incomplete")
 	}
 
 	// AI-generated (Claude): Reading preset data must not replace persisted custom formats.

--- a/tests/tst_qPrefLanguage.qml
+++ b/tests/tst_qPrefLanguage.qml
@@ -4,8 +4,8 @@ import QtTest 1.2
 TestCase {
 	name: "qPrefLanguage"
 	property date plannerDateTime: new Date(2026, 7, 26, 13, 5, 0)
-	property string plannerDateDisplay: Qt.formatDate(plannerDateTime, PrefLanguage.date_format_short)
-	property string plannerTimeDisplay: Qt.formatTime(plannerDateTime, PrefLanguage.time_format)
+	property string plannerDateDisplay: Qt.formatDate(plannerDateTime, PrefLanguage.effectiveDateFormatShort)
+	property string plannerTimeDisplay: Qt.formatTime(plannerDateTime, PrefLanguage.effectiveTimeFormat)
 
 	function test_variables() {
 		var x1 = PrefLanguage.date_format
@@ -108,9 +108,13 @@ TestCase {
 		PrefLanguage.applyTimePreset("system")
 		compare(PrefLanguage.date_format_override, false)
 		compare(PrefLanguage.time_format_override, false)
-		verify(PrefLanguage.date_format.length > 0)
-		verify(PrefLanguage.date_format_short.length > 0)
-		verify(PrefLanguage.time_format.length > 0)
+		// System-default stores empty strings; effective* resolve to locale defaults.
+		compare(PrefLanguage.date_format, "")
+		compare(PrefLanguage.date_format_short, "")
+		compare(PrefLanguage.time_format, "")
+		verify(PrefLanguage.effectiveDateFormat.length > 0)
+		verify(PrefLanguage.effectiveDateFormatShort.length > 0)
+		verify(PrefLanguage.effectiveTimeFormat.length > 0)
 	}
 
 	// AI-generated (Claude): The planner binds to these preferences while it remains instantiated.
@@ -132,10 +136,10 @@ TestCase {
 		compare(plannerTimeDisplay, "1:05 PM")
 		// The time input fields drop the digits-only IME hint when the format
 		// carries a meridiem token, so AM/PM letters stay reachable on Android.
-		verify(/AP|ap/.test(PrefLanguage.time_format))
+		verify(/AP|ap/.test(PrefLanguage.effectiveTimeFormat))
 		PrefLanguage.applyTimePreset("24-hour")
 		compare(plannerTimeDisplay, "13:05")
-		verify(!/AP|ap/.test(PrefLanguage.time_format))
+		verify(!/AP|ap/.test(PrefLanguage.effectiveTimeFormat))
 	}
 
 	// AI-generated (Claude): Exercise keypad conversion, meridiem changes and safe rejection.


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
On Android the numeric date/time IME hints hide the separators, letters
and AM/PM markers needed to edit these fields, so partial or malformed
entries could reach the backend and stale digit groups from a previous
value could leak into the display.

Split the date/time fields into keypad-friendly edit formats and
canonical display formats, with round-trip helpers in qPrefLanguage
(timeEditText/timeDisplayText, dateTimeEditText/dateTimeDisplayText).
Single-digit month, day and time components are accepted and zero-padded
before conversion, and the display is only rebuilt from the edit text
when the digit-group structure is unchanged so stale groups can no longer
appear.

Harden gas, duration and date/time parsing to reject invalid input
(impossible dates, non-numeric gas mixes, non-numeric durations) instead
of emitting values such as "EANNaN" or "NaNmin", and verify that a parsed
date round-trips before it is applied.

Add meridiem support for 12-hour time formats: drop the digits-only IME
hint when the format carries an AP/ap token, expose an "A/P" toggle next
to the time field, and add toggleMeridiem() to flip the period safely.

Add QML tests covering keypad round-trips, meridiem toggling and safe
rejection of malformed date/time input.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
