### PR TITLE
core: detect Cressi Raffaello BLE advertisements

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -55,7 +55,8 @@ static QMap<int, QString> cressiModelNumToProduct{
 	{ 2, "Goa"},
 	{ 3, "Leonardo 2.0"},
 	{ 4, "Donatello"},
-        { 5, "Michelangelo"},
+	{ 5, "Michelangelo"},
+	{ 6, "Raffaello"},
 	{ 9, "Neon"},
 	{10, "Nepto"}
 };


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read CONTRIBUTING.md and also the notes in CODINGSTYLE.md. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

<!--
Translations are managed through Transifex. Do not open pull requests that
directly edit translation files. See the
[translation instructions](../blob/HEAD/CONTRIBUTING.md#translate-the-subsurface-application).
-->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Cressi Goa-family computers advertise their model number and a four-digit hexadecimal serial number, for example '6_11cd' for a Raffaello. The discovery code converts that model number to a libdivecomputer descriptor so the download UI can select the correct device automatically.

Although libdivecomputer defines Raffaello as Goa-family model 6, the corresponding desktop lookup table omitted model 6. Consequently, Raffaello advertisements were reported as unrecognised and required manual BLE selection.

Add the missing model-6 mapping. This leaves the duplicate device entries reported during the same test session unchanged, as their cause is separate and not established by the discovery log.

Tests: ./test_subsurface.sh (34/34 passed)

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
