### PR TITLE
mobile: keep DC selector within profile grid

### DIFF
--- a/mobile-widgets/qml/DiveDetailsView.qml
+++ b/mobile-widgets/qml/DiveDetailsView.qml
@@ -385,41 +385,36 @@ Item {
 		}
 		// under the profile
 		// -----------------
-		Row {
+		RowLayout {
+			visible: qmlProfile.numDC > 1
+			Layout.columnSpan: 3
+			Layout.fillWidth: true
+			Layout.minimumWidth: 0
+			Item {
+				Layout.fillWidth: true
+			}
 			TemplateButton {
 				id: prevDC
-				visible: qmlProfile.numDC > 1
 				text: qsTr("prev.DC")
 				font.pointSize: subsurfaceTheme.smallPointSize
 				onClicked: {
 					qmlProfile.prevDC()
 				}
 			}
-			TemplateLabel {
-				text: " "
-				width: Kirigami.Units.largeSpacing
-				visible: qmlProfile.numDC > 1
+			Item {
+				Layout.preferredWidth: Kirigami.Units.largeSpacing
 			}
 			TemplateButton {
 				id: nextDC
-				visible: qmlProfile.numDC > 1
 				text: qsTr("next DC")
 				font.pointSize: subsurfaceTheme.smallPointSize
 				onClicked: {
 					qmlProfile.nextDC()
 				}
 			}
-		}
-		// two empty entries
-		TemplateLabel {
-			text: " "
-			width: Kirigami.Units.largeSpacing
-			visible: qmlProfile.numDC > 1
-		}
-		TemplateLabel {
-			text: " "
-			width: Kirigami.Units.largeSpacing
-			visible: qmlProfile.numDC > 1
+			Item {
+				Layout.fillWidth: true
+			}
 		}
 		// first row
 		//-----------


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Make the multi-computer selector span all three details columns. Its
previous single-cell row could set a column minimum wider than the
viewport, clipping the profile and the text below it.

Keep the existing controls and translations, while using flexible side
items to centre them in the available row width. Single-computer dives
continue to omit the selector.

The current QML test target cannot cover this view: TestQML returns
immediately unless THIS_IS_REPAIRED is defined, and the desktop test
target does not build or load the mobile QML application.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4918.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
