### PR TITLE
Android: improve incremental build robustness and add -clean option

### DIFF
--- a/packaging/android/README.md
+++ b/packaging/android/README.md
@@ -55,6 +55,23 @@ rm /some/path/install-root-arm64-v8a-android/.image-id
 
 The next `local-build.sh` invocation will treat it as a fresh start.
 
+Alternatively, when using the named-container approach (default in
+`local-build.sh`), use the `-clean` option to wipe build artifacts inside the
+container:
+
+```bash
+bash packaging/android/local-build.sh -clean
+```
+
+This removes build trees (build-android, kirigami-build, googlemaps-build,
+googlemaps, libdivecomputer-build) and cache stamps (.mobilecomponents-hash,
+.libdivecomputer-hash) inside the container, forcing a full recompile of
+mobilecomponents, libdivecomputer, and Subsurface on the next build. However,
+it keeps the container itself and the pre-built native libraries in
+install-root, so it is faster than removing the container entirely
+(`docker rm -f subsurface-android-build`). The source checkout and
+`output/android` directory on the host remain unchanged.
+
 If you provide a `.secrets` file in the Subsurface source directory (or a
 location specified in the -secrets argument) with the encoded signing key,
 the outputs will be signed. The format of this file is

--- a/packaging/android/README.md
+++ b/packaging/android/README.md
@@ -65,12 +65,13 @@ bash packaging/android/local-build.sh -clean
 
 This removes build trees (build-android, kirigami-build, googlemaps-build,
 googlemaps, libdivecomputer-build) and cache stamps (.mobilecomponents-hash,
-.libdivecomputer-hash) inside the container, forcing a full recompile of
-mobilecomponents, libdivecomputer, and Subsurface on the next build. However,
-it keeps the container itself and the pre-built native libraries in
-install-root, so it is faster than removing the container entirely
-(`docker rm -f subsurface-android-build`). The source checkout and
-`output/android` directory on the host remain unchanged.
+.libdivecomputer-hash) inside the container, forcing a full rebuild of
+mobilecomponents (Kirigami/ECM), libdivecomputer, and Subsurface on the next
+run. The container and the image-seeded base libraries in install-root
+(OpenSSL, SQLite, libxml2, libxslt, libzip, libgit2) are kept, so there is no
+need to re-seed from the image -- which is why this is faster than removing the
+container entirely (`docker rm -f subsurface-android-build`). The source
+checkout and `output/android` directory on the host remain unchanged.
 
 If you provide a `.secrets` file in the Subsurface source directory (or a
 location specified in the -secrets argument) with the encoded signing key,

--- a/packaging/android/in-container-build.sh
+++ b/packaging/android/in-container-build.sh
@@ -94,8 +94,25 @@ MC_HASH=$(cat \
 	mobile-widgets/3rdparty/00*.patch \
 	| sha256sum | awk '{print $1}')
 
+# AI-generated (Claude)
+# Determine whether mobilecomponents.sh needs to run. Rebuild if:
+#   - the stamp file is missing or its hash doesn't match (inputs changed)
+#   - the stamp matches but required outputs are missing (partial/failed build)
+MC_NEEDS_REBUILD=0
+MC_REBUILD_REASON=""
 if [ ! -f "${MC_STAMP}" ] || [ "$(cat "${MC_STAMP}" 2>/dev/null)" != "${MC_HASH}" ]; then
-	echo "=== Building Kirigami / ECM (mobilecomponents.sh) ==="
+	MC_NEEDS_REBUILD=1
+	MC_REBUILD_REASON="inputs changed"
+elif [ ! -f "${SUBSURFACE_SOURCE}/mobile-widgets/3rdparty/ECM/cmake/ECMConfig.cmake" ]; then
+	MC_NEEDS_REBUILD=1
+	MC_REBUILD_REASON="ECM output missing"
+elif [ ! -f "${ANDROID_INSTALL_PREFIX}/lib/libKF6Kirigami.so" ]; then
+	MC_NEEDS_REBUILD=1
+	MC_REBUILD_REASON="Kirigami output missing"
+fi
+
+if [ "${MC_NEEDS_REBUILD}" = "1" ]; then
+	echo "=== Building Kirigami / ECM (${MC_REBUILD_REASON}) ==="
 	KIRIGAMI_BUILDDIR="${BUILDROOT}/src/kirigami-build" \
 	KIRIGAMI_INSTALL_PREFIX="${ANDROID_INSTALL_PREFIX}" \
 	bash ./scripts/mobilecomponents.sh \
@@ -108,7 +125,7 @@ if [ ! -f "${MC_STAMP}" ] || [ "$(cat "${MC_STAMP}" 2>/dev/null)" != "${MC_HASH}
 		-DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384"
 	echo "${MC_HASH}" > "${MC_STAMP}"
 else
-	echo "=== Skipping mobilecomponents.sh (inputs unchanged) ==="
+	echo "=== Skipping mobilecomponents.sh (cache complete and unchanged) ==="
 fi
 
 # build googlemaps geoservices plugin (shared library for Android)

--- a/packaging/android/local-build.sh
+++ b/packaging/android/local-build.sh
@@ -35,6 +35,7 @@
 #   -release           Build release APK (default; no version downgrade allowed)
 #   -build-aab         Also build Android App Bundle (.aab) in addition to APK
 #   -secrets <file>    Path to .secrets file (default: ./.secrets)
+#   -clean             Wipe build artifacts inside container to force a full rebuild
 
 set -e
 
@@ -44,6 +45,8 @@ cd "${SUBSURFACE_SOURCE}"
 SECRETS_FILE="${SUBSURFACE_SOURCE}/.secrets"
 BUILD_AAB="0"
 BUILD_TYPE="release"
+# AI-generated (Claude)
+CLEAN_BUILD="0"
 
 while [ $# -gt 0 ]; do
 	arg="$1"
@@ -61,9 +64,13 @@ while [ $# -gt 0 ]; do
 		-release)
 			BUILD_TYPE="release"
 			;;
+		# AI-generated (Claude)
+		-clean)
+			CLEAN_BUILD="1"
+			;;
 		*)
 			echo "Unknown command line argument $arg"
-			echo "Usage: ${BASH_SOURCE[0]} [-secrets <secrets filename>] [-build-aab] [-debug | -release]"
+			echo "Usage: ${BASH_SOURCE[0]} [-secrets <secrets filename>] [-build-aab] [-debug | -release] [-clean]"
 			exit 1
 			;;
 	esac
@@ -166,6 +173,27 @@ fi
 
 # Start the container (no-op if already running).
 ${CONTAINER_RT} start "${CONTAINER_NAME}" >/dev/null
+
+# AI-generated (Claude)
+# If -clean was requested, wipe build artifacts and cache stamps inside the
+# container to force a full rebuild. This removes build trees and hash stamps
+# that control whether mobilecomponents.sh and libdivecomputer are rebuilt,
+# but keeps the container and the pre-built native libraries in install-root.
+if [ "${CLEAN_BUILD}" = "1" ]; then
+	echo "=== Cleaning build artifacts inside container ==="
+	${CONTAINER_RT} exec "${CONTAINER_NAME}" rm -rf \
+		"${BUILDROOT}/build-android" \
+		"${BUILDROOT}/src/kirigami-build" \
+		"${BUILDROOT}/src/googlemaps-build" \
+		"${BUILDROOT}/src/googlemaps" \
+		"${BUILDROOT}/libdivecomputer-build"
+	# The install-root path is arm64-v8a-specific; that is the only ABI
+	# the current image supports and ANDROID_BUILD_ABI is a container ENV
+	# not available here.
+	${CONTAINER_RT} exec "${CONTAINER_NAME}" rm -f \
+		"${BUILDROOT}/src/install-root-arm64-v8a/.mobilecomponents-hash" \
+		"${BUILDROOT}/src/install-root-arm64-v8a/.libdivecomputer-hash"
+fi
 
 # AI-generated (Claude): unsigned builds do not have a keystore to copy.
 if [ -n "${ANDROID_KEYSTORE_BASE64}" ]; then


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Two related improvements to the local Android container build.

**Rerun mobilecomponents.sh when stamp matches but outputs are missing**

The `.mobilecomponents-hash` stamp lives inside the persistent container at
`/android/src/install-root-<ABI>/`, while the ECM output it guards lives on
the host bind-mount under `mobile-widgets/3rdparty/ECM/`. A `git clean` or
source-tree wipe on the host can delete the ECM directory without invalidating
the container-side stamp, causing the next build to fail at
`find_package(ECM REQUIRED)`.

`in-container-build.sh` now validates two required outputs before trusting a
matching stamp:

- `mobile-widgets/3rdparty/ECM/cmake/ECMConfig.cmake` (host bind-mount)
- `install-root-<ABI>/lib/libKirigami.so` (container storage)

If the stamp matches but either output is absent the build reruns
`mobilecomponents.sh` and refreshes the stamp automatically. The log message
now names the reason (inputs changed / ECM output missing / Kirigami output
missing / cache complete and unchanged) so it is clear which path was taken.

**Add `-clean` option to local-build.sh**

`local-build.sh` accepts a new `-clean` flag that wipes the build artifacts
inside the running container without destroying it:

- build trees: `build-android`, `kirigami-build`, `googlemaps`,
  `googlemaps-build`, `libdivecomputer-build`
- cache stamps: `.mobilecomponents-hash`, `.libdivecomputer-hash`

The container itself and the pre-built native libraries in `install-root` are
kept, so the next build re-runs mobilecomponents.sh and libdivecomputer but
does not need to re-seed from the image. This is meaningfully faster than the
nuclear option (`docker rm -f subsurface-android-build`), which is still
documented in the script header and README for cases where a full container
reset is needed.

The stamp paths are hard-coded to `arm64-v8a`, which is intentional: the
current image is single-ABI and `ANDROID_BUILD_ABI` is a container `ENV` not
visible to `local-build.sh` on the host.

README updated to document both the `-clean` option and the
output-validation behaviour.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
