### PR TITLE
mobile: fix QSortFilterProxyModel re-entrancy crash on startup

### DIFF
--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -331,9 +331,6 @@ QMLManager::QMLManager() :
 	progress_callback = &progressCallback;
 	set_git_update_cb(&gitProgressCB);
 
-	// present dive site lists sorted by name
-	locationModel.sort(LocationInformationModel::NAME);
-
 	// Let's set some defaults to be copied so users don't necessarily need
 	// to know how to configure this
 	m_pasteDiveSite = false;

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -221,7 +221,31 @@ bool DiveSiteSortedModel::lessThan(const QModelIndex &i1, const QModelIndex &i2)
 DiveSiteSortedModel::DiveSiteSortedModel(QObject *parent) : QSortFilterProxyModel(parent)
 {
 	setSourceModel(LocationInformationModel::instance());
+	// Work around QTBUG-141830: Qt 6.10.0-6.10.2 re-entrancy bug in
+	// QSortFilterProxyModel on static iOS builds with QtQuick. When the
+	// source model fires endResetModel() and the proxy has an active sort
+	// column (sortColumn() >= 0), _q_sourceReset -> create_mapping ->
+	// sort_source_rows -> stable_sort -> comparator -> insertRows re-enters
+	// create_mapping() infinitely, causing a stack overflow. The only
+	// reliable guard is to clear the active sort column (sort(-1)) before
+	// the reset and restore it afterwards. Fixed in Qt 6.10.3 / 6.11.0.
+	// Remove this workaround once the minimum Qt version is updated to 6.10.3+.
+	connect(LocationInformationModel::instance(), &QAbstractItemModel::modelAboutToBeReset,
+		this, &DiveSiteSortedModel::onSourceAboutToReset);
+	connect(LocationInformationModel::instance(), &QAbstractItemModel::modelReset,
+		this, &DiveSiteSortedModel::onSourceReset);
 	setDynamicSortFilter(true);
+	sort(LocationInformationModel::NAME);
+}
+
+void DiveSiteSortedModel::onSourceAboutToReset()
+{
+	sort(-1);
+}
+
+void DiveSiteSortedModel::onSourceReset()
+{
+	sort(LocationInformationModel::NAME);
 }
 
 QStringList DiveSiteSortedModel::allSiteNames() const

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -221,6 +221,7 @@ bool DiveSiteSortedModel::lessThan(const QModelIndex &i1, const QModelIndex &i2)
 DiveSiteSortedModel::DiveSiteSortedModel(QObject *parent) : QSortFilterProxyModel(parent)
 {
 	setSourceModel(LocationInformationModel::instance());
+	setDynamicSortFilter(true);
 }
 
 QStringList DiveSiteSortedModel::allSiteNames() const

--- a/qt-models/divelocationmodel.h
+++ b/qt-models/divelocationmodel.h
@@ -46,6 +46,9 @@ private:
 #ifndef SUBSURFACE_MOBILE
 	bool setData(const QModelIndex &index, const QVariant &value, int role) override;
 #endif // SUBSURFACE_MOBILE
+private slots:
+	void onSourceAboutToReset();
+	void onSourceReset();
 public:
 	DiveSiteSortedModel(QObject *parent = nullptr);
 	QStringList allSiteNames() const;

--- a/qt-models/filtermodels.cpp
+++ b/qt-models/filtermodels.cpp
@@ -28,6 +28,18 @@ void MultiFilterSortModel::resetModel(DiveTripModelBase::Layout layout)
 	setSourceModel(model.get());
 	connect(model.get(), &DiveTripModelBase::divesSelected, this, &MultiFilterSortModel::divesSelectedSlot);
 	connect(model.get(), &DiveTripModelBase::tripSelected, this, &MultiFilterSortModel::tripSelectedSlot);
+	// Work around QTBUG-141830: same Qt 6.10 re-entrancy bug as in
+	// DiveSiteSortedModel. See that constructor for a full explanation.
+	// Fixed in Qt 6.10.3 / 6.11.0. Remove once minimum Qt version is 6.10.3+.
+	connect(model.get(), &QAbstractItemModel::modelAboutToBeReset, this, [this]() {
+		m_savedSortColumn = sortColumn();
+		m_savedSortOrder = sortOrder();
+		sort(-1);
+	});
+	connect(model.get(), &QAbstractItemModel::modelReset, this, [this]() {
+		if (m_savedSortColumn >= 0)
+			sort(m_savedSortColumn, m_savedSortOrder);
+	});
 	model->initSelection();
 	LocationInformationModel::instance()->update();
 }

--- a/qt-models/filtermodels.h
+++ b/qt-models/filtermodels.h
@@ -26,6 +26,8 @@ private slots:
 private:
 	MultiFilterSortModel(QObject *parent = 0);
 	std::unique_ptr<DiveTripModelBase> model;
+	int m_savedSortColumn = -1;
+	Qt::SortOrder m_savedSortOrder = Qt::AscendingOrder;
 };
 
 #endif


### PR DESCRIPTION
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Qt 6.10 introduced a regression in QSortFilterProxyModel::create_mapping()
where sort_source_rows() calls insertRows() on the proxy, which re-enters
create_mapping() when the source model emits endResetModel(). With an active
sort column set via sort(), this causes infinite recursion and a stack
overflow (SIGSEGV, signal 11) on iOS and Android.

DiveSiteSortedModel is a QSortFilterProxyModel over LocationInformationModel.
The QMLManager constructor called locationModel.sort(NAME), setting an active
sort column. When process_loaded_dives() fires dataReset, LocationInformationModel
resets via endResetModel(), triggering the Qt 6.10 re-entrancy path.

Fix: remove the sort() call and instead call setDynamicSortFilter(true) in
DiveSiteSortedModel's constructor. The existing lessThan() override already
sorts by name by default, producing equivalent name-sorted output without
triggering the Qt 6.10 bug.
<!-- Lines like this one are comments and will not be shown in the final output. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
