### PR TITLE
datetime: route all date/time format consumers through effectiveDateFormat() helpers

### DIFF
--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -620,14 +620,14 @@ QString get_short_dive_date_string(timestamp_t when)
 {
 	QDateTime ts;
 	ts.setMSecsSinceEpoch(when * 1000L);
-	return loc.toString(ts.toUTC(), QString::fromStdString(prefs.date_format_short + " " + prefs.time_format));
+	return loc.toString(ts.toUTC(), qPrefLanguage::effectiveDateFormatShort() + ' ' + qPrefLanguage::effectiveTimeFormat());
 }
 
 static QString get_dive_only_date_string(timestamp_t when)
 {
 	QDateTime ts;
 	ts.setMSecsSinceEpoch(when * 1000L);
-	return loc.toString(ts.toUTC(), QString::fromStdString(prefs.date_format));
+	return loc.toString(ts.toUTC(), qPrefLanguage::effectiveDateFormat());
 }
 
 QString get_first_dive_date_string()
@@ -647,7 +647,7 @@ std::string get_current_date()
 	QDateTime ts(QDateTime::currentDateTime());;
 	QString current_date;
 
-	current_date = loc.toString(ts, QString::fromStdString(prefs.date_format_short));
+	current_date = loc.toString(ts, qPrefLanguage::effectiveDateFormatShort());
 
 	return current_date.toStdString();
 }

--- a/core/string-format.cpp
+++ b/core/string-format.cpp
@@ -324,7 +324,7 @@ QString formatTripTitle(const dive_trip &trip)
 
 	QString prefix = !trip.location.empty() ? QString::fromStdString(trip.location) + ", " : QString();
 	if (getday)
-		return prefix + loc.toString(localTime, QString::fromStdString(prefs.date_format));
+		return prefix + loc.toString(localTime, qPrefLanguage::effectiveDateFormat());
 	else
 		return prefix + loc.toString(localTime, "MMM yyyy");
 }
@@ -567,7 +567,7 @@ QString get_dive_date_string(timestamp_t when)
 {
 	QDateTime ts;
 	ts.setMSecsSinceEpoch(when * 1000L);
-	return loc.toString(ts.toUTC(), QString::fromStdString(prefs.date_format + " " + prefs.time_format));
+	return loc.toString(ts.toUTC(), qPrefLanguage::effectiveDateFormat() + ' ' + qPrefLanguage::effectiveTimeFormat());
 }
 
 QString format_timezone_offset(int seconds)

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -7,6 +7,7 @@
 #include "core/units.h"
 #include "core/selection.h"
 #include "core/settings/qPrefDivePlanner.h"
+#include "core/settings/qPrefLanguage.h"
 #include "core/subsurface-qt/divelistnotifier.h"
 #include "core/gettextfromc.h"
 #include "backend-shared/plannershared.h"
@@ -201,8 +202,8 @@ void DivePlannerWidget::settingsChanged()
 	ui.atmHeight->setValue((int) get_depth_units(pressure_to_altitude(DivePlannerPointsModel::instance()->getSurfacePressure()), NULL, NULL));
 	ui.atmHeight->blockSignals(false);
 
-	ui.dateEdit->setDisplayFormat(QString::fromStdString(prefs.date_format));
-	ui.startTime->setDisplayFormat(QString::fromStdString(prefs.time_format));
+	ui.dateEdit->setDisplayFormat(qPrefLanguage::effectiveDateFormat());
+	ui.startTime->setDisplayFormat(qPrefLanguage::effectiveTimeFormat());
 }
 
 void DivePlannerWidget::atmPressureChanged(int pressure_in_mbar)

--- a/desktop-widgets/filterconstraintwidget.cpp
+++ b/desktop-widgets/filterconstraintwidget.cpp
@@ -2,6 +2,7 @@
 #include "filterconstraintwidget.h"
 #include "starwidget.h"
 #include "core/pref.h"
+#include "core/settings/qPrefLanguage.h"
 #include "core/subsurface-qt/divelistnotifier.h"
 #include "qt-models/cleanertablemodel.h" // for trashIcon()
 #include "qt-models/filterconstraintmodel.h"
@@ -291,13 +292,13 @@ void FilterConstraintWidget::update()
 {
 	// The user might have changed the date and/or time format. Let's update the widgets.
 	if (dateFrom)
-		dateFrom->setDisplayFormat(QString::fromStdString(prefs.date_format));
+		dateFrom->setDisplayFormat(qPrefLanguage::effectiveDateFormat());
 	if (dateTo)
-		dateTo->setDisplayFormat(QString::fromStdString(prefs.date_format));
+		dateTo->setDisplayFormat(qPrefLanguage::effectiveDateFormat());
 	if (timeFrom)
-		timeFrom->setDisplayFormat(QString::fromStdString(prefs.time_format));
+		timeFrom->setDisplayFormat(qPrefLanguage::effectiveTimeFormat());
 	if (timeTo)
-		timeTo->setDisplayFormat(QString::fromStdString(prefs.time_format));
+		timeTo->setDisplayFormat(qPrefLanguage::effectiveTimeFormat());
 
 	QModelIndex idx = model->index(row, 0);
 	setIndex(negate.get(), idx, FilterConstraintModel::NEGATE_INDEX_ROLE);

--- a/desktop-widgets/preferences/preferences_language.cpp
+++ b/desktop-widgets/preferences/preferences_language.cpp
@@ -54,9 +54,11 @@ void PreferencesLanguage::refreshSettings()
 	ui->languageSystemDefault->setChecked(prefs.locale.use_system_language);
 	ui->timeFormatSystemDefault->setChecked(!prefs.time_format_override);
 	ui->dateFormatSystemDefault->setChecked(!prefs.date_format_override);
-	ui->timeFormatEntry->setCurrentText(QString::fromStdString(prefs.time_format));
-	ui->dateFormatEntry->setCurrentText(QString::fromStdString(prefs.date_format));
-	ui->shortDateFormatEntry->setText(QString::fromStdString(prefs.date_format_short));
+	// Show the effective (resolved) format so the user sees what is actually used,
+	// including the system-locale default when no override is set.
+	ui->timeFormatEntry->setCurrentText(qPrefLanguage::effectiveTimeFormat());
+	ui->dateFormatEntry->setCurrentText(qPrefLanguage::effectiveDateFormat());
+	ui->shortDateFormatEntry->setText(qPrefLanguage::effectiveDateFormatShort());
 	QAbstractItemModel *m = ui->languageDropdown->model();
 	QModelIndexList languages = m->match(m->index(0, 0), Qt::UserRole, QString::fromStdString(prefs.locale.lang_locale).replace("-", "_"));
 	if (languages.count())

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -4,6 +4,7 @@
 #include "core/divesite.h"
 #include "core/qthelper.h"
 #include "core/pref.h"
+#include "core/settings/qPrefLanguage.h"
 #include "core/selection.h"
 #include "core/subsurface-string.h"
 #include "core/string-format.h"
@@ -94,8 +95,8 @@ TabDiveNotes::TabDiveNotes(MainTab *parent) : TabBase(parent),
 
 void TabDiveNotes::updateDateTimeFields()
 {
-	ui.dateEdit->setDisplayFormat(QString::fromStdString(prefs.date_format));
-	ui.timeEdit->setDisplayFormat(QString::fromStdString(prefs.time_format));
+	ui.dateEdit->setDisplayFormat(qPrefLanguage::effectiveDateFormat());
+	ui.timeEdit->setDisplayFormat(qPrefLanguage::effectiveTimeFormat());
 }
 
 void TabDiveNotes::closeWarning()

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -44,6 +44,7 @@
 #include "core/sample.h"
 #include "core/selection.h"
 #include "core/save-profiledata.h"
+#include "core/settings/qPrefLanguage.h"
 #include "core/settings/qPrefLog.h"
 #include "core/settings/qPrefTechnicalDetails.h"
 #include "core/settings/qPrefPartialPressureGas.h"
@@ -969,7 +970,7 @@ bool QMLManager::checkDate(struct dive *d, QString date)
 		// what a pain - Qt will not parse dates if the day of the week is incorrect
 		// so if the user changed the date but didn't update the day of the week (most likely behavior, actually),
 		// we need to make sure we don't try to parse that
-		QString format = QString::fromStdString(prefs.date_format_short + ' ' + prefs.time_format);
+		QString format = qPrefLanguage::effectiveDateFormatShort() + ' ' + qPrefLanguage::effectiveTimeFormat();
 		if (format.contains(QLatin1String("ddd")) || format.contains(QLatin1String("dddd"))) {
 			QString dateFormatToDrop = format.contains(QLatin1String("ddd")) ? QStringLiteral("ddd") : QStringLiteral("dddd");
 			QDateTime ts;

--- a/stats/statsaxis.cpp
+++ b/stats/statsaxis.cpp
@@ -7,6 +7,7 @@
 #include "statsview.h"
 #include "zvalues.h"
 #include "core/pref.h"
+#include "core/settings/qPrefLanguage.h"
 #include "core/subsurface-time.h"
 #include <math.h> // for lrint
 #include <numeric>
@@ -572,7 +573,10 @@ static void inc(std::array<int, 3> &ymd)
 // the separator character. Returns a (day_first, separator) pair.
 static std::pair<bool, char> day_format()
 {
-	const char *fmt = prefs.date_format.c_str();
+	// AI-generated (Claude): use effectiveDateFormat() so the system-default
+	// (empty prefs.date_format) produces a valid pattern rather than an empty string.
+	const std::string fmtStr = qPrefLanguage::effectiveDateFormat().toStdString();
+	const char *fmt = fmtStr.c_str();
 	const char *d, *m, *sep;
 	for (d = fmt; *d && *d != 'd' && *d != 'D'; ++d)
 		;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
When date/time formats are set to "System default", prefs.date_format,
prefs.date_format_short, and prefs.time_format are stored as empty strings
(by design, so the iOS 12/24-hour system toggle is picked up live at call
time). Consumers that read the raw prefs directly produce blank output --
the dive-list Date column being the most visible symptom (issue #4958).

The effectiveDateFormat(), effectiveDateFormatShort(), and
effectiveTimeFormat() static helpers in qPrefLanguage already fall back to
the system-locale default when the stored pref is empty. Route every
raw-pref consumer through these helpers:

- core/string-format.cpp: formatTripTitle() date prefix and
  get_dive_date_string() (the reported dive-list Date column)
- core/qthelper.cpp: get_short_dive_date_string(), get_dive_only_date_string(),
  get_current_date()
- stats/statsaxis.cpp: day_format() -- hold the QString result in a local
  std::string so the c_str() pointer stays valid
- desktop-widgets/diveplanner.cpp: DivePlannerWidget::settingsChanged()
  display formats for dateEdit and startTime
- desktop-widgets/tab-widgets/TabDiveNotes.cpp: updateDateTimeFields()
  display formats for dateEdit and timeEdit
- desktop-widgets/filterconstraintwidget.cpp: FilterConstraintWidget::update()
  display formats for dateFrom, dateTo, timeFrom, timeTo
- desktop-widgets/preferences/preferences_language.cpp: refreshSettings()
  now shows the effective (resolved) format so the System-default entries
  are populated rather than blank
- mobile-widgets/qmlmanager.cpp: QMLManager::checkDate() parse format

The "store empty when system-default" behaviour in applyFormats() is
unchanged. All 33 tests pass.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4958.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
